### PR TITLE
python: Make package upload blocking more "synchronous"

### DIFF
--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -71,6 +71,13 @@ class LedgerNetwork:
         updates through the TimeService. In these contexts, this method is a no-op.
         """
 
+    async def upload_package(self, dar_contents: bytes) -> None:
+        """
+        Upload a DAR file to the ledger.
+
+        :param dar_contents: The raw bytes that represent a package.
+        """
+
     async def close(self):
         """
         Shut down all connections and transition the pool to the closed state.
@@ -118,13 +125,6 @@ class LedgerClient:
     async def events_end(self) -> str:
         """
         Return the (current) last offset of the ledger.
-        """
-
-    async def upload_package(self, dar_contents: bytes) -> None:
-        """
-        Upload a DAR file to the ledger.
-
-        :param dar_contents: The raw bytes that represent a package.
         """
 
 

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -241,12 +241,9 @@ def grpc_main_thread(connection: 'GRPCv1Connection', ledger_id: str) -> Iterable
         time_thread = Thread(name='time-sync-thread', target=time_sync_thread, daemon=True)
         time_thread.start()
 
-    LOG.debug('There is no time service, so we will merely wait for the underlying transaction '
-              'stream to die.')
-    while True:
+    # poll for package updates once a second
+    while not connection._closed.wait(1):
         grpc_package_sync(package_provider, store)
-        if connection._closed.wait(1):
-            break
 
     LOG.debug('The gRPC monitor thread is now shutting down.')
     yield None

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from os import path
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import BinaryIO, Dict, List, Mapping, Optional, Union, TYPE_CHECKING, Sequence
+from typing import BinaryIO, Dict, Collection, Mapping, Optional, Sequence, Union, TYPE_CHECKING
 from zipfile import ZipFile
 
 from .process import ProcessWatcher
@@ -79,7 +79,7 @@ class TemporaryDar:
     """
     __slots__ = ('daml_path', 'dar_paths', 'damlc_component', '_tmp_dir', 'damlc_extra_args')
 
-    daml_path: 'str'
+    daml_path: 'Path'
     dar_paths: 'Optional[Sequence[Path]]'
     damlc_component: 'Optional[str]'
     _tmp_dir: 'TemporaryDirectory'
@@ -216,6 +216,12 @@ def parse_dalf(contents: bytes) -> 'PackageStore':
     a.ParseFromString(contents)
     p = parse_archive_payload(a.payload)
     return parse_daml_metadata_pb(a.hash, p)
+
+
+def get_dar_package_ids(contents: bytes) -> 'Collection[str]':
+    with BytesIO(contents) as buf:
+        with DarFile(buf) as dar:
+            return dar.read_metadata().package_ids()
 
 
 class DamlcPackageError(Exception):

--- a/python/dazl/util/io.py
+++ b/python/dazl/util/io.py
@@ -7,17 +7,53 @@ Utilities for dealing with the file system.
 
 import socket
 import sys
-from io import TextIOBase, SEEK_SET
+from io import BufferedIOBase, TextIOBase, SEEK_SET
 from pathlib import Path
 from types import TracebackType
-from typing import TextIO, Optional, Type, Iterator, Iterable, List, Union
+from typing import BinaryIO, TextIO, Optional, Type, Iterator, Iterable, List, Union, overload
+
+
+@overload
+def get_bytes(_: None) -> None: ...
+
+
+@overload
+def get_bytes(_: bytes) -> bytes: ...
+
+
+@overload
+def get_bytes(_: str) -> bytes: ...
+
+
+@overload
+def get_bytes(_: Path) -> bytes: ...
+
+
+@overload
+def get_bytes(_: BinaryIO) -> bytes: ...
+
+
+def get_bytes(src):
+    """
+    Read the contents of a file as ``bytes``. If ``src`` is ``None``, then ``None`` is returned
+    instead.
+    """
+    if src is None:
+        return None
+    elif isinstance(src, str):
+        with open(src, 'rb') as f:
+            return f.read()
+    elif isinstance(src, bytes):
+        return src
+    elif isinstance(src, Path):
+        return src.read_bytes()
+    elif isinstance(src, BufferedIOBase):
+        return src.read(-1)
+    else:
+        raise ValueError('src must be a string path, a Path, or a BytesIO')
 
 
 def read_file_bytes(file_path: Optional[str]) -> Optional[bytes]:
-    """
-    Read the contents of a file as ``bytes``. If ``file_path`` is ``None``, then ``None`` is
-    returned instead.
-    """
     if file_path is not None:
         with open(file_path, 'rb') as f:
             return f.read()


### PR DESCRIPTION
Wait until DAR uploads are done _and_ packages are reported locally before returning.