### PR TITLE
python: Moved some generic asyncio utils into…`asyncio_utils.py`

### DIFF
--- a/python/_template/integration-test.py
+++ b/python/_template/integration-test.py
@@ -42,7 +42,7 @@ class PartyBot:
                 choices.append(('CreateTimeLetter', dict(
                     address=receiver_address,
                     content=datetime(2000,1,1))))
-                choices.append(('CreateListIntegerLetter', dict(
+                choices.append(('CreateListIntLetter', dict(
                     address=receiver_address,
                     content=[0, 1, 2, 3, 4])))
 

--- a/python/dazl/client/_network_client_impl.py
+++ b/python/dazl/client/_network_client_impl.py
@@ -324,12 +324,12 @@ class _NetworkImpl:
 
     # noinspection PyShadowingBuiltins
 
-    def add_event_handler(self, key, handler: 'Callable[[BaseEvent], None]', context):
+    def add_event_handler(self, key, handler: 'Callable[[BaseEvent], None]'):
         """
         Add an event handler to a specific event. Unlike event listeners on party clients, these
         event handlers are not allowed to return anything in response to handling an event.
         """
-        self._callbacks.add_listener(key, handler, None, context)
+        self._callbacks.add_listener(key, handler, None)
 
     def emit_event(self, data: BaseEvent):
         for key in EventKey.from_event(data):

--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -115,7 +115,7 @@ class _PartyClientImpl:
     # region Event Handler Management
 
     # noinspection PyShadowingBuiltins
-    def add_event_handler(self, key, handler, filter, context):
+    def add_event_handler(self, key: str, handler, filter, context):
         from functools import wraps
 
         @wraps(handler)
@@ -443,7 +443,9 @@ class _PartyClientImpl:
                                    timeout=5, return_when=ALL_COMPLETED)
 
         if pending:
-            LOG.warning('Writer loop for party %s has NOT fully finished, but will be terminated anyway (%d futures still pending).', self.party, len(pending))
+            LOG.warning('Writer loop for party %s has NOT fully finished, '
+                        'but will be terminated anyway (%d futures still pending).',
+                        self.party, len(pending))
         else:
             LOG.info('Writer loop for party %s is finished.', self.party)
 


### PR DESCRIPTION
Moved some generic asyncio utils out of `_party_client_impl` and gave them more accurate names.

This is basically cleanup in preparation for more sweeping changes to `_party_client_impl` to support more fine-grained control over bots.