### PR TITLE
python: Deeper support for using the Active Contract Set service

### DIFF
--- a/python/_template/integration-test.py
+++ b/python/_template/integration-test.py
@@ -139,6 +139,7 @@ def _main():
     """
     import argparse
     argparser = argparse.ArgumentParser()
+    argparser.add_argument('--sandbox-version')
 
     backend_args = argparser.add_mutually_exclusive_group()
     backend_args.add_argument('--url', required=False, help='The URL of the *existing* server to connect to')
@@ -153,7 +154,7 @@ def _main():
         run_test(args.url)
     else:
         LOG.info('Spinning up a local sandbox as part of the test...')
-        with sandbox(dar_file if dar_file.exists() else daml_file, port=args.port) as damli_proc:
+        with sandbox(dar_file if dar_file.exists() else daml_file, port=args.port, backend=args.sandbox_version, extra_args=['-w']) as damli_proc:
             run_test(damli_proc.url, args.keep_alive)
 
 

--- a/python/dazl/client/_reader_sync.py
+++ b/python/dazl/client/_reader_sync.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from asyncio import ensure_future, gather, sleep, Future
+from typing import Collection, List, Optional, Tuple, TYPE_CHECKING
+
+from .. import LOG
+from ..model.reading import sortable_offset_height, max_offset
+from ..util.asyncio_util import completed, named_gather
+
+if TYPE_CHECKING:
+    from ._party_client_impl import _PartyClientImpl
+
+"""
+Functions for ensuring that readers across different parties remain as close in sync to each other
+as practical.
+"""
+
+
+async def run_iteration(party_impls: 'Collection[_PartyClientImpl]') \
+        -> 'Tuple[str, Collection[Future]]':
+    """
+    Read the next set of transactions for the set of parties. This coroutine ends when all
+    parties are caught up to the same offset.
+
+    :param party_impls:
+        A collection of :class:`_PartyClientImpl` will have scheduled invocations.
+    :return:
+        A tuple of the current ending offset and Futures that represent completions for commands
+        that were submitted as a direct result of these events.
+    """
+    read_coroutines = []  # type: List[Future]
+
+    # have every client read as far ahead as they can
+    offsets, event_fut = await read_transactions(party_impls, None, True)
+    if not event_fut.done():
+        read_coroutines.append(event_fut)
+
+    final_offset = max_offset(offsets)
+    if len(offsets) > 1:
+        # now have every client catch up to the agreed-upon HEAD
+        _, event_fut = await read_transactions(party_impls, final_offset, True)
+        if not event_fut.done():
+            read_coroutines.append(event_fut)
+
+    await sleep(0)
+
+    return final_offset, [fut for fut in read_coroutines if not fut.done()]
+
+
+async def read_initial_acs(
+        party_impls: 'Collection[_PartyClientImpl]') -> 'Optional[str]':
+    """
+    Perform the initial synchronization of the Active Contract Set with the server, using the
+    Active Contract Set service.
+
+    :param party_impls:
+        A collection of _PartyClientImpl's whose offset and ACS state need to be updated.
+    :return:
+        The ending offset that all parties have reached, or ``None`` if no calls were actually
+        made.
+    """
+    LOG.info('Reading current ledger state from the Active Contract Set service...')
+
+    # Fetch the ACS as every single client.
+    if not party_impls:
+        return None
+
+    offsets = [offset for offset, _ in
+               await gather(*[party_impl.read_acs(None, False) for party_impl in party_impls])]
+    offset = max_offset(offsets)
+
+    # Find the most recent offset among all of those clients, and use the transaction stream
+    # to catch up all clients to the same point.
+    await gather(*[party_impl.read_transactions(offset, False) for party_impl in party_impls])
+    return offset
+
+
+async def read_transaction_event_stream(
+        party_impls: 'Collection[_PartyClientImpl]') -> 'Optional[str]':
+    LOG.info('Reading current ledger state...')
+    if not party_impls:
+        return None
+
+    party_impl = next(iter(party_impls))
+    offset = await party_impl.read_end()
+
+    await gather(*[party_impl.read_transactions(offset, False) for party_impl in party_impls])
+    return offset
+
+
+async def read_transactions(
+        party_impls: 'Collection[_PartyClientImpl]',
+        until_offset: 'Optional[str]',
+        raise_events: bool) -> 'Tuple[Collection[str], Future]':
+    """
+    Read transactions from a collection of PartyImpls.
+
+    :param party_impls:
+    :param until_offset:
+    :param raise_events:
+    :return:
+        A tuple containing:
+         * a set of the offsets returned from all readers, and
+         * a Future that is resolved when all events across all readers have resolved either
+           successfully or unsuccessfully.
+    """
+    tuples = await gather(*(pi.read_transactions(until_offset, raise_events) for pi in party_impls))
+    offsets = sorted({t[0] for t in tuples}, key=sortable_offset_height)
+    futures = [ensure_future(t[1]) for t in tuples]
+    futures = [fut for fut in futures if not fut.done()]
+    if not futures:
+        return offsets, completed(None)
+    elif len(futures):
+        return offsets, futures[0]
+    else:
+        return offsets, named_gather(repr(futures), *futures, return_exceptions=True)

--- a/python/dazl/model/ledger.py
+++ b/python/dazl/model/ledger.py
@@ -56,7 +56,6 @@ class LedgerMetadata:
     Attributes that are invariant with respect to any party on the ledger.
     """
     ledger_id: str
-    offset: str
     store: PackageStore
     time_model: TimeModel
     serializer: Serializer[Any, Any]

--- a/python/dazl/plugins/capture/fmt_pretty.py
+++ b/python/dazl/plugins/capture/fmt_pretty.py
@@ -116,7 +116,7 @@ class ByPartySort:
 
     def key(self, entry):
         party_vis = [1 if entry.parties.get(party) is not None else 0 for party in self.parties]
-        return (sum(party_vis), ''.join(map(str, reversed(party_vis))))
+        return sum(party_vis), ''.join(map(str, reversed(party_vis)))
 
 
 def split_header_name(name, max_length=None):
@@ -162,6 +162,7 @@ class _TemplateEntryRenderer:
             self.headers = [_Header(".cdata", None, parties)]
             self.template_name = template.template_name
 
+        self.headers.insert(0, _Header(".time", None, parties))
         self.headers.insert(0, _Header(".cid", None, parties))
         self.headers.insert(0, _Header(".party", None, parties, colsize=len(parties)))
         self.entry_count = 0
@@ -205,6 +206,9 @@ class _Header:
         if name == '.cid':
             self.header_lines = ['#cid']
             self._value_from_entry = lambda entry: entry.contract_id
+        elif name == '.time':
+            self.header_lines = ['#time']
+            self._value_from_entry = lambda entry: entry.time
         elif name == '.party':
             self.header_lines = ['']
             self._value_from_entry = lambda entry: render_parties(parties, entry)

--- a/python/dazl/plugins/capture/model_capture.py
+++ b/python/dazl/plugins/capture/model_capture.py
@@ -19,12 +19,12 @@ class LedgerCapture:
         self.entries = dict()  # type: Dict[ContractId, LedgerCaptureEntry]
         self.store: Optional[PackageStore] = None
 
-    def capture(self, party: str, contract_id: ContractId, contract_data: Optional[ContractData]):
+    def capture(self, party: str, contract_id: ContractId, contract_data: Optional[ContractData], time):
         entry = self.entries.get(contract_id)
         if entry is not None:
             entry.extend(party, contract_id, contract_data)
         else:
-            self.entries[contract_id] = LedgerCaptureEntry(party, contract_id, contract_data)
+            self.entries[contract_id] = LedgerCaptureEntry(party, contract_id, contract_data, time)
 
     def capture_archive(self, party: str, contract_id: ContractId):
         return self.capture(party, contract_id, None)
@@ -43,11 +43,12 @@ class LedgerCapture:
 
 
 class LedgerCaptureEntry:
-    def __init__(self, party, contract_id, contract_data):
+    def __init__(self, party, contract_id, contract_data, time):
         self.parties = {party: True}
         self.contract_id = contract_id
         self.template_id = contract_id.template_id
         self.contract_args = contract_data
+        self.time = time
         self.errors = []
 
     def extend(self, party, _, contract_data):

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -105,6 +105,11 @@ class LedgerClient:
         """
         raise NotImplementedError('events must be implemented')
 
+    async def events_end(self) -> str:
+        """
+        Return the (current) last offset of the ledger.
+        """
+
 
 class _LedgerConnectionContext:
     def __init__(self,

--- a/python/dazl/protocols/v1/model/__init__.py
+++ b/python/dazl/protocols/v1/model/__init__.py
@@ -21,7 +21,7 @@ from ...._gen.com.digitalasset.ledger.api.v1.testing.time_service_pb2_grpc impor
 from ...._gen.com.digitalasset.ledger.api.v1.transaction_filter_pb2 import Filters, \
     TransactionFilter
 from ...._gen.com.digitalasset.ledger.api.v1.transaction_service_pb2 import GetTransactionsRequest, \
-    GetLedgerEndRequest
+    GetLedgerEndRequest, GetTransactionByEventIdRequest
 from ...._gen.com.digitalasset.ledger.api.v1.transaction_service_pb2_grpc import \
     TransactionServiceStub
 from ...._gen.da.daml_lf_pb2 import ArchivePayload

--- a/python/tests/tutorials/post_office/Main.daml
+++ b/python/tests/tutorials/post_office/Main.daml
@@ -10,13 +10,13 @@ template PostmanRole
   where
     signatory postman
     controller postman can
-      nonconsuming InviteParticipant : ()
+      nonconsuming InviteParticipant : (ContractId InviteAuthorRole, ContractId InviteReceiverRole)
         with
           party : Party; address: Text
         do
-          create InviteAuthorRole with postman; author = party
-          create InviteReceiverRole with postman; receiver = party; address
-          return ()
+          c <- create InviteAuthorRole with postman; author = party
+          d <- create InviteReceiverRole with postman; receiver = party; address
+          return (c, d)
 
 template AuthorRole
   with

--- a/python/tests/unit/test_plugins_capture.py
+++ b/python/tests/unit/test_plugins_capture.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from datetime import datetime
 
 from dazl.model.core import ContractId
 from dazl.plugins.capture import fmt_pretty
@@ -15,7 +16,7 @@ class PluginsCaptureTest(unittest.TestCase):
         capture = LedgerCapture()
         capture.capture('A',
                         ContractId('0:0', template_id='some_unknown_template'),
-                        dict(some_field='some_value'))
+                        dict(some_field='some_value'), datetime.utcnow())
 
         lines = fmt_pretty.format_entries(capture, parties)
         output = '\n'.join(lines) + '\n'


### PR DESCRIPTION
Deeper support for using the Active Contract Set service to populate initial state.

This uses the ACS to get a sense of the initial state of contracts, and then subsequently uses the Transaction Event Stream to fill in missing data (effective time) and to filter out contracts where parties are not stakeholders (https://github.com/digital-asset/daml/issues/164).