### PR TITLE
python: Completely switch over to using Pytest-style tests.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -15,7 +15,7 @@ Rich Python bindings for accessing Ledger API-based applications.
 Requirements
 ------------
 * Python 3.6+
-* [Pipenv](https://pipenv.readthedocs.io/en/latest/)
+* [Poetry](https://python-poetry.org/)
 * Although not strictly required for building, you'll probably want the [DAML SDK](https://www.daml.com)
 
 Examples
@@ -69,12 +69,14 @@ network.start()
 Building locally
 ----------------
 ```sh
-cd python && pipenv run package
+make package
 ```
 
 Tests
 -----
 
+Tests in dazl are written using [pytest](https://docs.pytest.org/en/latest/). You can run them by doing:
+
 ```sh
-cd python && pipenv run test
+make test
 ```

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -4,7 +4,7 @@ description = "Async http client/server framework (asyncio)"
 name = "aiohttp"
 optional = false
 python-versions = ">=3.5.3"
-version = "3.6.1"
+version = "3.6.2"
 
 [package.dependencies]
 async-timeout = ">=3.0,<4.0"
@@ -20,6 +20,9 @@ version = ">=1.0"
 [package.dependencies.typing-extensions]
 python = "<3.7"
 version = ">=3.6.5"
+
+[package.extras]
+speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
 category = "dev"
@@ -48,6 +51,7 @@ version = "3.0.1"
 [[package]]
 category = "dev"
 description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -59,7 +63,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
 category = "dev"
@@ -86,7 +96,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.9.11"
+version = "2019.11.28"
 
 [[package]]
 category = "main"
@@ -110,8 +120,8 @@ description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.4.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
 
 [[package]]
 category = "main"
@@ -119,8 +129,8 @@ description = "A backport of the dataclasses module for Python 3.6"
 marker = "python_version >= \"3.6.0\" and python_version < \"3.7.0\""
 name = "dataclasses"
 optional = false
-python-versions = "*"
-version = "0.6"
+python-versions = ">=3.6, <3.7"
+version = "0.7"
 
 [[package]]
 category = "dev"
@@ -144,18 +154,24 @@ Werkzeug = ">=0.15"
 click = ">=5.1"
 itsdangerous = ">=0.24"
 
+[package.extras]
+dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
+docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
+dotenv = ["python-dotenv"]
+
 [[package]]
 category = "main"
 description = "Google Authentication Library"
 name = "google-auth"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.6.3"
+version = "1.10.0"
 
 [package.dependencies]
-cachetools = ">=2.0.0"
+cachetools = ">=2.0.0,<5.0"
 pyasn1-modules = ">=0.2.1"
-rsa = ">=3.1.4"
+rsa = ">=3.1.4,<4.1"
+setuptools = ">=40.3.0"
 six = ">=1.9.0"
 
 [[package]]
@@ -164,7 +180,7 @@ description = "HTTP/2-based RPC framework"
 name = "grpcio"
 optional = false
 python-versions = "*"
-version = "1.23.0"
+version = "1.26.0"
 
 [package.dependencies]
 six = ">=1.5.2"
@@ -175,10 +191,10 @@ description = "Protobuf code generator for gRPC"
 name = "grpcio-tools"
 optional = false
 python-versions = "*"
-version = "1.23.0"
+version = "1.26.0"
 
 [package.dependencies]
-grpcio = ">=1.23.0"
+grpcio = ">=1.26.0"
 protobuf = ">=3.5.0.post1"
 
 [[package]]
@@ -223,11 +239,15 @@ description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.23"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
@@ -239,14 +259,17 @@ version = "1.1.0"
 
 [[package]]
 category = "dev"
-description = "A small but fast and easy to use stand-alone template engine written in pure python."
+description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
 python-versions = "*"
-version = "2.10.1"
+version = "2.10.3"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
 
 [[package]]
 category = "dev"
@@ -261,16 +284,16 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.0.2"
 
 [[package]]
 category = "main"
 description = "multidict implementation"
 name = "multidict"
 optional = false
-python-versions = ">=3.4.1"
-version = "4.5.2"
+python-versions = ">=3.5"
+version = "4.7.2"
 
 [[package]]
 category = "dev"
@@ -278,12 +301,15 @@ description = "Optional static typing for Python"
 name = "mypy"
 optional = false
 python-versions = ">=3.5"
-version = "0.730"
+version = "0.761"
 
 [package.dependencies]
-mypy-extensions = ">=0.4.0,<0.5.0"
+mypy-extensions = ">=0.4.3,<0.5.0"
 typed-ast = ">=1.4.0,<1.5.0"
 typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 category = "dev"
@@ -291,7 +317,7 @@ description = "Experimental type system extensions for programs checked with the
 name = "mypy-extensions"
 optional = false
 python-versions = "*"
-version = "0.4.1"
+version = "0.4.3"
 
 [[package]]
 category = "main"
@@ -300,6 +326,11 @@ name = "oauthlib"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "3.1.0"
+
+[package.extras]
+rsa = ["cryptography"]
+signals = ["blinker"]
+signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
 
 [[package]]
 category = "dev"
@@ -327,12 +358,15 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "main"
@@ -342,13 +376,16 @@ optional = true
 python-versions = "*"
 version = "0.7.1"
 
+[package.extras]
+twisted = ["twisted"]
+
 [[package]]
 category = "main"
 description = "Protocol Buffers"
 name = "protobuf"
 optional = false
 python-versions = "*"
-version = "3.9.2"
+version = "3.11.1"
 
 [package.dependencies]
 setuptools = "*"
@@ -368,7 +405,7 @@ description = "ASN.1 types and codecs"
 name = "pyasn1"
 optional = false
 python-versions = "*"
-version = "0.4.7"
+version = "0.4.8"
 
 [[package]]
 category = "main"
@@ -376,7 +413,7 @@ description = "A collection of ASN.1-based protocols modules."
 name = "pyasn1-modules"
 optional = false
 python-versions = "*"
-version = "0.2.6"
+version = "0.2.7"
 
 [package.dependencies]
 pyasn1 = ">=0.4.6,<0.5.0"
@@ -387,7 +424,10 @@ description = "The kitchen sink of Python utility libraries for doing \"stuff\" 
 name = "pydash"
 optional = false
 python-versions = "*"
-version = "4.7.5"
+version = "4.7.6"
+
+[package.extras]
+dev = ["coverage", "flake8", "mock", "pylint", "pytest", "pytest-cov", "sphinx", "sphinx-rtd-theme", "tox", "twine", "wheel"]
 
 [[package]]
 category = "main"
@@ -395,7 +435,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.4.2"
+version = "2.5.2"
 
 [[package]]
 category = "dev"
@@ -403,7 +443,7 @@ description = "A development tool to measure, monitor and analyze the memory beh
 name = "pympler"
 optional = false
 python-versions = "*"
-version = "0.7"
+version = "0.8"
 
 [[package]]
 category = "dev"
@@ -411,7 +451,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.2"
+version = "2.4.5"
 
 [[package]]
 category = "dev"
@@ -419,7 +459,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.3"
+version = "5.3.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -435,13 +475,27 @@ wcwidth = "*"
 python = "<3.8"
 version = ">=0.12"
 
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "unittest subTest() support and subtests fixture"
+name = "pytest-subtests"
+optional = false
+python-versions = ">=3.4"
+version = "0.2.1"
+
+[package.dependencies]
+pytest = ">=4.4.0"
+
 [[package]]
 category = "dev"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2019.2"
+version = "2019.3"
 
 [[package]]
 category = "main"
@@ -449,7 +503,7 @@ description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "5.1.2"
+version = "5.2"
 
 [[package]]
 category = "main"
@@ -464,6 +518,10 @@ certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<3.1.0"
 idna = ">=2.5,<2.9"
 urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 category = "main"
@@ -482,7 +540,7 @@ description = "Python helper for Semantic Versioning (http://semver.org/)"
 name = "semver"
 optional = false
 python-versions = "*"
-version = "2.8.1"
+version = "2.9.0"
 
 [[package]]
 category = "main"
@@ -490,7 +548,7 @@ description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 category = "dev"
@@ -498,7 +556,7 @@ description = "This package provides 26 stemmers for 25 languages generated from
 name = "snowballstemmer"
 optional = false
 python-versions = "*"
-version = "1.9.1"
+version = "2.0.0"
 
 [[package]]
 category = "dev"
@@ -506,7 +564,7 @@ description = "Python documentation generator"
 name = "sphinx"
 optional = false
 python-versions = ">=3.5"
-version = "2.2.0"
+version = "2.3.0"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
@@ -527,13 +585,17 @@ sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = "*"
 
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+test = ["pytest", "pytest-cov", "html5lib", "flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.750)", "docutils-stubs"]
+
 [[package]]
 category = "dev"
 description = "sphinx builder that outputs markdown files"
 name = "sphinx-markdown-builder"
 optional = false
 python-versions = "*"
-version = "0.5.2"
+version = "0.5.3"
 
 [package.dependencies]
 html2text = "*"
@@ -550,6 +612,9 @@ optional = false
 python-versions = "*"
 version = "1.0.1"
 
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
+
 [[package]]
 category = "dev"
 description = ""
@@ -557,6 +622,9 @@ name = "sphinxcontrib-devhelp"
 optional = false
 python-versions = "*"
 version = "1.0.1"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
 
 [[package]]
 category = "dev"
@@ -566,6 +634,9 @@ optional = false
 python-versions = "*"
 version = "1.0.2"
 
+[package.extras]
+test = ["pytest", "flake8", "mypy", "html5lib"]
+
 [[package]]
 category = "dev"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
@@ -573,6 +644,9 @@ name = "sphinxcontrib-jsmath"
 optional = false
 python-versions = ">=3.5"
 version = "1.0.1"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
 
 [[package]]
 category = "dev"
@@ -582,6 +656,9 @@ optional = false
 python-versions = "*"
 version = "1.0.2"
 
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
+
 [[package]]
 category = "dev"
 description = ""
@@ -589,6 +666,9 @@ name = "sphinxcontrib-serializinghtml"
 optional = false
 python-versions = "*"
 version = "1.1.3"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
 
 [[package]]
 category = "main"
@@ -608,22 +688,11 @@ version = "1.4.0"
 
 [[package]]
 category = "main"
-description = "Type Hints for Python"
-name = "typing"
-optional = false
-python-versions = "*"
-version = "3.7.4.1"
-
-[[package]]
-category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4"
-
-[package.dependencies]
-typing = ">=3.7.4"
+version = "3.7.4.1"
 
 [[package]]
 category = "dev"
@@ -651,6 +720,10 @@ name = "urllib3"
 optional = false
 python-versions = "*"
 version = "1.22"
+
+[package.extras]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "dev"
@@ -681,21 +754,26 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.16.0"
 
+[package.extras]
+dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
+termcolor = ["termcolor"]
+watchdog = ["watchdog"]
+
 [[package]]
 category = "dev"
 description = "A formatter for Python code."
 name = "yapf"
 optional = false
 python-versions = "*"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 category = "main"
 description = "Yet another URL library"
 name = "yarl"
 optional = false
-python-versions = ">=3.5.3"
-version = "1.3.0"
+python-versions = ">=3.5"
+version = "1.4.2"
 
 [package.dependencies]
 idna = ">=2.0"
@@ -713,84 +791,524 @@ version = "0.6.0"
 [package.dependencies]
 more-itertools = "*"
 
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "contextlib2", "unittest2"]
+
 [extras]
 prometheus = ["prometheus_client"]
 pygments = ["pygments"]
+pytest = []
 
 [metadata]
-content-hash = "3424b9b06a0cd200c4e282fb275cacf5452e545e0cad630c74c6f489dc2be927"
+content-hash = "f8655f99cb6c712b76c3e824149124edbcd8d7405a3f1c772981b31199f4c16b"
 python-versions = ">=3.6"
 
-[metadata.hashes]
-aiohttp = ["022c400e30848b1994236e31fb38db1dc4b551efe049f737cbac690ab2cdf5c4", "10f9316ef068536dec0b9f09531fa1cb6bfa8394f278022cb96e789c77811ad2", "2599b93fd5ba1120b3bd1366d67a7e26bd45b3d5d5548069e00b2fbef7f20ab0", "2a1c71e7fb8c50e60fb4c9bab8bd5cf7c07f91a6b27dc2556d7354cd2ebb3689", "6a19d34cc01414d94dd5a4466f8f397293fcb8929df8eeb8989119cc5ef928bb", "7aab39c2a61a5c6b15bb7e561218ef64770ca1fbf4cc1878c96e630e2b7cc3cc", "8959e28bc1b87542b0ee4a8302128f633bee296252f261bf03e118c4dff725f0", "89820f7c488f4e9b1f74371da33403181e11e006663ddf074317aacd690838a6", "ab761cf0f0b0b90887e276b4a7918f11e323f2228bbb30814bbd538c122028bf", "cc648ecaca79e37c6e26f370e802e7ae640a069913f661f66c0421084bef219a", "d6f26e80cd55ac88e1f0397fc8d547933225a5dc1add040e27788c2a028c64c6", "e7d6ae4a36bfe6d7f93c6f42a0bfa1659f7d011006cb6e8207c85ef5acdb2986", "fc55b1fec0e4cc1134ffb09ea3970783ee2906dc5dfd7cd16917913f2cfed65b"]
-alabaster = ["446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359", "a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"]
-argh = ["a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3", "e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"]
-async-timeout = ["0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f", "4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"]
-atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
-attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
-babel = ["af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab", "e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"]
-cachetools = ["428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae", "8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"]
-certifi = ["e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50", "fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"]
-chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
-click = ["2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13", "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"]
-colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
-dataclasses = ["454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f", "6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"]
-docutils = ["6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0", "9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827", "a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"]
-flask = ["13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52", "45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"]
-google-auth = ["0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4", "20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed"]
-grpcio = ["1303578092f1f6e4bfbc354c04ac422856c393723d3ffa032fff0f7cb5cfd693", "229c6b313cd82bec8f979b059d87f03cc1a48939b543fe170b5a9c5cf6a6bc69", "3cd3d99a8b5568d0d186f9520c16121a0f2a4bcad8e2b9884b76fb88a85a7774", "41cfb222db358227521f9638a6fbc397f310042a4db5539a19dea01547c621cd", "43330501660f636fd6547d1e196e395cd1e2c2ae57d62219d6184a668ffebda0", "45d7a2bd8b4f25a013296683f4140d636cdbb507d94a382ea5029a21e76b1648", "47dc935658a13b25108823dabd010194ddea9610357c5c1ef1ad7b3f5157ebee", "480aa7e2b56238badce0b9413a96d5b4c90c3bfbd79eba5a0501e92328d9669e", "4a0934c8b0f97e1d8c18e76c45afc0d02d33ab03125258179f2ac6c7a13f3626", "5624dab19e950f99e560400c59d87b685809e4cfcb2c724103f1ab14c06071f7", "60515b1405bb3dadc55e6ca99429072dad3e736afcf5048db5452df5572231ff", "610f97ebae742a57d336a69b09a9c7d7de1f62aa54aaa8adc635b38f55ba4382", "64ea189b2b0859d1f7b411a09185028744d494ef09029630200cc892e366f169", "686090c6c1e09e4f49585b8508d0a31d58bc3895e4049ea55b197d1381e9f70f", "7745c365195bb0605e3d47b480a2a4d1baa8a41a5fd0a20de5fa48900e2c886a", "79491e0d2b77a1c438116bf9e5f9e2e04e78b78524615e2ce453eff62db59a09", "825177dd4c601c487836b7d6b4ba268db59787157911c623ba59a7c03c8d3adc", "8a060e1f72fb94eee8a035ed29f1201ce903ad14cbe27bda56b4a22a8abda045", "90168cc6353e2766e47b650c963f21cfff294654b10b3a14c67e26a4e3683634", "94b7742734bceeff6d8db5edb31ac844cb68fc7f13617eca859ff1b78bb20ba1", "962aebf2dd01bbb2cdb64580e61760f1afc470781f9ecd5fe8f3d8dcd8cf4556", "9c8d9eacdce840b72eee7924c752c31b675f8aec74790e08cff184a4ea8aa9c1", "af5b929debc336f6bab9b0da6915f9ee5e41444012aed6a79a3c7e80d7662fdf", "b9cdb87fc77e9a3eabdc42a512368538d648fa0760ad30cf97788076985c790a", "c5e6380b90b389454669dc67d0a39fb4dc166416e01308fcddd694236b8329ef", "d60c90fe2bfbee735397bf75a2f2c4e70c5deab51cd40c6e4fa98fae018c8db6", "d8582c8b1b1063249da1588854251d8a91df1e210a328aeb0ece39da2b2b763b", "ddbf86ba3aa0ad8fed2867910d2913ee237d55920b55f1d619049b3399f04efc", "e46bc0664c5c8a0545857aa7a096289f8db148e7f9cca2d0b760113e8994bddc", "f6437f70ec7fed0ca3a0eef1146591bb754b418bb6c6b21db74f0333d624e135", "f71693c3396530c6b00773b029ea85e59272557e9bd6077195a6593e4229892a", "f79f7455f8fbd43e8e9d61914ecf7f48ba1c8e271801996fef8d6a8f3cc9f39f"]
-grpcio-tools = ["056f2a274edda4315e825ac2e3a9536f5415b43aa51669196860c8de6e76d847", "0c953251585fdcd422072e4b7f4243fce215f22e21db94ec83c5970e41db6e18", "142a73f5769f37bf2e4a8e4a77ef60f7af5f55635f60428322b49c87bd8f9cc0", "1b333e2a068d8ef89a01eb23a098d2a789659c3178de79da9bd3d0ffb944cc6d", "2124f19cc51d63405a0204ae38ef355732ab0a235975ab41ff6f6f9701905432", "24c3a04adfb6c6f1bc4a2f8498d7661ca296ae352b498e538832c22ddde7bf81", "3a2054e9640cbdd0ce8a345afb86be52875c5a8f9f5973a5c64791a8002da2dd", "3fd15a09eecef83440ac849dcda2ff522f8ee1603ebfcdbb0e9b320ef2012e41", "457e7a7dfa0b6bb608a766edba6f20c9d626a790df802016b930ad242fec4470", "49ad5661d54ff0d164e4b441ee5e05191187d497380afa16d36d72eb8ef048de", "561078e425d21a6720c3c3828385d949e24c0765e2852a46ecc3ad3fca2706e5", "5a4f65ab06b32dc34112ed114dee3b698c8463670474334ece5b0b531073804c", "8883e0e34676356d219a4cd37d239c3ead655cc550836236b52068e091416fff", "8d2b45b1faf81098780e07d6a1c207b328b07e913160b8baa7e2e8d89723e06c", "b0ebddb6ecc4c161369f93bb3a74c6120a498d3ddc759b64679709a885dd6d4f", "b786ba4842c50de865dd3885b5570690a743e84a327b7213dd440eb0e6b996f8", "be8efa010f5a80f1862ead80c3b19b5eb97dc954a0f59a1e2487078576105e03", "c29106eaff0e2e708a9a89628dc0134ef145d0d3631f0ef421c09f380c30e354", "c3c71236a056ec961b2b8b3b7c0b3b5a826283bc69c4a1c6415d23b70fea8243", "cbc35031ec2b29af36947d085a7fbbcd8b79b84d563adf6156103d82565f78db", "d47307c22744918e803c1eec7263a14f36aaf34fe496bff9ccbcae67c02b40ae", "db088c98e563c1bb070da5984c8df08b45b61e4d9c6d2a8a1ffeed2af89fd1f3", "df4dd1cb670062abdacc1fbce41cae4e08a4a212d28dd94fdbbf90615d027f73", "e3adcf1499ca08d1e036ff44aedf55ed78653d946f4c4426b6e72ab757cc4dec", "e3b3e32e0cda4dc382ec5bed8599dab644e4b3fc66a9ab54eb58248e207880b9", "ed524195b35304c670755efa1eca579e5c290a66981f97004a5b2c0d12d6897d", "edb42432790b1f8ec9f08faf9326d7e5dfe6e1d8c8fe4db39abc0a49c1c76537", "eff1f995e5aa4cc941b6bbc45b5b57842f8f62bbe1a99427281c2c70cf42312c", "f2fcdc2669662d77b400f80e20315a3661466e3cb3df1730f8083f9e49465cbc", "f52ec9926daf48f41389d39d01570967b99c7dbc12bffc134cc3a3c5b5540ba2", "fd007d67fdfbd2a13bf8a8c8ced8353b42a92ca72dbee54e951d8ddbc6ca12bc", "ff9045e928dbb7943ea8559bfabebee95a43a830e00bf52c16202d2d805780fb"]
-html2text = ["55ce85704f244fc18890c5ded89fa22ff7333e41e9f3cad04d51f48d62ad8834", "6f56057c5c2993b5cc5b347cb099bdf6d095828fef1b53ef4e2a2bf2a1be9b4f"]
-idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
-idna-ssl = ["a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"]
-imagesize = ["3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8", "f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"]
-importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26", "d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"]
-itsdangerous = ["321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19", "b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"]
-jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
-markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473", "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161", "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235", "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5", "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff", "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1", "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e", "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183", "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66", "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1", "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1", "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e", "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b", "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905", "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735", "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d", "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e", "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d", "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c", "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21", "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2", "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5", "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b", "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6", "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f", "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f", "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"]
-more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-multidict = ["024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f", "041e9442b11409be5e4fc8b6a97e4bcead758ab1e11768d1e69160bdde18acc3", "045b4dd0e5f6121e6f314d81759abd2c257db4634260abcfe0d3f7083c4908ef", "047c0a04e382ef8bd74b0de01407e8d8632d7d1b4db6f2561106af812a68741b", "068167c2d7bbeebd359665ac4fff756be5ffac9cda02375b5c5a7c4777038e73", "148ff60e0fffa2f5fad2eb25aae7bef23d8f3b8bdaf947a65cdbe84a978092bc", "1d1c77013a259971a72ddaa83b9f42c80a93ff12df6a4723be99d858fa30bee3", "1d48bc124a6b7a55006d97917f695effa9725d05abe8ee78fd60d6588b8344cd", "31dfa2fc323097f8ad7acd41aa38d7c614dd1960ac6681745b6da124093dc351", "34f82db7f80c49f38b032c5abb605c458bac997a6c3142e0d6c130be6fb2b941", "3d5dd8e5998fb4ace04789d1d008e2bb532de501218519d70bb672c4c5a2fc5d", "4a6ae52bd3ee41ee0f3acf4c60ceb3f44e0e3bc52ab7da1c2b2aa6703363a3d1", "4b02a3b2a2f01d0490dd39321c74273fed0568568ea0e7ea23e02bd1fb10a10b", "4b843f8e1dd6a3195679d9838eb4670222e8b8d01bc36c9894d6c3538316fa0a", "5de53a28f40ef3c4fd57aeab6b590c2c663de87a5af76136ced519923d3efbb3", "61b2b33ede821b94fa99ce0b09c9ece049c7067a33b279f343adfe35108a4ea7", "6a3a9b0f45fd75dc05d8e93dc21b18fc1670135ec9544d1ad4acbcf6b86781d0", "76ad8e4c69dadbb31bad17c16baee61c0d1a4a73bed2590b741b2e1a46d3edd0", "7ba19b777dc00194d1b473180d4ca89a054dd18de27d0ee2e42a103ec9b7d014", "7c1b7eab7a49aa96f3db1f716f0113a8a2e93c7375dd3d5d21c4941f1405c9c5", "7fc0eee3046041387cbace9314926aa48b681202f8897f8bff3809967a049036", "8ccd1c5fff1aa1427100ce188557fc31f1e0a383ad8ec42c559aabd4ff08802d", "8e08dd76de80539d613654915a2f5196dbccc67448df291e69a88712ea21e24a", "c18498c50c59263841862ea0501da9f2b3659c00db54abfbf823a80787fde8ce", "c49db89d602c24928e68c0d510f4fcf8989d77defd01c973d6cbe27e684833b1", "ce20044d0317649ddbb4e54dab3c1bcc7483c78c27d3f58ab3d0c7e6bc60d26a", "d1071414dd06ca2eafa90c85a079169bfeb0e5f57fd0b45d44c092546fcd6fd9", "d3be11ac43ab1a3e979dac80843b42226d5d3cccd3986f2e03152720a4297cd7", "db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"]
-mypy = ["1d98fd818ad3128a5408148c9e4a5edce6ed6b58cc314283e631dd5d9216527b", "22ee018e8fc212fe601aba65d3699689dd29a26410ef0d2cc1943de7bec7e3ac", "3a24f80776edc706ec8d05329e854d5b9e464cd332e25cde10c8da2da0a0db6c", "42a78944e80770f21609f504ca6c8173f7768043205b5ac51c9144e057dcf879", "4b2b20106973548975f0c0b1112eceb4d77ed0cafe0a231a1318f3b3a22fc795", "591a9625b4d285f3ba69f541c84c0ad9e7bffa7794da3fa0585ef13cf95cb021", "5b4b70da3d8bae73b908a90bb2c387b977e59d484d22c604a2131f6f4397c1a3", "84edda1ffeda0941b2ab38ecf49302326df79947fa33d98cdcfbf8ca9cf0bb23", "b2b83d29babd61b876ae375786960a5374bba0e4aba3c293328ca6ca5dc448dd", "cc4502f84c37223a1a5ab700649b5ab1b5e4d2bf2d426907161f20672a21930b", "e29e24dd6e7f39f200a5bb55dcaa645d38a397dd5a6674f6042ef02df5795046"]
-mypy-extensions = ["37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812", "b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"]
-oauthlib = ["bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889", "df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"]
-packaging = ["28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47", "d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"]
-pathtools = ["7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"]
-pluggy = ["0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6", "fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"]
-prometheus-client = ["71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"]
-protobuf = ["26c0d756c7ad6823fccbc3b5f84c619b9cc7ac281496fe0a9d78e32023c45034", "3200046e4d4f6c42ed66257dbe15e2e5dc76072c280e9b3d69dc8f3a4fa3fbbc", "368f1bae6dd22d04fd2254d30cd301863408a96ff604422e3ddd8ab601f095a4", "3902fa1920b4ef9f710797496b309efc5ccd0faeba44dc82ed6a711a244764a0", "3a7a8925ba6481b9241cdb5d69cd0b0700f23efed6bb691dc9543faa4aa25d6f", "43cebb63d0a9a724afa020c84dfabe7037fefcb385d154bf1fdd94a9c8ae45f6", "4bc33d49f43c6e9916fb56b7377cb4478cbf25824b4d2bedfb8a4e3df31c12ca", "568b434a36e31ed30d60d600b2227666ce150b8b5275948f50411481a4575d6d", "5c393cd665d03ce6b29561edd6b0cc4bcb3fb8e2a7843e8f223d693f07f61b40", "80072e9ba36c73cf89c01f669c7b123733fc2de1780b428082a850f53cc7865f", "843f498e98ad1469ad54ecb4a7ccf48605a1c5d2bd26ae799c7a2cddab4a37ec", "aa45443035651cbfae74c8deb53358ba660d8e7a5fbab3fc4beb33fb3e3ca4be", "aaab817d9d038dd5f56a6fb2b2e8ae68caf1fd28cc6a963c755fa73268495c13", "e6f68b9979dc8f75299293d682f67fecb72d78f98652da2eeb85c85edef1ca94", "e7366cabddff3441d583fdc0176ab42eba4ee7090ef857d50c4dd59ad124003a", "f0144ad97cd28bfdda0567b9278d25061ada5ad2b545b538cd3577697b32bda3", "f655338491481f482042f19016647e50365ab41b75b486e0df56e0dcc425abf4"]
-py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
-pyasn1 = ["1321d4b2f051410fe7302bb1619903d30b24ba1451d019c11d242d11b2a35444", "2860a047f666afd23b197a65f33145313511c368ce919b2d9b1853ffd3e9d32d", "2919babd43b3b44247c23201b71072c0c65a636daa595cad5bcd276094dbfc2d", "437a23121602c0bb6c65320b27e31e334ffd73a9ca5c6c075b66b6270b1a8184", "5a89df3c62688261e27439d5715fd0d3ca6bf7bf1067e2171642e92aff17e817", "62cdade8b5530f0b185e09855dd422bc05c0bbff6b72ff61381c09dac7befd8c", "67a43aec85f4ea96e72a7b22227ba7a45cf03b7297e1a53418be164bbf68335e", "813b198c169e9442f340743f77093435bf3e1de8d1731f3abc45d44afba17556", "96c44b5604e7674e53e27fce98f3fc68821d9546151b98842c27b533122649da", "a9495356ca1d66ed197a0f72b41eb1823cf7ea8b5bd07191673e8147aecf8604", "bcac468e38d16e94fee4c8f76eef1feb9a06a911e93465f2351a4140fa66d303", "c39d11c72f0e5e71faa35c8c8ef5ee9b810ec99a3c64f05133f1325fe5636bba", "f124185ccc1c1c5e782aa58d46bc28be279673a482334d70de6735d05d8b4b10"]
-pyasn1-modules = ["256c234d85baf315f0e99786d812e68b816e4ee4b35bac982689198ff3df5a61", "3b350a01813f4878f4ebb3e7348d3753556b120145460a810e3121fe78925923", "43c17a83c155229839cc5c6b868e8d0c6041dba149789b6d6e28801c64821722", "525edd202cadbb014587e6e8a82a86424d4c92340222000b300cfd4041625f5a", "5965cb606a914b1b086f6ffdb9e526b5ec21cea81ba0bb75f3b807d5500dda1a", "75819dd99d1be4effd1322859ec8ac3fa7c7503fec0acbce6985b2aae41aa838", "a00100a99dcc71a97b2291fcac868a39f32a72cc54d86a4e5504b34b2f5f8584", "a480489471e67c579f49057a10879cc9a787b64a84af00ed2ed3f68a652b0197", "b3899b59d6c6b4e91e9c5278ec49c0adb971349ef9c3531ae67149e3bb0b272b", "b5e0ab3dc16f42ef0c2e5ebf51db9f1e1aa734a68a4d26a2b475a289182b697f", "bf68431a9043b35aa0a18b865ecbb19ec19f8354488ea0b3b5d9ec33cb4c2be5", "e30199a9d221f1b26c885ff3d87fd08694dbbe18ed0e8e405a2a7126d30ce4c0", "ee0eb28ad9e9c0237954b4ca4c8a91cc2e98476c1dc9a1422310332518b0dd82"]
-pydash = ["bc6fe03097634f5cf49f271ff6bb808a53a9950aa8ad24d93b6f4baaf6547b11", "ec151c9877f9c095e4548a97fa12164900ee2f5c271d3d19a966702ce6def9ca"]
-pygments = ["71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127", "881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"]
-pympler = ["7a11e739125a9ce8bf868ded67238a40e8a7bf979bc03005eb8126182e5e274e"]
-pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
-pytest = ["813b99704b22c7d377bbd756ebe56c35252bb710937b46f207100e843440b3c2", "cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31"]
-pytz = ["26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32", "c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"]
-pyyaml = ["0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9", "01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4", "5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8", "5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696", "7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34", "7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9", "87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73", "9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299", "a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b", "b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae", "b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681", "bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41", "f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"]
-requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
-rsa = ["14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66", "1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"]
-semver = ["41c9aa26c67dc16c54be13074c352ab666bce1fa219c7110e8f03374cd4206b0", "5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8"]
-six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
-snowballstemmer = ["713e53b79cbcf97bc5245a06080a33d54a77e7cce2f789c835a143bcdb5c033e"]
-sphinx = ["0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845", "839a3ed6f6b092bb60f492024489cc9e6991360fb9f52ed6361acd510d261069"]
-sphinx-markdown-builder = ["aedd65534b2d5edb0c3cbcc5d6d956149bb1f3a647866572d2cbbe1d1c4d11e8", "d285c373a8e1ac8d5b904623b8aeb9467c84958a940c117681302e1b3463a741"]
-sphinxcontrib-applehelp = ["edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897", "fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"]
-sphinxcontrib-devhelp = ["6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34", "9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"]
-sphinxcontrib-htmlhelp = ["4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422", "d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"]
-sphinxcontrib-jsmath = ["2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"]
-sphinxcontrib-qthelp = ["513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20", "79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"]
-sphinxcontrib-serializinghtml = ["c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227", "db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"]
-toposort = ["d80128b83b411d503b0cdb4a8f172998bc1d3b434b6402a349b8ebd734d51a80", "dba5ae845296e3bf37b042c640870ffebcdeb8cd4df45adaa01d8c5476c557dd"]
-typed-ast = ["18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e", "262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e", "2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0", "354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c", "4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631", "630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4", "66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34", "71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b", "95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a", "bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233", "cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1", "d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36", "d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d", "d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a", "ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"]
-typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]
-typing-extensions = ["2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95", "b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87", "d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"]
-unify = ["8ddce812b2457212b7598fe574c9e6eb3ad69710f445391338270c7f8a71723c"]
-untokenize = ["3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2"]
-urllib3 = ["06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b", "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"]
-watchdog = ["965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"]
-wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
-werkzeug = ["7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7", "e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"]
-yapf = ["02ace10a00fa2e36c7ebd1df2ead91dbfbd7989686dc4ccbdc549e95d19f5780", "6f94b6a176a7c114cfa6bad86d40f259bbe0f10cf2fa7f2f4b3596fc5802a41b"]
-yarl = ["024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9", "2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f", "3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb", "3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320", "5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842", "73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0", "7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829", "b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310", "c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4", "c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8", "e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"]
-zipp = ["3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e", "f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"]
+[metadata.files]
+aiohttp = [
+    {file = "aiohttp-3.6.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e"},
+    {file = "aiohttp-3.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec"},
+    {file = "aiohttp-3.6.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48"},
+    {file = "aiohttp-3.6.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59"},
+    {file = "aiohttp-3.6.2-cp36-cp36m-win32.whl", hash = "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a"},
+    {file = "aiohttp-3.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17"},
+    {file = "aiohttp-3.6.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a"},
+    {file = "aiohttp-3.6.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd"},
+    {file = "aiohttp-3.6.2-cp37-cp37m-win32.whl", hash = "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"},
+    {file = "aiohttp-3.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654"},
+    {file = "aiohttp-3.6.2-py3-none-any.whl", hash = "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4"},
+    {file = "aiohttp-3.6.2.tar.gz", hash = "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326"},
+]
+alabaster = [
+    {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
+    {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+argh = [
+    {file = "argh-0.26.2-py2.py3-none-any.whl", hash = "sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3"},
+    {file = "argh-0.26.2.tar.gz", hash = "sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"},
+]
+async-timeout = [
+    {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
+    {file = "async_timeout-3.0.1-py3-none-any.whl", hash = "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
+    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+babel = [
+    {file = "Babel-2.7.0-py2.py3-none-any.whl", hash = "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab"},
+    {file = "Babel-2.7.0.tar.gz", hash = "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"},
+]
+cachetools = [
+    {file = "cachetools-3.1.1-py2.py3-none-any.whl", hash = "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae"},
+    {file = "cachetools-3.1.1.tar.gz", hash = "sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"},
+]
+certifi = [
+    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
+    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
+    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+dataclasses = [
+    {file = "dataclasses-0.7-py3-none-any.whl", hash = "sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836"},
+    {file = "dataclasses-0.7.tar.gz", hash = "sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6"},
+]
+docutils = [
+    {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
+    {file = "docutils-0.15.2-py3-none-any.whl", hash = "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0"},
+    {file = "docutils-0.15.2.tar.gz", hash = "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"},
+]
+flask = [
+    {file = "Flask-1.1.1-py2.py3-none-any.whl", hash = "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"},
+    {file = "Flask-1.1.1.tar.gz", hash = "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52"},
+]
+google-auth = [
+    {file = "google-auth-1.10.0.tar.gz", hash = "sha256:7bb2034a3a290190cf4e3eb8ebf29e5025c90f0b06a00ba4d1fb94bf0c6448f7"},
+    {file = "google_auth-1.10.0-py2.py3-none-any.whl", hash = "sha256:c57074e594d2c6e3e316162734e8af3e15d40252022e69414cba67de66594417"},
+]
+grpcio = [
+    {file = "grpcio-1.26.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:f6580a8a4f5e701289b45fd62a8f6cb5ec41e4d77082424f8b676806dcd22564"},
+    {file = "grpcio-1.26.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:cd3d3e328f20f7c807a862620c6ee748e8d57ba2a8fc960d48337ed71c6d9d32"},
+    {file = "grpcio-1.26.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:bfd7d3130683a1a0a50c456273c21ec8a604f2d043b241a55235a78a0090ee06"},
+    {file = "grpcio-1.26.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:99fd873699df17cb11c542553270ae2b32c169986e475df0d68a8629b8ef4df7"},
+    {file = "grpcio-1.26.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:6edda1b96541187f73aab11800d25f18ee87e53d5f96bb74473873072bf28a0e"},
+    {file = "grpcio-1.26.0-cp27-cp27m-win32.whl", hash = "sha256:ffec45b0db18a555fdfe0c6fa2d0a3fceb751b22b31e8fcd14ceed7bde05481e"},
+    {file = "grpcio-1.26.0-cp27-cp27m-win_amd64.whl", hash = "sha256:066630f6b62bffa291dacbee56994279a6a3682b8a11967e9ccaf3cc770fc11e"},
+    {file = "grpcio-1.26.0-cp27-cp27mu-linux_armv7l.whl", hash = "sha256:5b0fa09efb33e2af4e8822b4eb8b2cbc201d562e3e185c439be7eaeee2e8b8aa"},
+    {file = "grpcio-1.26.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6c2db348ac73d73afe14e0833b18abbbe920969bf2c5c03c0922719f8020d06"},
+    {file = "grpcio-1.26.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bdb2f3dcb664f0c39ef1312cd6acf6bc6375252e4420cf8f36fff4cb4fa55c71"},
+    {file = "grpcio-1.26.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:d9542366a0917b9b48bab1fee481ac01f56bdffc52437b598c09e7840148a6a9"},
+    {file = "grpcio-1.26.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d1a481777952e4f99b8a6956581f3ee866d7614100d70ae6d7e07327570b85ce"},
+    {file = "grpcio-1.26.0-cp35-cp35m-linux_armv7l.whl", hash = "sha256:57be5a6c509a406fe0ffa6f8b86904314c77b5e2791be8123368ad2ebccec874"},
+    {file = "grpcio-1.26.0-cp35-cp35m-macosx_10_7_intel.whl", hash = "sha256:6d8ab28559be98b02f8b3a154b53239df1aa5b0d28ff865ae5be4f30e7ed4d3f"},
+    {file = "grpcio-1.26.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:cb7a4b41b5e2611f85c3402ac364f1d689f5d7ecbc24a55ef010eedcd6cf460f"},
+    {file = "grpcio-1.26.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2f78ebf340eaf28fa09aba0f836a8b869af1716078dfe8f3b3f6ff785d8f2b0f"},
+    {file = "grpcio-1.26.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:d1d49720ed636920bb3d74cedf549382caa9ad55aea89d1de99d817068d896b2"},
+    {file = "grpcio-1.26.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:33a07a1a8e817d733588dbd18e567caad1a6fe0d440c165619866cd490c7911a"},
+    {file = "grpcio-1.26.0-cp35-cp35m-win32.whl", hash = "sha256:d44c34463a7c481e076f691d8fa25d080c3486978c2c41dca09a8dd75296c2d7"},
+    {file = "grpcio-1.26.0-cp35-cp35m-win_amd64.whl", hash = "sha256:b6fda5674f990e15e1bcaacf026428cf50bce36e708ddcbd1de9673b14aab760"},
+    {file = "grpcio-1.26.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:d7e5b7af1350e9c8c17a7baf99d575fbd2de69f7f0b0e6ebd47b57506de6493a"},
+    {file = "grpcio-1.26.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0a0fb2f8e3a13537106bc77e4c63005bc60124a6203034304d9101921afa4e90"},
+    {file = "grpcio-1.26.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9939727d9ae01690b24a2b159ac9dbca7b7e8e6edd5af6a6eb709243cae7b52b"},
+    {file = "grpcio-1.26.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ed10e5fad105ecb0b12822f924e62d0deb07f46683a0b64416b17fd143daba1d"},
+    {file = "grpcio-1.26.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:1c6e0f6b9d091e3717e9a58d631c8bb4898be3b261c2a01fe46371fdc271052f"},
+    {file = "grpcio-1.26.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:d42433f0086cccd192114343473d7dbd4aae9141794f939e2b7b83efc57543db"},
+    {file = "grpcio-1.26.0-cp36-cp36m-win32.whl", hash = "sha256:df7cdfb40179acc9790a462c049e0b8e109481164dd7ad1a388dd67ff1528759"},
+    {file = "grpcio-1.26.0-cp36-cp36m-win_amd64.whl", hash = "sha256:6a43d2f2ff8250f200fdf7aa31fa191a997922aa9ea1182453acd705ad83ab72"},
+    {file = "grpcio-1.26.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f7b83e4b2842d44fce3cdc0d54db7a7e0d169a598751bf393601efaa401c83e0"},
+    {file = "grpcio-1.26.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f0ec5371ce2363b03531ed522bfbe691ec940f51f0e111f0500fc0f44518c69d"},
+    {file = "grpcio-1.26.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:42b903a3596a10e2a3727bae2a76f8aefd324d498424b843cfa9606847faea7b"},
+    {file = "grpcio-1.26.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0c61b74dcfb302613926e785cb3542a0905b9a3a86e9410d8cf5d25e25e10104"},
+    {file = "grpcio-1.26.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:8d866aafb08657c456a18c4a31c8526ea62de42427c242b58210b9eae6c64559"},
+    {file = "grpcio-1.26.0-cp37-cp37m-win32.whl", hash = "sha256:13383bd70618da03684a8aafbdd9e3d9a6720bf8c07b85d0bc697afed599d8f0"},
+    {file = "grpcio-1.26.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4fffbb58134c4f23e5a8312ac3412db6f5e39e961dc0eb5e3115ce5aa16bf927"},
+    {file = "grpcio-1.26.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7109c8738a8a3c98cfb5dda1c45642a8d6d35dc00d257ab7a175099b2b4daecd"},
+    {file = "grpcio-1.26.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e1a9d9d2e7224d981aea8da79260c7f6932bf31ce1f99b7ccfa5eceeb30dc5d0"},
+    {file = "grpcio-1.26.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6e47866b7dc14ca3a12d40c1d6082e7bea964670f1c5315ea0fb8b0550244d64"},
+    {file = "grpcio-1.26.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:07e95762ca6b18afbeb3aa2793e827c841152d5e507089b1db0b18304edda105"},
+    {file = "grpcio-1.26.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:2da5cee9faf17bb8daf500cd0d28a17ae881ab5500f070a6aace457f4c08cac4"},
+    {file = "grpcio-1.26.0-cp38-cp38-win32.whl", hash = "sha256:3d090c66af9c065b7228b07c3416f93173e9839b1d40bb0ce3dd2aa783645026"},
+    {file = "grpcio-1.26.0-cp38-cp38-win_amd64.whl", hash = "sha256:1cf710c04689daa5cc1e598efba00b028215700dcc1bf66fcb7b4f64f2ea5d5f"},
+    {file = "grpcio-1.26.0.tar.gz", hash = "sha256:5ef42dfc18f9a63a06aca938770b69470bb322e4c137cf08cf21703d1ef4ae5c"},
+]
+grpcio-tools = [
+    {file = "grpcio-tools-1.26.0.tar.gz", hash = "sha256:5580b86cf49936c9c74f0def44d3582a7a1bb720eba8a14805c3a61efa790c70"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:809d60f15a32c21dc221ddb591aff8adfdde4e05095414eb8e015cdfef361615"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:675918f83fa35bd54f4c29d95d8652c6215d5e95a13b6f14e626cdef6d0fce79"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:826c19f26b41e99691e77823ad67f04dc0b69e514212907695e330c6f106415c"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:4e9a1276f8699d06518cec8caceb2c423fc7f971765cab7550d39f281795fd81"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:51ac9c4f8a542cd20c6776fde781c84c0acd8faba55ec14f121c6b4eb4245e89"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-win32.whl", hash = "sha256:a209002e3d4787f0e90e29f15cddbe83dc9054238c0da7f539c913002a348cc1"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27m-win_amd64.whl", hash = "sha256:376a1840d1f5d25e9c3391557d6b3eeb3de17be697b0e55d8247d0262fcbaacf"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27mu-linux_armv7l.whl", hash = "sha256:bba8d3b61ec113bb94596599d2568217b22ddfc7baa46c00dec5106cfd4e914b"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:1e80f74854bd1c7263942e836d69f95ffc66bb45bf14bf3e1ab61113271b5884"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dcbd1fbb540638c9ad9c3a071b392b654f79666a2bc12808080b0e9f674b9a80"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:6cea124cbd9081a587e1954b98e9a27c7cca6ae72babc3046ab6b439a5730679"},
+    {file = "grpcio_tools-1.26.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:ab841c69581085b6f9aa54044a13db6ec31183513f7cce0862d29c9b7b4e3c64"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-linux_armv7l.whl", hash = "sha256:1783b8fa74f58a643e7780112fc4eb6110789672e852a691fad6af6b94a90c4a"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:033a4e80dc78d9c11860800bd5a66b65ff385be8f669e96b02e795364c860597"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:eae371a663ceeef8f930323a120a9d11e13e1c49903a66ddb4ada4830d5bcb7d"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b97e74ffe121dfa9ae7ec94393fce4e95e9e0a343827663e989dc4b7c918d1a5"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:da75e33e185c8be17a82ec4a97f5c75ec05d57e85f8b285f86e2a22484849e4a"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:facb8c588cdd6adc51ae7545f59283565dae8d946c6163e578b70ab6bf161215"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-win32.whl", hash = "sha256:68259fd06188951d152665ffe44f9660edd715c102ae4bc4216eca4c4666dadf"},
+    {file = "grpcio_tools-1.26.0-cp35-cp35m-win_amd64.whl", hash = "sha256:d396fdb7026986e6d3897bb207cc7d5bc536a82a2e50af806a24b3d254c73bc3"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:9af72b764b41ba939e8e0a7ae9ec8a17d1c46a18797c6342cba6483f29e1790f"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9a2091371298f04ef350f776365945537d0befa95bad5623d80c4207bdff9d3a"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7f7430434bd997584f2136a675559ba0d4afdf7cb71d9bbc429b0cc831e6828c"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:58a879208bd84d6819a61c1b0618655574ef9df1d63a0e2f434fdcb5cfa1fb57"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c15f0718cbc3986e747d5b0734198dce0ac07d188ec5e063b1e9889ac947f86e"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:d62ab00dea7fa0813fc813a6c848da2eeda5cb71893b892a229d23949de0cecd"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-win32.whl", hash = "sha256:0e3b5469912430f19407ebe14cfd1bece1b5a277c4d43e1b65dbff19d9475ccc"},
+    {file = "grpcio_tools-1.26.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a908d5af2f26673e970c7c03703437bf95d10e88dad3322e7e267467db44a04d"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0286f704e55e3012fec3910400fe1a4ed11aeb66d3ec4b7f8041845af7fb7206"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6f356a445ba7afc634b1046d9f51d3ae37afbf4fe1a500285aca37677462a7b9"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4ba7e5afc93b413bbb5f3dd65ba583e078ff5895a5053d825ab793cf7720ae96"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:33c6bee5a02408018dc10a5737818d2159f14cbb0613df41cc93ba6cbaeea095"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:96c6f657b93f49243d083840d27a5a686a1fc26044a80ebf8585734d5152d4ee"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-win32.whl", hash = "sha256:fb043e45f91634776acdfe4b8dfc96b636c53a458799179041ab633e15c3d833"},
+    {file = "grpcio_tools-1.26.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f290cccc972533a288c2ebc55eb3c0fbe0c6a0d0a9775cb34ce6bfb11fe14a11"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c56d0ac769bf1f01dbb6ec6b6492849e70cd35bdeeb660e206a70ab43917ae92"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:131aa8c3862a555819428856f872ab9e919e351d7cd60c98012e12d2fb6afc45"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b1bc78efefb8e085c072add2c02326fdecad9b8644b3be11e715ea4c6102ad87"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:bfe0e33aea60da100b214c72c1746cc0194bb8da910004518c185041cc795543"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:27ae784acff3d2fa04e3b4dc72f8d60a55d654f90e410adf08f46a4d2d673dd3"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-win32.whl", hash = "sha256:3922dffd8160d54dc00c7d32b30776a974cc098086493c668faffac19e752087"},
+    {file = "grpcio_tools-1.26.0-cp38-cp38-win_amd64.whl", hash = "sha256:e7e90bad5466347a3648358e9f437e72d5f6d6025fe741171a88aca8b9d864df"},
+]
+html2text = [
+    {file = "html2text-2019.9.26-py3-none-any.whl", hash = "sha256:55ce85704f244fc18890c5ded89fa22ff7333e41e9f3cad04d51f48d62ad8834"},
+    {file = "html2text-2019.9.26.tar.gz", hash = "sha256:6f56057c5c2993b5cc5b347cb099bdf6d095828fef1b53ef4e2a2bf2a1be9b4f"},
+]
+idna = [
+    {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
+    {file = "idna-2.8.tar.gz", hash = "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"},
+]
+idna-ssl = [
+    {file = "idna-ssl-1.1.0.tar.gz", hash = "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"},
+]
+imagesize = [
+    {file = "imagesize-1.1.0-py2.py3-none-any.whl", hash = "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8"},
+    {file = "imagesize-1.1.0.tar.gz", hash = "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.3.0-py2.py3-none-any.whl", hash = "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"},
+    {file = "importlib_metadata-1.3.0.tar.gz", hash = "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45"},
+]
+itsdangerous = [
+    {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
+    {file = "itsdangerous-1.1.0.tar.gz", hash = "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"},
+]
+jinja2 = [
+    {file = "Jinja2-2.10.3-py2.py3-none-any.whl", hash = "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f"},
+    {file = "Jinja2-2.10.3.tar.gz", hash = "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+more-itertools = [
+    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
+    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
+]
+multidict = [
+    {file = "multidict-4.7.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:8f30ead697c2e37147d82ba8019952b5ea99bd3d1052f1f1ebff951eaa953209"},
+    {file = "multidict-4.7.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:824716bba5a4efd74ddd36a3830efb9e49860149514ef7c41aac0144757ebb5d"},
+    {file = "multidict-4.7.2-cp35-cp35m-win32.whl", hash = "sha256:63d9a3d93a514549760cb68c82864966bddb6ab53a3326931c8db9ad29414603"},
+    {file = "multidict-4.7.2-cp35-cp35m-win_amd64.whl", hash = "sha256:a03efe8b7591c77d9ad4b9d81dcfb9c96e538ae25eb114385f35f4d7ffa3bac2"},
+    {file = "multidict-4.7.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:7dd6f6a51b64d0a6473bc30c53e1d73fcb461c437f43662b7d6d701bd90db253"},
+    {file = "multidict-4.7.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:77264002c184538df5dcb4fc1de5df6803587fa30bbe12203a7a3436b8aafc0f"},
+    {file = "multidict-4.7.2-cp36-cp36m-win32.whl", hash = "sha256:b86e8e33a0a24240b293e7fad233a7e886bae6e51ca6923d39f4e313dd1d5578"},
+    {file = "multidict-4.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:daf6d89e47418e38af98e1f2beb3fe0c8aa34806f681d04df314c0f131dcf01d"},
+    {file = "multidict-4.7.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:7f4e591ec80619e74c50b7800f9db9b0e01d2099094767050dfe2e78e1c41839"},
+    {file = "multidict-4.7.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:335344a3c3b19845c73a7826f359c51c4a12a1ccd2392b5f572a63b452bfc771"},
+    {file = "multidict-4.7.2-cp37-cp37m-win32.whl", hash = "sha256:615a282acd530a1bc1b01f069a8c5874cb7c2780c287a2895ad5ab7407540e9d"},
+    {file = "multidict-4.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:20081b14c923d2c5122c13e060d0ee334e078e1802c36006b20c8d7a59ee6a52"},
+    {file = "multidict-4.7.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:49e80c53659c7ac50ec1c4b5fa50f045b67fffeb5b735dccb6205e4ff122e8b6"},
+    {file = "multidict-4.7.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ff53a434890a16356bc45c0b90557efd89d0e5a820dbab37015d7ee630c6707a"},
+    {file = "multidict-4.7.2-cp38-cp38-win32.whl", hash = "sha256:c1c64c93b8754a5cebd495d136f47a5ca93cbfceba532e306a768c27a0c1292b"},
+    {file = "multidict-4.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:e03b7addca96b9eb24d6eabbdc3041e8f71fd47b316e0f3c0fa993fc7b99002c"},
+    {file = "multidict-4.7.2.tar.gz", hash = "sha256:d4dafdcfbf0ac80fc5f00603f0ce43e487c654ae34a656e4749f175d9832b1b5"},
+]
+mypy = [
+    {file = "mypy-0.761-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6"},
+    {file = "mypy-0.761-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36"},
+    {file = "mypy-0.761-cp35-cp35m-win_amd64.whl", hash = "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72"},
+    {file = "mypy-0.761-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2"},
+    {file = "mypy-0.761-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0"},
+    {file = "mypy-0.761-cp36-cp36m-win_amd64.whl", hash = "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474"},
+    {file = "mypy-0.761-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a"},
+    {file = "mypy-0.761-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749"},
+    {file = "mypy-0.761-cp37-cp37m-win_amd64.whl", hash = "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1"},
+    {file = "mypy-0.761-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7"},
+    {file = "mypy-0.761-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"},
+    {file = "mypy-0.761-cp38-cp38-win_amd64.whl", hash = "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b"},
+    {file = "mypy-0.761-py3-none-any.whl", hash = "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217"},
+    {file = "mypy-0.761.tar.gz", hash = "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+oauthlib = [
+    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
+    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
+]
+packaging = [
+    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
+    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+]
+pathtools = [
+    {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.7.1.tar.gz", hash = "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"},
+]
+protobuf = [
+    {file = "protobuf-3.11.1-cp27-cp27m-macosx_10_9_intel.whl", hash = "sha256:34a7270940f86da7a28be466ac541c89b6dbf144a6348b9cf7ac6f56b71006ce"},
+    {file = "protobuf-3.11.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e028fee51c96de4e81924484c77111dfdea14010ecfc906ea5b252209b0c4de6"},
+    {file = "protobuf-3.11.1-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:29bd1ed46b2536ad8959401a2f02d2d7b5a309f8e97518e4f92ca6c5ba74dbed"},
+    {file = "protobuf-3.11.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839bad7d115c77cdff29b488fae6a3ab503ce9a4192bd4c42302a6ea8e5d0f33"},
+    {file = "protobuf-3.11.1-cp35-cp35m-win32.whl", hash = "sha256:c65d135ea2d85d40309e268106dab02d3bea723db2db21c23ecad4163ced210b"},
+    {file = "protobuf-3.11.1-cp35-cp35m-win_amd64.whl", hash = "sha256:38cbc830a4a5ba9956763b0f37090bfd14dd74e72762be6225de2ceac55f4d03"},
+    {file = "protobuf-3.11.1-cp36-cp36m-macosx_10_9_intel.whl", hash = "sha256:c98dea04a1ff41a70aff2489610f280004831798cb36a068013eed04c698903d"},
+    {file = "protobuf-3.11.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0265379852b9e1f76af6d3d3fe4b3c383a595cc937594bda8565cf69a96baabd"},
+    {file = "protobuf-3.11.1-cp36-cp36m-win32.whl", hash = "sha256:934a9869a7f3b0d84eca460e386fba1f7ba2a0c1a120a2648bc41fadf50efd1c"},
+    {file = "protobuf-3.11.1-cp36-cp36m-win_amd64.whl", hash = "sha256:3175d45698edb9a07c1a78a1a4850e674ce8988f20596580158b1d0921d0f057"},
+    {file = "protobuf-3.11.1-cp37-cp37m-macosx_10_9_intel.whl", hash = "sha256:d9049aa194378a426f0b2c784e2054565bf6f754d20fcafdee7102a6250556e8"},
+    {file = "protobuf-3.11.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e88a924b591b06d0191620e9c8aa75297b3111066bb09d49a24bae1054a10c13"},
+    {file = "protobuf-3.11.1-cp37-cp37m-win32.whl", hash = "sha256:c4e90bc27c0691c76e09b5dc506133451e52caee1472b8b3c741b7c912ce43ef"},
+    {file = "protobuf-3.11.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e84ad26fb50091b1ea676403c0dd2bd47663099454aa6d88000b1dafecab0941"},
+    {file = "protobuf-3.11.1-py2.7.egg", hash = "sha256:200b77e51f17fbc1d3049045f5835f60405dec3a00fe876b9b986592e46d908c"},
+    {file = "protobuf-3.11.1-py2.py3-none-any.whl", hash = "sha256:665194f5ad386511ac8d8a0bd57b9ab37b8dd2cd71969458777318e774b9cd46"},
+    {file = "protobuf-3.11.1.tar.gz", hash = "sha256:aecdf12ef6dc7fd91713a6da93a86c2f2a8fe54840a3b1670853a2b7402e77c9"},
+]
+py = [
+    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
+    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pyasn1-modules = [
+    {file = "pyasn1-modules-0.2.7.tar.gz", hash = "sha256:0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b"},
+    {file = "pyasn1_modules-0.2.7-py2.4.egg", hash = "sha256:233f55c840e821e76828262db976ac894b285909d22d060c2bdb522e7bf28cc6"},
+    {file = "pyasn1_modules-0.2.7-py2.5.egg", hash = "sha256:9ca5e376a6d9dee35bb3a62608dfa2e6698798aa6b8db3c7afd0eb31af0d63c7"},
+    {file = "pyasn1_modules-0.2.7-py2.6.egg", hash = "sha256:27581362b4253b9c999882a64df974124cde12be0bf2c04148a0d68bc6bbb7b8"},
+    {file = "pyasn1_modules-0.2.7-py2.7.egg", hash = "sha256:13a6955947d8a554de78fc305a4d651f20fb5580b88612a5f0661d4f189d27ac"},
+    {file = "pyasn1_modules-0.2.7-py2.py3-none-any.whl", hash = "sha256:b6ada4f840fe51abf5a6bd545b45bf537bea62221fa0dde2e8a553ed9f06a4e3"},
+    {file = "pyasn1_modules-0.2.7-py3.1.egg", hash = "sha256:9b972f81f59d896cebb9ebb1d44296f1acb28bf7869443c37551f4eed8d74f83"},
+    {file = "pyasn1_modules-0.2.7-py3.2.egg", hash = "sha256:64f6aecf26e93f6a3ba3725b4eb9f532551747d7a63ca9ff43aef12f4bf11eac"},
+    {file = "pyasn1_modules-0.2.7-py3.3.egg", hash = "sha256:33c220a2701032261a23eea6e9881404ac6fc7ff96f183b5353fea8fc8962547"},
+    {file = "pyasn1_modules-0.2.7-py3.4.egg", hash = "sha256:24d54188cb7abd750e0a2cba61b7b46a75608175a0c3c1b1eee08322915d8d21"},
+    {file = "pyasn1_modules-0.2.7-py3.5.egg", hash = "sha256:7b4edf07ca2f759d7cf693184be09f22e067c2eb52b03c770d0a2e9de1c67dfd"},
+    {file = "pyasn1_modules-0.2.7-py3.6.egg", hash = "sha256:eaf35047a0b068e3e0c2a99618b13b65c98c329661daa78c9d44a4ef0fe8139e"},
+    {file = "pyasn1_modules-0.2.7-py3.7.egg", hash = "sha256:c14b107a67ee36a7f183ae9f4803ffde4a03b67f3192eab0a62e851af71371d3"},
+]
+pydash = [
+    {file = "pydash-4.7.6-py2.py3-none-any.whl", hash = "sha256:bc9762159c3fd1f822b131a2d9cbb2b2036595a42ad257d2d821b29803d85f7d"},
+    {file = "pydash-4.7.6.tar.gz", hash = "sha256:a7733886ab811e36510b44ff1de7ccc980327d701fb444a4b2ce395e6f4a4a87"},
+]
+pygments = [
+    {file = "Pygments-2.5.2-py2.py3-none-any.whl", hash = "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b"},
+    {file = "Pygments-2.5.2.tar.gz", hash = "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"},
+]
+pympler = [
+    {file = "Pympler-0.8.tar.gz", hash = "sha256:f74cd2982c5cd92ded55561191945616f2bb904a0ae5cdacdb566c6696bdb922"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
+    {file = "pyparsing-2.4.5.tar.gz", hash = "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"},
+]
+pytest = [
+    {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
+    {file = "pytest-5.3.2.tar.gz", hash = "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa"},
+]
+pytest-subtests = [
+    {file = "pytest-subtests-0.2.1.tar.gz", hash = "sha256:9c0480d4a44dbff5c6ad8ecb283ac66e5bc5ef951c6ba838d51e2548376b3a00"},
+    {file = "pytest_subtests-0.2.1-py3-none-any.whl", hash = "sha256:3842459a43e9a40c0ee388891b198847ea0a93649b88957efd8fc4c140ed458b"},
+]
+pytz = [
+    {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
+    {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
+]
+pyyaml = [
+    {file = "PyYAML-5.2-cp27-cp27m-win32.whl", hash = "sha256:35ace9b4147848cafac3db142795ee42deebe9d0dad885ce643928e88daebdcc"},
+    {file = "PyYAML-5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:ebc4ed52dcc93eeebeae5cf5deb2ae4347b3a81c3fa12b0b8c976544829396a4"},
+    {file = "PyYAML-5.2-cp35-cp35m-win32.whl", hash = "sha256:38a4f0d114101c58c0f3a88aeaa44d63efd588845c5a2df5290b73db8f246d15"},
+    {file = "PyYAML-5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:483eb6a33b671408c8529106df3707270bfacb2447bf8ad856a4b4f57f6e3075"},
+    {file = "PyYAML-5.2-cp36-cp36m-win32.whl", hash = "sha256:7f38e35c00e160db592091751d385cd7b3046d6d51f578b29943225178257b31"},
+    {file = "PyYAML-5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc"},
+    {file = "PyYAML-5.2-cp37-cp37m-win32.whl", hash = "sha256:e4c015484ff0ff197564917b4b4246ca03f411b9bd7f16e02a2f586eb48b6d04"},
+    {file = "PyYAML-5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:4b6be5edb9f6bb73680f5bf4ee08ff25416d1400fbd4535fe0069b2994da07cd"},
+    {file = "PyYAML-5.2-cp38-cp38-win32.whl", hash = "sha256:8100c896ecb361794d8bfdb9c11fce618c7cf83d624d73d5ab38aef3bc82d43f"},
+    {file = "PyYAML-5.2-cp38-cp38-win_amd64.whl", hash = "sha256:2e9f0b7c5914367b0916c3c104a024bb68f269a486b9d04a2e8ac6f6597b7803"},
+    {file = "PyYAML-5.2.tar.gz", hash = "sha256:c0ee8eca2c582d29c3c2ec6e2c4f703d1b7f1fb10bc72317355a746057e7346c"},
+]
+requests = [
+    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
+    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+]
+rsa = [
+    {file = "rsa-4.0-py2.py3-none-any.whl", hash = "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66"},
+    {file = "rsa-4.0.tar.gz", hash = "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"},
+]
+semver = [
+    {file = "semver-2.9.0-py2.py3-none-any.whl", hash = "sha256:aa1c6be3bf23e346e00c509a7ee87735a7e0fd6b404cf066037cfeab2c770320"},
+    {file = "semver-2.9.0.tar.gz", hash = "sha256:ed1edeaa0c27f68feb74f09f715077fd07b728446dc2bb7fc470fc0f737873a0"},
+]
+six = [
+    {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
+    {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
+    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+]
+sphinx = [
+    {file = "Sphinx-2.3.0-py3-none-any.whl", hash = "sha256:138e39aa10f28d52aa5759fc6d1cba2be6a4b750010974047fa7d0e31addcf63"},
+    {file = "Sphinx-2.3.0.tar.gz", hash = "sha256:0a11e2fd31fe5c7e64b4fc53c2c022946512f021d603eb41ac6ae51d5fcbb574"},
+]
+sphinx-markdown-builder = [
+    {file = "sphinx-markdown-builder-0.5.3.tar.gz", hash = "sha256:520407e000831a7970f45dcd911384beb554407e35117575bde37773f185c1bb"},
+    {file = "sphinx_markdown_builder-0.5.3-py2.py3-none-any.whl", hash = "sha256:36e8883f057c9b528ccaa0014df73565c70b8dc42a5440fb0dde452cef7bf46d"},
+]
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.1.tar.gz", hash = "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897"},
+    {file = "sphinxcontrib_applehelp-1.0.1-py2.py3-none-any.whl", hash = "sha256:fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"},
+]
+sphinxcontrib-devhelp = [
+    {file = "sphinxcontrib-devhelp-1.0.1.tar.gz", hash = "sha256:6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34"},
+    {file = "sphinxcontrib_devhelp-1.0.1-py2.py3-none-any.whl", hash = "sha256:9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"},
+]
+sphinxcontrib-htmlhelp = [
+    {file = "sphinxcontrib-htmlhelp-1.0.2.tar.gz", hash = "sha256:4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422"},
+    {file = "sphinxcontrib_htmlhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"},
+]
+sphinxcontrib-jsmath = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+sphinxcontrib-qthelp = [
+    {file = "sphinxcontrib-qthelp-1.0.2.tar.gz", hash = "sha256:79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"},
+    {file = "sphinxcontrib_qthelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20"},
+]
+sphinxcontrib-serializinghtml = [
+    {file = "sphinxcontrib-serializinghtml-1.1.3.tar.gz", hash = "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227"},
+    {file = "sphinxcontrib_serializinghtml-1.1.3-py2.py3-none-any.whl", hash = "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"},
+]
+toposort = [
+    {file = "toposort-1.5-py2.py3-none-any.whl", hash = "sha256:d80128b83b411d503b0cdb4a8f172998bc1d3b434b6402a349b8ebd734d51a80"},
+    {file = "toposort-1.5.tar.gz", hash = "sha256:dba5ae845296e3bf37b042c640870ffebcdeb8cd4df45adaa01d8c5476c557dd"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0"},
+    {file = "typed_ast-1.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win32.whl", hash = "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e"},
+    {file = "typed_ast-1.4.0.tar.gz", hash = "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},
+    {file = "typing_extensions-3.7.4.1-py3-none-any.whl", hash = "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"},
+    {file = "typing_extensions-3.7.4.1.tar.gz", hash = "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2"},
+]
+unify = [
+    {file = "unify-0.5.tar.gz", hash = "sha256:8ddce812b2457212b7598fe574c9e6eb3ad69710f445391338270c7f8a71723c"},
+]
+untokenize = [
+    {file = "untokenize-0.1.1.tar.gz", hash = "sha256:3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2"},
+]
+urllib3 = [
+    {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
+    {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
+]
+watchdog = [
+    {file = "watchdog-0.9.0.tar.gz", hash = "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"},
+]
+wcwidth = [
+    {file = "wcwidth-0.1.7-py2.py3-none-any.whl", hash = "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"},
+    {file = "wcwidth-0.1.7.tar.gz", hash = "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"},
+]
+werkzeug = [
+    {file = "Werkzeug-0.16.0-py2.py3-none-any.whl", hash = "sha256:e5f4a1f98b52b18a93da705a7458e55afb26f32bff83ff5d19189f92462d65c4"},
+    {file = "Werkzeug-0.16.0.tar.gz", hash = "sha256:7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7"},
+]
+yapf = [
+    {file = "yapf-0.29.0-py2.py3-none-any.whl", hash = "sha256:cad8a272c6001b3401de3278238fdc54997b6c2e56baa751788915f879a52fca"},
+    {file = "yapf-0.29.0.tar.gz", hash = "sha256:712e23c468506bf12cadd10169f852572ecc61b266258422d45aaf4ad7ef43de"},
+]
+yarl = [
+    {file = "yarl-1.4.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b"},
+    {file = "yarl-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1"},
+    {file = "yarl-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080"},
+    {file = "yarl-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a"},
+    {file = "yarl-1.4.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f"},
+    {file = "yarl-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea"},
+    {file = "yarl-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb"},
+    {file = "yarl-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70"},
+    {file = "yarl-1.4.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d"},
+    {file = "yarl-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce"},
+    {file = "yarl-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"},
+    {file = "yarl-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce"},
+    {file = "yarl-1.4.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b"},
+    {file = "yarl-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae"},
+    {file = "yarl-1.4.2-cp38-cp38-win32.whl", hash = "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462"},
+    {file = "yarl-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6"},
+    {file = "yarl-1.4.2.tar.gz", hash = "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b"},
+]
+zipp = [
+    {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},
+    {file = "zipp-0.6.0.tar.gz", hash = "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"},
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,10 +35,12 @@ sphinx = "*"
 watchdog = "*"
 flask = "^1.0"
 sphinx-markdown-builder = "^0.5.1"
+pytest-subtests = "^0.2.1"
 
 [tool.poetry.extras]
 prometheus = ["prometheus_client"]
 pygments = ["pygments"]
+pytest = []
 
 [tool.poetry.scripts]
 dazl = 'dazl.cli:main'

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from unittest import TestCase
 
-from dazl import sandbox, create, setup_default_logger, Network
+from dazl import sandbox, create, Network
 
 from .dars import AllParty
 
@@ -14,31 +13,28 @@ ALL_PARTY = '000'
 PrivateContract = 'AllParty.PrivateContract'
 PublicContract = 'AllParty.PublicContract'
 
-setup_default_logger(logging.DEBUG)
 
+def test_some_party_receives_public_contract():
+    some_party_cids = []
+    publisher_cids = []
+    with sandbox(AllParty, extra_args=None) as proc:
+        network = Network()
+        network.set_config(url=proc.url, party_groups=[ALL_PARTY])
 
-class AllPartyTest(TestCase):
-    def test_some_party_receives_public_contract(self):
-        some_party_cids = []
-        publisher_cids = []
-        with sandbox(AllParty, extra_args=None) as proc:
-            network = Network()
-            network.set_config(url=proc.url, party_groups=[ALL_PARTY])
+        some_client = network.aio_party(SOME_PARTY)
+        some_client.add_ledger_ready(lambda _: create(PrivateContract, {'someParty': SOME_PARTY}))
 
-            some_client = network.aio_party(SOME_PARTY)
-            some_client.add_ledger_ready(lambda _: create(PrivateContract, {'someParty': SOME_PARTY}))
+        publisher_client = network.aio_party(PUBLISHER)
+        publisher_client.add_ledger_ready(lambda _: create(PublicContract, {'publisher': PUBLISHER, 'allParty': ALL_PARTY}))
 
-            publisher_client = network.aio_party(PUBLISHER)
-            publisher_client.add_ledger_ready(lambda _: create(PublicContract, {'publisher': PUBLISHER, 'allParty': ALL_PARTY}))
+        some_client.add_ledger_created(PublicContract, lambda e: some_party_cids.append(e.cid))
+        some_client.add_ledger_created(PrivateContract, lambda e: some_party_cids.append(e.cid))
 
-            some_client.add_ledger_created(PublicContract, lambda e: some_party_cids.append(e.cid))
-            some_client.add_ledger_created(PrivateContract, lambda e: some_party_cids.append(e.cid))
+        publisher_client.add_ledger_created(PublicContract, lambda e: publisher_cids.append(e.cid))
+        publisher_client.add_ledger_created(PrivateContract, lambda e: publisher_cids.append(e.cid))
 
-            publisher_client.add_ledger_created(PublicContract, lambda e: publisher_cids.append(e.cid))
-            publisher_client.add_ledger_created(PrivateContract, lambda e: publisher_cids.append(e.cid))
+        network.run_until_complete()
 
-            network.run_until_complete()
-
-        print(f'got to the end with some_party contracts: {some_party_cids} and publisher contracts: {publisher_cids}')
-        self.assertEqual(len(some_party_cids), 2)
-        self.assertEqual(len(publisher_cids), 1)
+    logging.info(f'got to the end with some_party contracts: {some_party_cids} and publisher contracts: {publisher_cids}')
+    assert len(some_party_cids) == 2
+    assert len(publisher_cids) == 1

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
-import unittest
 from decimal import Decimal
 
 from dazl import sandbox, create, Network
@@ -29,44 +28,42 @@ SOME_ARGS = dict(
     theUnit=dict())
 
 
-class TestAllTypes(unittest.TestCase):
-    def test_all_types(self):
-        test_case = AllTypesTestCase()
-        with sandbox(AllKindsOf) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_all_types():
+    test_case = AllTypesTestCase()
+    with sandbox(AllKindsOf) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(test_case.create_one_of_everything)
-            party_client.add_ledger_created(TEMPLATE, test_case.on_one_of_everything)
-            network.run_until_complete()
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(test_case.create_one_of_everything)
+        party_client.add_ledger_created(TEMPLATE, test_case.on_one_of_everything)
+        network.run_until_complete()
 
-        self.assertIsNotNone(
-            test_case.found_instance,
-            'Expected to find an instance of OneOfEverything!')
+    assert test_case.found_instance is not None, \
+        'Expected to find an instance of OneOfEverything!'
 
-        self.assertEqual(
-            SOME_ARGS.keys(), test_case.found_instance.keys(),
-            'There are either extra fields or missing fields!')
+    assert SOME_ARGS.keys() == test_case.found_instance.keys(), \
+        'There are either extra fields or missing fields!'
 
-        for key in SOME_ARGS:
-            expected = SOME_ARGS.get(key)
-            actual = test_case.found_instance.get(key)
-            self.assertEqual(expected, actual, f'Failed to compare types for key: {key}')
+    for key in SOME_ARGS:
+        expected = SOME_ARGS.get(key)
+        actual = test_case.found_instance.get(key)
+        assert expected == actual, f'Failed to compare types for key: {key}'
 
-    def test_maps(self):
-        with sandbox(AllKindsOf) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda e: create(
-                'AllKindsOf.MappyContract', {
-                    'operator': PARTY,
-                    'value': {'Map_internal': []}
-                }))
+def test_maps():
+    with sandbox(AllKindsOf) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            network.run_until_complete()
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda e: create(
+            'AllKindsOf.MappyContract', {
+                'operator': PARTY,
+                'value': {'Map_internal': []}
+            }))
+
+        network.run_until_complete()
 
 
 class AllTypesTestCase:

--- a/python/tests/unit/test_api_consistency.py
+++ b/python/tests/unit/test_api_consistency.py
@@ -1,23 +1,20 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
-from dazl.client._network_client_impl import _NetworkImpl
-from dazl.client._party_client_impl import _PartyClientImpl
 from dazl.client.api import AIOPartyClient, SimplePartyClient
 from dazl.model.core import Party
 
 
-class TestApiConsistency(TestCase):
-    def test_api_consistency(self):
-        impl = _PartyClientImpl(_NetworkImpl(), Party('party'))
+def test_api_consistency():
+    from dazl.client._network_client_impl import _NetworkImpl
+    from dazl.client._party_client_impl import _PartyClientImpl
+    impl = _PartyClientImpl(_NetworkImpl(), Party('party'))
 
-        apc = AIOPartyClient(impl)
-        tpc = SimplePartyClient(impl)
+    apc = AIOPartyClient(impl)
+    tpc = SimplePartyClient(impl)
 
-        callable_apcs = {key: getattr(apc, key) for key in dir(apc) if not key.startswith('_') and callable(getattr(apc, key))}
-        callable_tpcs = {key: getattr(tpc, key) for key in dir(tpc) if not key.startswith('_') and callable(getattr(tpc, key))}
+    callable_apcs = {key: getattr(apc, key) for key in dir(apc) if not key.startswith('_') and callable(getattr(apc, key))}
+    callable_tpcs = {key: getattr(tpc, key) for key in dir(tpc) if not key.startswith('_') and callable(getattr(tpc, key))}
 
-        self.assertEqual(sorted(set(callable_apcs.keys())), sorted(set(callable_tpcs.keys())))
+    assert sorted(set(callable_apcs.keys())) == sorted(set(callable_tpcs.keys()))
 

--- a/python/tests/unit/test_artifacts.py
+++ b/python/tests/unit/test_artifacts.py
@@ -1,8 +1,5 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-from unittest import TestCase
-
 from semver import VersionInfo
 
 from dazl.damlsdk.artifacts import load_artifacts, get_artifact_url, ArtifactLocation
@@ -14,52 +11,57 @@ DUMMY_TAR_GZ_ARTIFACT = ArtifactLocation('com.something', 'somewhere', ZERO_VERS
 DUMMY_NATIVE_TAR_GZ_ARTIFACT = ArtifactLocation('com.something', 'somewhere', ZERO_VERSION, 'tar.gz', native=True)
 
 
-class TestArtifacts(TestCase):
+def test_artifacts_yaml_can_parse():
+    """
+    Verify that the artifacts manifest is syntactically correct.
+    """
+    load_artifacts()
 
-    def test_artifacts_yaml_can_parse(self):
-        """
-        Verify that the artifacts manifest is syntactically correct.
-        """
-        load_artifacts()
 
-    def test_artifacts_yaml_are_valid(self):
-        """
-        Verify that all artifacts resolve to correct URLs.
-        """
-        repository = load_artifacts()
-        for platform in ('osx', 'linux'):
-            for name, artifact in repository.artifacts.items():
-                url = get_artifact_url(repository.root_url, artifact, platform=platform)
-                from urllib.request import urlopen, Request, HTTPError
+def test_artifacts_yaml_are_valid():
+    """
+    Verify that all artifacts resolve to correct URLs.
+    """
+    repository = load_artifacts()
+    for platform in ('osx', 'linux'):
+        for name, artifact in repository.artifacts.items():
+            url = get_artifact_url(repository.root_url, artifact, platform=platform)
+            from urllib.error import HTTPError
+            from urllib.request import urlopen, Request
 
-                try:
-                    with urlopen(Request(url, method='HEAD')) as response:
-                        if response.status != 200:
-                            print(f'{url}: {response.status}')
-                except HTTPError as err:
-                    print(f'{url}: {err.code}')
+            try:
+                with urlopen(Request(url, method='HEAD')) as response:
+                    if response.status != 200:
+                        print(f'{url}: {response.status}')
+            except HTTPError as err:
+                print(f'{url}: {err.code}')
 
-    def test_artifact_url_no_root_slash(self):
-        expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.jar'
-        actual = get_artifact_url('http://nowhere/repo', DUMMY_ARTIFACT)
-        self.assertEqual(expected, actual)
 
-    def test_artifact_url_root_slash(self):
-        expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.jar'
-        actual = get_artifact_url('http://nowhere/repo/', DUMMY_ARTIFACT)
-        self.assertEqual(expected, actual)
+def test_artifact_url_no_root_slash():
+    expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.jar'
+    actual = get_artifact_url('http://nowhere/repo', DUMMY_ARTIFACT)
+    assert expected == actual
 
-    def test_artifact_url_native(self):
-        expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0-osx.jar'
-        actual = get_artifact_url('http://nowhere/repo/', DUMMY_NATIVE_ARTIFACT, platform='osx')
-        self.assertEqual(expected, actual)
 
-    def test_artifact_url_packaging(self):
-        expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.tar.gz'
-        actual = get_artifact_url('http://nowhere/repo/', DUMMY_TAR_GZ_ARTIFACT)
-        self.assertEqual(expected, actual)
+def test_artifact_url_root_slash():
+    expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.jar'
+    actual = get_artifact_url('http://nowhere/repo/', DUMMY_ARTIFACT)
+    assert expected == actual
 
-    def test_artifact_url_packaging_native(self):
-        expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0-osx.tar.gz'
-        actual = get_artifact_url('http://nowhere/repo/', DUMMY_NATIVE_TAR_GZ_ARTIFACT, platform='osx')
-        self.assertEqual(expected, actual)
+
+def test_artifact_url_native():
+    expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0-osx.jar'
+    actual = get_artifact_url('http://nowhere/repo/', DUMMY_NATIVE_ARTIFACT, platform='osx')
+    assert expected == actual
+
+
+def test_artifact_url_packaging():
+    expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0.tar.gz'
+    actual = get_artifact_url('http://nowhere/repo/', DUMMY_TAR_GZ_ARTIFACT)
+    assert expected == actual
+
+
+def test_artifact_url_packaging_native():
+    expected = 'http://nowhere/repo/com/something/somewhere/0.0.0/somewhere-0.0.0-osx.tar.gz'
+    actual = get_artifact_url('http://nowhere/repo/', DUMMY_NATIVE_TAR_GZ_ARTIFACT, platform='osx')
+    assert expected == actual

--- a/python/tests/unit/test_cli_ls.py
+++ b/python/tests/unit/test_cli_ls.py
@@ -5,7 +5,6 @@
 Tests to ensure that CLI commands work properly.
 """
 from pathlib import Path
-from unittest import TestCase
 
 from dazl import sandbox
 from dazl.cli import _main
@@ -13,25 +12,25 @@ from dazl.cli import _main
 DAML_PATH = Path(__file__).parent.parent.parent / '_template' / 'Main.daml'
 
 
-class TestCliLs(TestCase):
+def test_simple_ls():
+    with sandbox(daml_path=DAML_PATH) as proc:
+        exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice'.split(' '))
 
-    def test_simple_ls(self):
-        with sandbox(daml_path=DAML_PATH) as proc:
-            exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice'.split(' '))
+    assert exit_code == 0
 
-        self.assertEqual(exit_code, 0)
 
-    def test_simple_ls_two_parties(self):
-        with sandbox(daml_path=DAML_PATH) as proc:
-            exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice,Bob'.split(' '))
+def test_simple_ls_two_parties():
+    with sandbox(daml_path=DAML_PATH) as proc:
+        exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice,Bob'.split(' '))
 
-        self.assertEqual(exit_code, 0)
+    assert exit_code == 0
 
-    def test_env_ls(self):
-        import os
-        with sandbox(daml_path=DAML_PATH) as proc:
-            os.environ['DAML_LEDGER_URL'] = proc.url
-            os.environ['DAML_LEDGER_PARTY'] = 'Alice'
-            exit_code = _main('dazl ls'.split(' '))
 
-        self.assertEqual(exit_code, 0)
+def test_env_ls():
+    import os
+    with sandbox(daml_path=DAML_PATH) as proc:
+        os.environ['DAML_LEDGER_URL'] = proc.url
+        os.environ['DAML_LEDGER_PARTY'] = 'Alice'
+        exit_code = _main('dazl ls'.split(' '))
+
+    assert exit_code == 0

--- a/python/tests/unit/test_coerce_bool.py
+++ b/python/tests/unit/test_coerce_bool.py
@@ -1,36 +1,46 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl.util.prim_types import PrimitiveTypeConverter
 
 
-class TestCoerceBool(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.converter = PrimitiveTypeConverter()
+def test_true_lowercase_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('true')
 
-    def test_true_lowercase_bool(self):
-        actual = self.converter.to_boolean('true')
-        self.assertTrue(actual)
+    assert actual
 
-    def test_true_titlecase_bool(self):
-        actual = self.converter.to_boolean('True')
-        self.assertTrue(actual)
 
-    def test_true_lowercase_whitespace_bool(self):
-        actual = self.converter.to_boolean('  true ')
-        self.assertTrue(actual)
+def test_true_titlecase_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('True')
 
-    def test_false_lowercase_bool(self):
-        actual = self.converter.to_boolean('false')
-        self.assertFalse(actual)
+    assert actual
 
-    def test_false_titlecase_bool(self):
-        actual = self.converter.to_boolean('False')
-        self.assertFalse(actual)
 
-    def test_false_lowercase_whitespace_bool(self):
-        actual = self.converter.to_boolean('  false ')
-        self.assertFalse(actual)
+def test_true_lowercase_whitespace_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('  true ')
+
+    assert actual
+
+
+def test_false_lowercase_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('false')
+
+    assert not actual
+
+
+def test_false_titlecase_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('False')
+
+    assert not actual
+
+
+def test_false_lowercase_whitespace_bool():
+    sut = PrimitiveTypeConverter()
+    actual = sut.to_boolean('  false ')
+
+    assert not actual

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -43,7 +43,7 @@ class TestCommandBuilderTest(TestCase):
         )]
         actual = CommandBuilder.coerce(expr).build(DEFAULTS, DEFAULT_NOW)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_object_create_untyped(self):
         builder = CommandBuilder()
@@ -61,7 +61,7 @@ class TestCommandBuilderTest(TestCase):
         )]
         actual = builder.build(DEFAULTS, DEFAULT_NOW)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_object_atomic_default_false(self):
         builder = CommandBuilder(atomic_default=False)
@@ -91,7 +91,7 @@ class TestCommandBuilderTest(TestCase):
 
         actual = builder.build(DEFAULTS, DEFAULT_NOW)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_object_atomic_default_true(self):
         builder = CommandBuilder(atomic_default=True)
@@ -114,4 +114,4 @@ class TestCommandBuilderTest(TestCase):
 
         actual = builder.build(DEFAULTS, DEFAULT_NOW)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual

--- a/python/tests/unit/test_complicated_types.py
+++ b/python/tests/unit/test_complicated_types.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from operator import setitem
-from unittest import TestCase
 
 from dazl import sandbox, create, exercise, Network
 from .dars import Complicated as ComplicatedDar
@@ -15,22 +15,21 @@ class Complicated:
     OperatorFormulaNotification = 'Complicated.OperatorFormulaNotification'
 
 
-class ComplicatedTypesTest(TestCase):
-    def test_complicated_types(self):
-        recorded_data = dict()
-        with sandbox(ComplicatedDar) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_complicated_types():
+    recorded_data = dict()
+    with sandbox(ComplicatedDar) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda _: create(Complicated.OperatorRole, {'operator': PARTY}))
-            party_client.add_ledger_created(Complicated.OperatorRole, _create_empty_notification)
-            party_client.add_ledger_created(Complicated.OperatorRole, _create_complicated_notifications)
-            party_client.add_ledger_created(Complicated.OperatorFormulaNotification, lambda e: setitem(recorded_data, e.cid, e.cdata))
-            network.run_until_complete()
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda _: create(Complicated.OperatorRole, {'operator': PARTY}))
+        party_client.add_ledger_created(Complicated.OperatorRole, _create_empty_notification)
+        party_client.add_ledger_created(Complicated.OperatorRole, _create_complicated_notifications)
+        party_client.add_ledger_created(Complicated.OperatorFormulaNotification, lambda e: setitem(recorded_data, e.cid, e.cdata))
+        network.run_until_complete()
 
-        print('got to the end with contracts: ', recorded_data)
-        self.assertEqual(len(recorded_data), 4)
+    logging.info('got to the end with contracts: %s', recorded_data)
+    assert len(recorded_data) == 4
 
 
 def _create_complicated_notifications(e) -> list:

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -1,16 +1,14 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase, skip
+import pytest
 
 from dazl.util.dar import DarFile
 from .dars import Pending
 
 
-class TestDarFile(TestCase):
-    @skip('Something about the way dazl compiles DARs currently causes this field to be blank')
-    def test_get_sdk_version(self):
-        with DarFile(Pending) as dar:
-            print(dar.get_manifest())
-            self.assertEqual('0.13.18', dar.get_sdk_version())
-
+@pytest.mark.skip('Something about the way dazl compiles DARs currently causes this field to be blank')
+def test_get_sdk_version():
+    with DarFile(Pending) as dar:
+        print(dar.get_manifest())
+        assert '0.13.18' == dar.get_sdk_version()

--- a/python/tests/unit/test_dar_upload.py
+++ b/python/tests/unit/test_dar_upload.py
@@ -2,59 +2,58 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from asyncio import new_event_loop, set_event_loop, sleep
-from unittest import TestCase
 
 from dazl import Network, sandbox
 from .dars import AllKindsOf
 
 
-class TestDarUpload(TestCase):
-    def test_dar_uploads_near_startup(self):
-        set_event_loop(new_event_loop())
+def test_dar_uploads_near_startup():
+    set_event_loop(new_event_loop())
 
-        package_ids = []
+    package_ids = []
 
-        with sandbox([]) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+    with sandbox([]) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            async def upload_dars_and_verify():
-                await upload_test_dars(network)
-                metadata = await network.aio_global().metadata()
-                package_ids.extend(metadata.store.package_ids())
+        async def upload_dars_and_verify():
+            await upload_test_dars(network)
+            metadata = await network.aio_global().metadata()
+            package_ids.extend(metadata.store.package_ids())
 
-            network.run_until_complete(upload_dars_and_verify())
+        network.run_until_complete(upload_dars_and_verify())
 
-        self.assertGreater(len(package_ids), 0)
+    assert len(package_ids) > 0
 
-    def test_package_events(self):
-        set_event_loop(new_event_loop())
 
-        initial_events = []
-        follow_up_events = []
+def test_package_events():
+    set_event_loop(new_event_loop())
 
-        with sandbox([]) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
-            client = network.aio_party('TestParty')
+    initial_events = []
+    follow_up_events = []
 
-            async def upload_dars_and_verify():
-                # make sure the client is "ready" before uploading DARs, because we are explicitly
-                # checking to make sure proper reporting of packages that are uploaded after a
-                # client is running and # operational
-                await client.ready()
-                await upload_test_dars(network)
+    with sandbox([]) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
+        client = network.aio_party('TestParty')
 
-                # give the client some time to pick up the new packages; unfortunately there isn't
-                # much more to do here except wait
-                await sleep(10)
+        async def upload_dars_and_verify():
+            # make sure the client is "ready" before uploading DARs, because we are explicitly
+            # checking to make sure proper reporting of packages that are uploaded after a
+            # client is running and # operational
+            await client.ready()
+            await upload_test_dars(network)
 
-            client.add_ledger_packages_added(initial_events.append, initial=True)
-            client.add_ledger_packages_added(follow_up_events.append)
-            network.run_until_complete(upload_dars_and_verify())
+            # give the client some time to pick up the new packages; unfortunately there isn't
+            # much more to do here except wait
+            await sleep(10)
 
-        self.assertEqual(len(initial_events), 2)
-        self.assertEqual(len(follow_up_events), 1)
+        client.add_ledger_packages_added(initial_events.append, initial=True)
+        client.add_ledger_packages_added(follow_up_events.append)
+        network.run_until_complete(upload_dars_and_verify())
+
+    assert len(initial_events) == 2
+    assert len(follow_up_events) == 1
 
 
 async def upload_test_dars(network: 'Network'):

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -1,41 +1,43 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
+import logging
 
 from dazl import sandbox, simple_client
 from .dars import DottedFields
 
 
-class TestDottedFields(TestCase):
-    def test_record_dotted_fields_submit(self):
-        with sandbox(daml_path=DottedFields) as proc:
-            with simple_client(url=proc.url, party='Test') as client:
-                client.ready()
-                client.submit_create('DottedFields.American', {
-                    'person': 'Test',
-                    'address.address': '1 Test Place',
-                    'address.city': 'Somewhere',
-                    'address.state': 'ZZ',
-                    'address.zip': '99999'
-                })
-                print(client.find_active('DottedFields.American'))
+def test_record_dotted_fields_submit():
+    with sandbox(daml_path=DottedFields) as proc:
+        with simple_client(url=proc.url, party='Test') as client:
+            client.ready()
+            client.submit_create('DottedFields.American', {
+                'person': 'Test',
+                'address.address': '1 Test Place',
+                'address.city': 'Somewhere',
+                'address.state': 'ZZ',
+                'address.zip': '99999'
+            })
 
-    def test_variant_dotted_fields_submit(self):
-        with sandbox(daml_path=DottedFields) as proc:
-            with simple_client(url=proc.url, party='Test') as client:
-                client.ready()
-                client.submit_create('DottedFields.Person', {
-                    'person': 'Test',
-                    'address.US.address': '1 Test Place',
-                    'address.US.city': 'Somewhere',
-                    'address.US.state': 'ZZ',
-                    'address.US.zip': '99999',
-                    'address.UK.address': '',
-                    'address.UK.locality': '',
-                    'address.UK.city': '',
-                    'address.UK.state': '',
-                    'address.UK.postcode': '',
+            logging.info(client.find_active('DottedFields.American'))
 
-                })
-                print(client.find_active('DottedFields.Person'))
+
+def test_variant_dotted_fields_submit():
+    with sandbox(daml_path=DottedFields) as proc:
+        with simple_client(url=proc.url, party='Test') as client:
+            client.ready()
+            client.submit_create('DottedFields.Person', {
+                'person': 'Test',
+                'address.US.address': '1 Test Place',
+                'address.US.city': 'Somewhere',
+                'address.US.state': 'ZZ',
+                'address.US.zip': '99999',
+                'address.UK.address': '',
+                'address.UK.locality': '',
+                'address.UK.city': '',
+                'address.UK.state': '',
+                'address.UK.postcode': '',
+
+            })
+
+            logging.info(client.find_active('DottedFields.Person'))

--- a/python/tests/unit/test_dynamic_dar_loading.py
+++ b/python/tests/unit/test_dynamic_dar_loading.py
@@ -10,17 +10,16 @@ from dazl.util.dar import DarFile
 from .dars import AllKindsOf, Pending
 
 
-class TestDynamicDarLoading(TestCase):
-    def test_package_sync_multiple_loads(self):
-        store = PackageStore.empty()
+def test_package_sync_multiple_loads():
+    store = PackageStore.empty()
 
-        pp1 = create_package_provider(AllKindsOf)
-        grpc_package_sync(pp1, store)
+    pp1 = create_package_provider(AllKindsOf)
+    grpc_package_sync(pp1, store)
 
-        pp2 = create_package_provider(Pending)
-        grpc_package_sync(pp2, store)
+    pp2 = create_package_provider(Pending)
+    grpc_package_sync(pp2, store)
 
-        print(store.package_ids())
+    print(store.package_ids())
 
 
 def create_package_provider(dar_file: 'Path') -> 'PackageProvider':

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -1,46 +1,41 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from pathlib import Path
-from unittest import TestCase
 
-from dazl import create, exercise, sandbox, Network, setup_default_logger
+from dazl import create, exercise, sandbox, Network
 
 DAML_PATH = Path(__file__).parent.parent.parent / '_template' / 'Main.daml'
 
-setup_default_logger(logging.DEBUG)
 
+def test_parties_can_be_added_after_run_forever():
+    with sandbox(daml_path=DAML_PATH) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-class TestDynamicParties(TestCase):
-    def test_parties_can_be_added_after_run_forever(self):
-        with sandbox(daml_path=DAML_PATH) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+        operator = network.aio_party('Operator')
+        party_a = network.aio_party('Party A')
+        party_b = network.aio_party('Party B')
 
-            operator = network.aio_party('Operator')
-            party_a = network.aio_party('Party A')
-            party_b = network.aio_party('Party B')
+        @operator.ledger_ready()
+        def _(event):
+            return create('Main.PostmanRole', {'postman': 'Operator'})
 
-            @operator.ledger_ready()
-            def _(event):
-                return create('Main.PostmanRole', {'postman': 'Operator'})
+        @operator.ledger_created('Main.PostmanRole')
+        def __(event):
+            return [exercise(event.cid, 'InviteParticipant', {'party': party, 'address': 'whatevs'})
+                    for party in ('Party A', 'Party B', 'Party C')]
 
-            @operator.ledger_created('Main.PostmanRole')
-            def __(event):
-                return [exercise(event.cid, 'InviteParticipant', {'party': party, 'address': 'whatevs'})
-                        for party in ('Party A', 'Party B', 'Party C')]
+        @party_a.ledger_created('Main.InviteAuthorRole')
+        async def _(event):
+            party_c = network.aio_party('Party C')
 
-            @party_a.ledger_created('Main.InviteAuthorRole')
-            async def _(event):
-                party_c = network.aio_party('Party C')
+            @party_c.ledger_created('Main.AuthorRole')
+            def ___(event):
+                network.shutdown()
 
-                @party_c.ledger_created('Main.AuthorRole')
-                def ___(event):
-                    network.shutdown()
+            cid, cdata = await party_c.find_one('Main.InviteAuthorRole')
+            party_c.submit_exercise(cid, 'AcceptInviteAuthorRole')
 
-                cid, cdata = await party_c.find_one('Main.InviteAuthorRole')
-                party_c.submit_exercise(cid, 'AcceptInviteAuthorRole')
-
-            network.run_forever()
+        network.run_forever()
 

--- a/python/tests/unit/test_event_handler_exceptions.py
+++ b/python/tests/unit/test_event_handler_exceptions.py
@@ -1,29 +1,24 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from pathlib import Path
-from unittest import TestCase
 
-from dazl import simple_client, sandbox, setup_default_logger
+from dazl import simple_client, sandbox
 from dazl.model.reading import ReadyEvent
 
 
 DAML_PATH = Path(__file__).parent.parent.parent / '_template' / 'Main.daml'
 SAMPLE_PARTY = 'TestParty'
 
-setup_default_logger(logging.INFO)
 
+def test_event_handler_exceptions():
+    with sandbox(daml_path=DAML_PATH) as proc:
+        with simple_client(proc.url, SAMPLE_PARTY) as client:
+            def throw_error(event: ReadyEvent):
+                raise MagicException(event.ledger_id)
 
-class TestEventHandlerExceptions(TestCase):
-    def test_event_handler_exceptions(self):
-        with sandbox(daml_path=DAML_PATH) as proc:
-            with simple_client(proc.url, SAMPLE_PARTY) as client:
-                def throw_error(event: ReadyEvent):
-                    raise MagicException(event.ledger_id)
-
-                client.add_ledger_ready(throw_error)
-                client.ready()
+            client.add_ledger_ready(throw_error)
+            client.ready()
 
 
 class MagicException(Exception):

--- a/python/tests/unit/test_event_order.py
+++ b/python/tests/unit/test_event_order.py
@@ -4,9 +4,8 @@
 import asyncio
 import logging
 import random
-from unittest import TestCase
 
-from dazl import create, exercise, sandbox, setup_default_logger, Network
+from dazl import create, exercise, sandbox, Network
 from .dars import Simple as SimpleDar
 
 NOTIFICATION_COUNT = 20
@@ -22,13 +21,7 @@ class Simple:
     OperatorNotification = 'Simple.OperatorNotification'
 
 
-class TestEventOrder(TestCase):
-    def test_event_order(self):
-        some_sample_app()
-
-
-def some_sample_app():
-    setup_default_logger(logging.INFO)
+def test_event_order():
     stage1 = Stage1LedgerInit()
     stage2 = Stage2LedgerVerify()
 
@@ -93,4 +86,6 @@ class Stage2LedgerVerify:
 
 
 if __name__ == '__main__':
-    some_sample_app()
+    from dazl import setup_default_logger
+    setup_default_logger(logging.INFO)
+    test_event_order()

--- a/python/tests/unit/test_expr.py
+++ b/python/tests/unit/test_expr.py
@@ -1,22 +1,16 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-from unittest import TestCase, skip
+import pytest
 
-from dazl import setup_default_logger
 from dazl.util.dar import DarFile
 from .dars import Pending
 
 
-setup_default_logger(logging.DEBUG)
-
-
-class TestExpr(TestCase):
-    @skip('This API does not really work yet, nor is it finalized')
-    def test_calculate_signatories(self):
-        with DarFile(Pending) as dar:
-            store = dar.read_metadata()
-            template = next(iter(store.resolve_template('Pending.Counter')))
-            actual = template.signatories(store, {'owner': 'Mommy', 'value': 0})
-            self.assertEqual(['Mommy'], actual)
+@pytest.mark.skip('This API does not really work yet, nor is it finalized')
+def test_calculate_signatories(self):
+    with DarFile(Pending) as dar:
+        store = dar.read_metadata()
+        template = next(iter(store.resolve_template('Pending.Counter')))
+        actual = template.signatories(store, {'owner': 'Mommy', 'value': 0})
+        self.assertEqual(['Mommy'], actual)

--- a/python/tests/unit/test_historical_dar_parsing.py
+++ b/python/tests/unit/test_historical_dar_parsing.py
@@ -1,25 +1,23 @@
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
-from unittest import TestCase
 
-from dazl import LOG, setup_default_logger
-
-import logging
+from dazl import LOG
 from dazl.util.dar import DarFile
 
 ARCHIVES: Path = Path(__file__).absolute().parent.parent.parent.parent / '_fixtures' / 'archives'
-setup_default_logger(logging.DEBUG)
 
 
-class TestHistoricalDarParsing(TestCase):
-    def test_dar_version_compatibility(self):
-        dars = list(ARCHIVES.glob('**/*.dar'))
-        self.assertGreater(len(dars), 0, f'Could not find any DARs in {ARCHIVES}')
+def test_dar_version_compatibility(subtests):
+    dars = list(ARCHIVES.glob('**/*.dar'))
+    assert len(dars) > 0, f'Could not find any DARs in {ARCHIVES}'
 
-        for dar in ARCHIVES.glob('**/*.dar'):
-            short_dar = dar.relative_to(ARCHIVES)
-            with self.subTest(str(short_dar)):
-                dar_file = DarFile(dar)
-                metadata = dar_file.read_metadata()
-                LOG.info('Successfully read %s with package IDs %r.', short_dar,
-                         metadata.package_ids())
+    for dar in ARCHIVES.glob('**/*.dar'):
+        short_dar = dar.relative_to(ARCHIVES)
+        with subtests.test(str(short_dar)):
+            dar_file = DarFile(dar)
+            metadata = dar_file.read_metadata()
+            LOG.info('Successfully read %s with package IDs %r.', short_dar,
+                     metadata.package_ids())
 

--- a/python/tests/unit/test_internal_natural_language.py
+++ b/python/tests/unit/test_internal_natural_language.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import unittest
-
 from datetime import datetime, timedelta, timezone
 
 from dazl.util.prim_natural import parse_datetime
@@ -11,14 +9,13 @@ MY_TIMEZONE = timezone(timedelta(hours=10), name='Spamland')
 MOCK_NOW = lambda: datetime(2016, 6, 25, 12, 0, 0, tzinfo=MY_TIMEZONE)
 
 
-class DateTimeTest(unittest.TestCase):
+def test_today_time_local():
+    expected = datetime(2016, 6, 25, 13, 0, tzinfo=MY_TIMEZONE)
+    actual = parse_datetime('13:00', now_fn=MOCK_NOW)
+    assert expected == actual
 
-    def test_today_time_local(self):
-        expected = datetime(2016, 6, 25, 13, 0, tzinfo=MY_TIMEZONE)
-        actual = parse_datetime('13:00', now_fn=MOCK_NOW)
-        self.assertEqual(expected, actual)
 
-    def test_today_time_utc(self):
-        expected = datetime(2016, 6, 25, 13, 0, tzinfo=timezone.utc)
-        actual = parse_datetime('13:00Z', now_fn=MOCK_NOW)
-        self.assertEqual(expected, actual)
+def test_today_time_utc():
+    expected = datetime(2016, 6, 25, 13, 0, tzinfo=timezone.utc)
+    actual = parse_datetime('13:00Z', now_fn=MOCK_NOW)
+    assert expected == actual

--- a/python/tests/unit/test_json_serialize.py
+++ b/python/tests/unit/test_json_serialize.py
@@ -1,10 +1,8 @@
-from unittest import TestCase
+# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-
-class TestJsonSerialize(TestCase):
-
-    def test_serializers(self):
-        # merely import the SCALAR_FORMATTERS symbol, which runs a check to make sure that all
-        # scalars can be safely serialized in JSON
-        from dazl.protocols.v0.json_ser_command import _SCALAR_FORMATTERS
-        self.assertIsNotNone(_SCALAR_FORMATTERS)
+def test_serializers():
+    # merely import the SCALAR_FORMATTERS symbol, which runs a check to make sure that all
+    # scalars can be safely serialized in JSON
+    from dazl.protocols.v0.json_ser_command import _SCALAR_FORMATTERS
+    assert _SCALAR_FORMATTERS

--- a/python/tests/unit/test_ledger_api_types.py
+++ b/python/tests/unit/test_ledger_api_types.py
@@ -25,9 +25,9 @@ class DateTimeTest(unittest.TestCase):
     def test_simple_date_parse(self):
         expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
         actual = to_datetime('2018-08-07T23:17:31.143080Z')
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_simple_date_parse_with_nanos(self):
         expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
         actual = to_datetime('2018-08-07T23:17:31.143080698Z')
-        self.assertEqual(expected, actual)
+        assert expected == actual

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -1,41 +1,43 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-from unittest import TestCase, skip
+import logging
+import pytest
 
 from dazl import frozendict, sandbox, simple_client
 
 from .dars import MapSupport
 
 
-class TestMapSupport(TestCase):
-    def test_map_support(self):
-        with sandbox(MapSupport) as proc:
-            with simple_client(url=proc.url, party='Test') as client:
-                client.ready()
-                client.submit_create('MapSupport.Sample', {
-                    'party': 'Test',
-                    'mappings': {
-                        '65': 'A',
-                        '97': 'a'
-                    },
-                    'text': None
-                })
-                print(client.find_active('*'))
+def test_map_support():
+    with sandbox(MapSupport) as proc:
+        with simple_client(url=proc.url, party='Test') as client:
+            client.ready()
+            client.submit_create('MapSupport.Sample', {
+                'party': 'Test',
+                'mappings': {
+                    '65': 'A',
+                    '97': 'a'
+                },
+                'text': None
+            })
 
-    @skip('Keys with arbitrary types are no longer supported. See the comments in MapSupport.daml.')
-    def test_complicated_map_support(self):
-        with sandbox(MapSupport) as proc:
-            with simple_client(url=proc.url, party='Test') as client:
-                client.ready()
-                client.submit_create('MapSupport.ComplicatedSample', {
-                    'party': 'Test',
-                    # Note: Python `dict`s are not hashable, so the only way to write this out
-                    # is to create a special dict as a key
-                    'keyIsMap': {frozendict(A='b'): 'mmm'},
-                    'keyIsRecord': {frozendict(x=2, y=4): 'rrr'},
-                    'keyIsRecordWithTypeParam': {frozendict(x=2, y=4): 'rrr'},
-                    'keyIsVariant': {frozendict(Apple=''): 'ttt'}
-                })
-                print(client.find_active('*'))
+            logging.info(client.find_active('*'))
+
+
+@pytest.mark.skip('Keys with arbitrary types are no longer supported. See the comments in MapSupport.daml.')
+def test_complicated_map_support():
+    with sandbox(MapSupport) as proc:
+        with simple_client(url=proc.url, party='Test') as client:
+            client.ready()
+            client.submit_create('MapSupport.ComplicatedSample', {
+                'party': 'Test',
+                # Note: Python `dict`s are not hashable, so the only way to write this out
+                # is to create a special dict as a key
+                'keyIsMap': {frozendict(A='b'): 'mmm'},
+                'keyIsRecord': {frozendict(x=2, y=4): 'rrr'},
+                'keyIsRecordWithTypeParam': {frozendict(x=2, y=4): 'rrr'},
+                'keyIsVariant': {frozendict(Apple=''): 'ttt'}
+            })
+
+            logging.info(client.find_active('*'))

--- a/python/tests/unit/test_matches.py
+++ b/python/tests/unit/test_matches.py
@@ -5,23 +5,22 @@
 This module contains tests for testing contract data against a match object.
 """
 
-from unittest import TestCase
-
 from dazl.client._reader_match import is_match
 
 
-class TestMatches(TestCase):
-    def test_match_of_partial_keys(self):
-        match = {"a": 2, "b": 3}
-        value = {"c": 4, "a": 2, "b": 3}
-        self.assertTrue(is_match(match, value))
+def test_match_of_partial_keys():
+    match = {"a": 2, "b": 3}
+    value = {"c": 4, "a": 2, "b": 3}
+    assert is_match(match, value)
 
-    def test_match_of_partial_top_level_keys(self):
-        match = {"d": 3}
-        value = {"a": {"b": 1, "c": 2}, "d": 3}
-        self.assertTrue(is_match(match, value))
 
-    def test_match_of_partial_deep_nested_keys(self):
-        match = {"a": {"b": 1}}
-        value = {"a": {"b": 1, "c": 2}, "d": 3}
-        self.assertTrue(is_match(match, value))
+def test_match_of_partial_top_level_keys():
+    match = {"d": 3}
+    value = {"a": {"b": 1, "c": 2}, "d": 3}
+    assert is_match(match, value)
+
+
+def test_match_of_partial_deep_nested_keys():
+    match = {"a": {"b": 1}}
+    value = {"a": {"b": 1, "c": 2}, "d": 3}
+    assert is_match(match, value)

--- a/python/tests/unit/test_package_loading.py
+++ b/python/tests/unit/test_package_loading.py
@@ -5,7 +5,6 @@
 Tests to ensure that packages can be loaded.
 """
 from operator import setitem
-from unittest import TestCase
 
 from dazl import sandbox, Network
 from dazl.model.types_store import PackageStore
@@ -13,21 +12,19 @@ from dazl.util.dar import DarFile
 from .dars import AllKindsOf
 
 
-class PackageLoadingTest(TestCase):
+def test_package_loading():
+    d = {}
+    with DarFile(AllKindsOf) as dar:
+        expected_package_ids = dar.get_package_provider().get_package_ids()
 
-    def test_package_loading(self):
-        d = {}
-        with DarFile(AllKindsOf) as dar:
-            expected_package_ids = dar.get_package_provider().get_package_ids()
+    with sandbox(AllKindsOf) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
+        client = network.aio_party('TestParty')
+        client.add_ledger_ready(lambda event: setitem(d, 'metadata', event.package_store))
+        network.run_until_complete()
 
-        with sandbox(AllKindsOf) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
-            client = network.aio_party('TestParty')
-            client.add_ledger_ready(lambda event: setitem(d, 'metadata', event.package_store))
-            network.run_until_complete()
+    store: PackageStore = d['metadata']
+    actual_package_ids = store.package_ids()
 
-        store: PackageStore = d['metadata']
-        actual_package_ids = store.package_ids()
-
-        self.assertEqual(set(expected_package_ids), set(actual_package_ids))
+    assert set(expected_package_ids) == set(actual_package_ids)

--- a/python/tests/unit/test_pending.py
+++ b/python/tests/unit/test_pending.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-import logging
-from unittest import TestCase
 
 from dazl import sandbox, create, exercise, Network
 from .dars import Pending
@@ -14,30 +12,29 @@ AccountRequest = 'Pending.AccountRequest'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-class PendingTest(TestCase):
-    def test_select_template_retrieves_contracts(self):
-        number_of_contracts = 10
+def test_select_template_retrieves_contracts():
+    number_of_contracts = 10
 
-        with sandbox(Pending) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+    with sandbox(Pending) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda _: [
-                create(Counter, {'owner': PARTY, 'value': 0}),
-                *[create(AccountRequest, {'owner': PARTY}) for i in range(number_of_contracts)],
-            ])
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda _: [
+            create(Counter, {'owner': PARTY, 'value': 0}),
+            *[create(AccountRequest, {'owner': PARTY}) for i in range(number_of_contracts)],
+        ])
 
-            @party_client.ledger_created(AccountRequest)
-            async def on_account_request(event):
-                counter_cid, counter_cdata = await event.acs_find_one(Counter)
-                return [
-                    exercise(event.cid, 'CreateAccount', dict(accountId=counter_cdata['value'])),
-                    exercise(counter_cid, 'Increment')
-                ]
+        @party_client.ledger_created(AccountRequest)
+        async def on_account_request(event):
+            counter_cid, counter_cdata = await event.acs_find_one(Counter)
+            return [
+                exercise(event.cid, 'CreateAccount', dict(accountId=counter_cdata['value'])),
+                exercise(counter_cid, 'Increment')
+            ]
 
-            network.run_until_complete()
+        network.run_until_complete()
 
-            data = party_client.find_active(Account)
+        data = party_client.find_active(Account)
 
-        self.assertEqual(len(data), number_of_contracts)
+    assert len(data) == number_of_contracts

--- a/python/tests/unit/test_plugins_capture.py
+++ b/python/tests/unit/test_plugins_capture.py
@@ -1,23 +1,20 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import unittest
 from datetime import datetime
 
-from dazl.model.core import ContractId
+from dazl import ContractId
 from dazl.plugins.capture import fmt_pretty
 from dazl.plugins.capture.model_capture import LedgerCapture
 
 
-class PluginsCaptureTest(unittest.TestCase):
+def test_capture_handles_unknown_templates():
+    parties = list('ABC')
+    capture = LedgerCapture()
+    capture.capture('A',
+                    ContractId('0:0', template_id='some_unknown_template'),
+                    dict(some_field='some_value'), datetime.utcnow())
 
-    def test_capture_handles_unknown_templates(self):
-        parties = list('ABC')
-        capture = LedgerCapture()
-        capture.capture('A',
-                        ContractId('0:0', template_id='some_unknown_template'),
-                        dict(some_field='some_value'), datetime.utcnow())
-
-        lines = fmt_pretty.format_entries(capture, parties)
-        output = '\n'.join(lines) + '\n'
-        self.assertTrue(output, 'some lines of output expected')
+    lines = fmt_pretty.format_entries(capture, parties)
+    output = '\n'.join(lines) + '\n'
+    assert output, 'some lines of output expected'

--- a/python/tests/unit/test_pretty_daml.py
+++ b/python/tests/unit/test_pretty_daml.py
@@ -1,92 +1,90 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl.pretty import DamlPrettyPrinter, PrettyOptions
 from dazl.util.dar import DarFile
 from .dars import Pending
 
 
-class TestDamlPrettyPrinter(TestCase):
+def test_render_list_of_party_old():
+    from dazl.model.types import ListType, SCALAR_TYPE_PARTY
 
-    # region Basic type rendering
+    type_ = ListType(SCALAR_TYPE_PARTY)
 
-    def test_render_list_of_party_old(self):
-        from dazl.model.types import ListType, SCALAR_TYPE_PARTY
+    expected = '[Party]'
+    actual = str(type_)
 
-        type_ = ListType(SCALAR_TYPE_PARTY)
+    assert expected == actual
 
-        expected = '[Party]'
-        actual = str(type_)
 
-        self.assertEqual(expected, actual)
+def test_render_list_of_party_new():
+    from dazl.damlast.daml_lf_1 import PrimType, Type
 
-    def test_render_list_of_party_new(self):
-        from dazl.damlast.daml_lf_1 import PrimType, Type
+    type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(Type(prim=Type.Prim(prim=PrimType.PARTY, args=())),)))
 
-        type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(Type(prim=Type.Prim(prim=PrimType.PARTY, args=())),)))
+    expected = '[Party]'
+    actual = str(type_)
 
-        expected = '[Party]'
-        actual = str(type_)
+    assert expected == actual
 
-        self.assertEqual(expected, actual)
 
-    def test_render_list_of_contract_type_con_old(self):
-        from dazl.model.types import ContractIdType, ListType, ModuleRef, TypeReference
+def test_render_list_of_contract_type_con_old():
+    from dazl.model.types import ContractIdType, ListType, ModuleRef, TypeReference
 
-        module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
-        type_ref = TypeReference(module=module_ref, name=('DefGhi',))
-        type_ = ListType(ContractIdType(type_ref))
+    module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
+    type_ref = TypeReference(module=module_ref, name=('DefGhi',))
+    type_ = ListType(ContractIdType(type_ref))
 
-        expected = '[ContractId ABC:DefGhi]'
-        actual = str(type_)
+    expected = '[ContractId ABC:DefGhi]'
+    actual = str(type_)
 
-        self.assertEqual(expected, actual)
+    assert expected == actual
 
-    def test_render_list_of_contract_type_con_new(self):
-        from dazl.damlast.daml_lf_1 import PrimType, Type
-        from dazl.model.types import ModuleRef, TypeReference
 
-        module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
-        con_type = Type(con=Type.Con(tycon=TypeReference(module=module_ref, name=('DefGhi',)), args=()))
-        cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
-        type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(cid_type,)))
+def test_render_list_of_contract_type_con_new():
+    from dazl.damlast.daml_lf_1 import PrimType, Type
+    from dazl.model.types import ModuleRef, TypeReference
 
-        expected = '[ContractId ABC:DefGhi]'
-        actual = str(type_)
+    module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
+    con_type = Type(con=Type.Con(tycon=TypeReference(module=module_ref, name=('DefGhi',)), args=()))
+    cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
+    type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(cid_type,)))
 
-        self.assertEqual(expected, actual)
+    expected = '[ContractId ABC:DefGhi]'
+    actual = str(type_)
 
-    def test_render_update_of_contract_type_con_old(self):
-        from dazl.model.types import ContractIdType, UpdateType, ModuleRef, TypeReference
+    assert expected == actual
 
-        module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
-        type_ref = TypeReference(module=module_ref, name=('DefGhi',))
-        type_ = UpdateType(ContractIdType(type_ref))
 
-        expected = 'Update (ContractId ABC:DefGhi)'
-        actual = str(type_)
+def test_render_update_of_contract_type_con_old():
+    from dazl.model.types import ContractIdType, UpdateType, ModuleRef, TypeReference
 
-        self.assertEqual(expected, actual)
+    module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
+    type_ref = TypeReference(module=module_ref, name=('DefGhi',))
+    type_ = UpdateType(ContractIdType(type_ref))
 
-    def test_render_update_of_contract_type_con_new(self):
-        from dazl.damlast.daml_lf_1 import PrimType, Type
-        from dazl.model.types import ModuleRef, TypeReference
+    expected = 'Update (ContractId ABC:DefGhi)'
+    actual = str(type_)
 
-        module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
-        con_type = Type(con=Type.Con(tycon=TypeReference(module=module_ref, name=('DefGhi',)), args=()))
-        cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
-        type_ = Type(prim=Type.Prim(prim=PrimType.UPDATE, args=(cid_type,)))
+    assert expected == actual
 
-        expected = 'Update (ContractId ABC:DefGhi)'
-        actual = str(type_)
 
-        self.assertEqual(expected, actual)
+def test_render_update_of_contract_type_con_new():
+    from dazl.damlast.daml_lf_1 import PrimType, Type
+    from dazl.model.types import ModuleRef, TypeReference
 
-    # endregion
+    module_ref = ModuleRef(package_id='00000000000000000000000000000000', module_name=('ABC',))
+    con_type = Type(con=Type.Con(tycon=TypeReference(module=module_ref, name=('DefGhi',)), args=()))
+    cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
+    type_ = Type(prim=Type.Prim(prim=PrimType.UPDATE, args=(cid_type,)))
 
-    def test_render_metadata(self):
-        with DarFile(Pending) as dar:
-            pp = DamlPrettyPrinter(store=dar.read_metadata(), context=PrettyOptions(show_hidden_types=True))
-            pp.render_store()
+    expected = 'Update (ContractId ABC:DefGhi)'
+    actual = str(type_)
+
+    assert expected == actual
+
+
+def test_render_metadata():
+    with DarFile(Pending) as dar:
+        pp = DamlPrettyPrinter(store=dar.read_metadata(), context=PrettyOptions(show_hidden_types=True))
+        pp.render_store()

--- a/python/tests/unit/test_sandbox_wrapper.py
+++ b/python/tests/unit/test_sandbox_wrapper.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
+import logging
 
 from dazl import sandbox, create, Network
 from dazl.model.core import ProcessDiedException
@@ -11,25 +11,29 @@ PARTY = 'Operator'
 OperatorRole = 'Simple.OperatorRole'
 
 
-class SandboxWrapperTest(TestCase):
-    def _sandbox_test(self, extra_args=None):
-        cids = []
-        with sandbox(Simple, extra_args=extra_args) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_nice_sandbox_allows_test():
+    _sandbox_test()
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda _: create(OperatorRole, {'operator': PARTY}))
-            party_client.add_ledger_created(OperatorRole, lambda e: cids.append(e.cid))
-            network.run_until_complete()
 
-        print('got to the end with contracts: ', cids)
-        self.assertEqual(len(cids), 1)
+def test_dead_sandbox_aborts_test():
+    try:
+        _sandbox_test(extra_args=['--please-crash'])
+    except ProcessDiedException:
+        return
 
-    def test_nice_sandbox_allows_test(self):
-        self._sandbox_test()
+    assert False, "Should have raised an exception"
 
-    def test_dead_sandbox_aborts_test(self):
-        self.failUnlessRaises(
-            ProcessDiedException,
-            lambda: self._sandbox_test(extra_args=['--please-crash']))
+
+def _sandbox_test(extra_args=None):
+    cids = []
+    with sandbox(Simple, extra_args=extra_args) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
+
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda _: create(OperatorRole, {'operator': PARTY}))
+        party_client.add_ledger_created(OperatorRole, lambda e: cids.append(e.cid))
+        network.run_until_complete()
+
+    logging.info('got to the end with contracts: %s', cids)
+    assert len(cids) == 1

--- a/python/tests/unit/test_select.py
+++ b/python/tests/unit/test_select.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl import sandbox, create, exercise, Network
 from .dars import Simple
 
@@ -12,81 +10,83 @@ OperatorRole = 'Simple.OperatorRole'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-class SelectTest(TestCase):
-    def test_select_template_retrieves_contracts(self):
-        with sandbox(Simple) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_select_template_retrieves_contracts():
+    with sandbox(Simple) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
-            network.run_until_complete()
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
+        network.run_until_complete()
 
-            data = party_client.find_active(OperatorRole)
+        data = party_client.find_active(OperatorRole)
 
-        self.assertEqual(len(data), 1)
+    assert len(data) == 1
 
-    def test_select_unknown_template_retrieves_empty_set(self):
-        with sandbox(Simple) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
-            network.run_until_complete()
+def test_select_unknown_template_retrieves_empty_set():
+    with sandbox(Simple) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            data = party_client.find_active('NonExistentTemplate')
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
+        network.run_until_complete()
 
-        self.assertEqual(len(data), 0)
+        data = party_client.find_active('NonExistentTemplate')
 
-    def test_select_operates_on_acs_before_event_handlers(self):
-        notification_count = 3
+    assert len(data) == 0
 
-        # we expect that, upon each on_created notification of an OperatorNotification contract,
-        # when we query the ACS, we get precisely the same number of contracts.
-        expected_select_count = notification_count * notification_count
-        actual_select_count = 0
 
-        def on_notification_contract(e):
-            nonlocal actual_select_count
-            actual_select_count += len(party_client.find_active(OperatorNotification))
+def test_select_operates_on_acs_before_event_handlers():
+    notification_count = 3
 
-        with sandbox(Simple) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+    # we expect that, upon each on_created notification of an OperatorNotification contract,
+    # when we query the ACS, we get precisely the same number of contracts.
+    expected_select_count = notification_count * notification_count
+    actual_select_count = 0
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
-            party_client.add_ledger_created(OperatorRole, lambda e: exercise(e.cid, 'PublishMany', dict(count=3)))
-            party_client.add_ledger_created(OperatorNotification, on_notification_contract)
-            network.run_until_complete()
+    def on_notification_contract(e):
+        nonlocal actual_select_count
+        actual_select_count += len(party_client.find_active(OperatorNotification))
 
-        self.assertEqual(actual_select_count, expected_select_count)
+    with sandbox(Simple) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-    def test_select_reflects_archive_events(self):
-        notification_count = 3
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
+        party_client.add_ledger_created(OperatorRole, lambda e: exercise(e.cid, 'PublishMany', dict(count=3)))
+        party_client.add_ledger_created(OperatorNotification, on_notification_contract)
+        network.run_until_complete()
 
-        # we expect that, upon each on_created notification of an OperatorNotification contract,
-        # when we query the ACS, we get precisely the same number of contracts.
-        expected_select_count = notification_count * notification_count
-        actual_select_count = 0
+    assert actual_select_count == expected_select_count
 
-        def on_notification_contract(event):
-            nonlocal actual_select_count
-            actual_select_count += len(event.acs_find_active(OperatorNotification))
 
-        with sandbox(Simple) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_select_reflects_archive_events():
+    notification_count = 3
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
-            party_client.add_ledger_created(OperatorRole, lambda e: exercise(e.cid, 'PublishMany', dict(count=3)))
-            party_client.add_ledger_created(OperatorNotification, lambda e: exercise(e.cid, 'Archive'))
-            party_client.add_ledger_created(OperatorNotification, on_notification_contract)
-            network.run_until_complete()
+    # we expect that, upon each on_created notification of an OperatorNotification contract,
+    # when we query the ACS, we get precisely the same number of contracts.
+    expected_select_count = notification_count * notification_count
+    actual_select_count = 0
 
-            final_select_count = len(party_client.find_active(OperatorNotification))
+    def on_notification_contract(event):
+        nonlocal actual_select_count
+        actual_select_count += len(event.acs_find_active(OperatorNotification))
 
-        self.assertEqual(actual_select_count, expected_select_count)
-        self.assertEqual(0, final_select_count)
+    with sandbox(Simple) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
+
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_ready(lambda e: create(OperatorRole, {'operator': PARTY}))
+        party_client.add_ledger_created(OperatorRole, lambda e: exercise(e.cid, 'PublishMany', dict(count=3)))
+        party_client.add_ledger_created(OperatorNotification, lambda e: exercise(e.cid, 'Archive'))
+        party_client.add_ledger_created(OperatorNotification, on_notification_contract)
+        network.run_until_complete()
+
+        final_select_count = len(party_client.find_active(OperatorNotification))
+
+    assert actual_select_count == expected_select_count
+    assert 0 == final_select_count

--- a/python/tests/unit/test_select_nonempty.py
+++ b/python/tests/unit/test_select_nonempty.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from asyncio import wait_for, ensure_future
-from unittest import TestCase
 
 from dazl import sandbox, exercise, Network, AIOPartyClient
 from .dars import Simple
@@ -13,21 +12,20 @@ OperatorRole = 'Simple.OperatorRole'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-class SelectNonEmptyTestCase(TestCase):
-    def test_select_template_retrieves_contracts(self):
-        seen_notifications = []
-        with sandbox(Simple) as proc:
-            network = Network()
-            network.set_config(url=proc.url)
+def test_select_template_retrieves_contracts():
+    seen_notifications = []
+    with sandbox(Simple) as proc:
+        network = Network()
+        network.set_config(url=proc.url)
 
-            party_client = network.aio_party(PARTY)
-            party_client.add_ledger_created(OperatorNotification, lambda event: seen_notifications.append(event.cid))
-            network.run_until_complete(async_test_case(party_client))
+        party_client = network.aio_party(PARTY)
+        party_client.add_ledger_created(OperatorNotification, lambda event: seen_notifications.append(event.cid))
+        network.run_until_complete(async_test_case(party_client))
 
-            data = party_client.find_active(OperatorNotification)
+        data = party_client.find_active(OperatorNotification)
 
-        self.assertEqual(len(data), 5)
-        self.assertEqual(len(seen_notifications), 8)
+    assert len(data) == 5
+    assert len(seen_notifications) == 8
 
 
 async def async_test_case(client: AIOPartyClient):

--- a/python/tests/unit/test_serialization_errors.py
+++ b/python/tests/unit/test_serialization_errors.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase, skip
+import pytest
 
 from dazl.client._writer_verify import ValidateSerializer
 from dazl.model.types import TypeReference, ModuleRef, RecordType, NamedArgumentList, \
@@ -9,17 +9,15 @@ from dazl.model.types import TypeReference, ModuleRef, RecordType, NamedArgument
 from dazl.model.types_store import PackageStoreBuilder
 
 
-class TestSerializationErrors(TestCase):
+@pytest.mark.skip('TODO: Enforce structural validations in ValidateSerializer')
+def test_validations():
+    type_ref = TypeReference(ModuleRef('pkg0', 'Some'), ('Template',))
+    data_type = RecordType(name=type_ref, named_args=NamedArgumentList((('a', SCALAR_TYPE_INTEGER),)), type_args=())
 
-    @skip('TODO: Enforce structural validations in ValidateSerializer')
-    def test_validations(self):
-        type_ref = TypeReference(ModuleRef('pkg0', 'Some'), ('Template',))
-        data_type = RecordType(name=type_ref, named_args=NamedArgumentList((('a', SCALAR_TYPE_INTEGER),)), type_args=())
-
-        psb = PackageStoreBuilder()
-        psb.add_type(type_ref, data_type)
-        serializer = ValidateSerializer(psb.build())
-        result1 = serializer.serialize_value(type_ref, {'a': {}})
-        result2 = serializer.serialize_value(type_ref, {'b': 2})
-        print(result1)
-        print(result2)
+    psb = PackageStoreBuilder()
+    psb.add_type(type_ref, data_type)
+    serializer = ValidateSerializer(psb.build())
+    result1 = serializer.serialize_value(type_ref, {'a': {}})
+    result2 = serializer.serialize_value(type_ref, {'b': 2})
+    print(result1)
+    print(result2)

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -3,7 +3,6 @@
 
 import logging
 from asyncio import sleep
-from unittest import TestCase
 
 from aiohttp import ClientSession
 
@@ -20,11 +19,10 @@ Carol = Party("Carol")
 LOG = logging.getLogger('test_server')
 
 
-class TestServer(TestCase):
-    def test_server_endpoint(self):
-        SERVER_PORT = 53390
-        with sandbox(TestServerDar) as proc:
-            bot_main(sandbox_url=proc.url, server_port=SERVER_PORT)
+def test_server_endpoint():
+    SERVER_PORT = 53390
+    with sandbox(TestServerDar) as proc:
+        bot_main(sandbox_url=proc.url, server_port=SERVER_PORT)
 
 
 def ensure_person_contract(network: Network, party: Party):

--- a/python/tests/unit/test_service_queue.py
+++ b/python/tests/unit/test_service_queue.py
@@ -33,4 +33,4 @@ class TestServiceQueue(TestCase):
         sq.start()
         loop.run_until_complete(gather(main_test(), populate()))
 
-        self.assertEqual(expected, actual)
+        assert expected == actual

--- a/python/tests/unit/test_simple_client_api.py
+++ b/python/tests/unit/test_simple_client_api.py
@@ -1,31 +1,25 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from pathlib import Path
-from unittest import TestCase
 
-from dazl import sandbox, setup_default_logger
-from dazl.client.api import simple_client
+from dazl import sandbox, simple_client, LOG
 
 DAML_FILE = Path(__file__).parent.parent.parent / '_template' / 'Main.daml'
 
-setup_default_logger(logging.DEBUG)
 
+def test_simple_client_api():
+    party = 'abc'
 
-class TestSimpleClientApi(TestCase):
+    LOG.info('Creating sandbox...')
+    with sandbox(daml_path=DAML_FILE) as proc:
+        LOG.info('Creating client...')
+        with simple_client(url=proc.url, party=party) as client:
+            client.ready()
+            LOG.info('Submitting...')
+            client.submit_create('Main.PostmanRole', {'postman': party})
+            LOG.info('getting contracts')
+            contracts = client.find_active('*')
+            LOG.info('got the contracts')
 
-    def test_simple_client_api(self):
-        party = 'abc'
-        print('creating sandbox')
-        with sandbox(daml_path=DAML_FILE) as proc:
-            print('creating client')
-            with simple_client(url=proc.url, party=party) as client:
-                client.ready()
-                print('submitting')
-                client.submit_create('Main.PostmanRole', {'postman': party})
-                print('getting contracts')
-                contracts = client.find_active('*')
-                print('got the contracts')
-
-        self.assertEqual(1, len(contracts))
+    assert 1 == len(contracts)

--- a/python/tests/unit/test_static_time.py
+++ b/python/tests/unit/test_static_time.py
@@ -6,73 +6,71 @@ Test of two clients operating simultaneously.
 """
 
 import logging
-import unittest
 
 from asyncio import gather, get_event_loop, ensure_future
 from datetime import datetime
 from pathlib import Path
 
-from dazl import create, exercise, sandbox, Network, setup_default_logger
+from dazl import create, exercise, sandbox, Network
 
 TEMPLATE_DAML_FILE = Path(__file__).parent.parent.parent / '_template' / 'Main.daml'
 
 LOG = logging.getLogger('test_static_time')
 
-setup_default_logger(logging.DEBUG)
 PARTY = 'POSTMAN'
 
 
-class TestStaticTime(unittest.TestCase):
-    def test_set_static_time(self):
-        """
-        Run a simple test involving manipulation of static time:
-         * Send a command at ledger startup.
-         * Upon receipt of a corresponding event, advance the time and submit a new command
-         * Observe a corresponding event has been received.
-        """
-        with sandbox(TEMPLATE_DAML_FILE) as damli_proc:
-            network = Network()
-            network.set_config(url=damli_proc.url)
+def test_set_static_time():
+    """
+    Run a simple test involving manipulation of static time:
+     * Send a command at ledger startup.
+     * Upon receipt of a corresponding event, advance the time and submit a new command
+     * Observe a corresponding event has been received.
+    """
+    with sandbox(TEMPLATE_DAML_FILE) as damli_proc:
+        network = Network()
+        network.set_config(url=damli_proc.url)
 
-            async def _handle_postman_role(event):
-                try:
-                    LOG.info('Received the postman role contract.')
-                    await network.aio_global().set_time(datetime(1980, 1, 1))
-                    return exercise(event.cid, 'InviteParticipant', dict(party=PARTY, address='something'))
-                except BaseException as ex:
-                    LOG.exception(ex)
+        async def _handle_postman_role(event):
+            try:
+                LOG.info('Received the postman role contract.')
+                await network.aio_global().set_time(datetime(1980, 1, 1))
+                return exercise(event.cid, 'InviteParticipant', dict(party=PARTY, address='something'))
+            except BaseException as ex:
+                LOG.exception(ex)
 
-            def _invitation_seen(event):
-                LOG.info('Invitation seen, so the app will be terminating now.')
-                network.shutdown()
+        def _invitation_seen(event):
+            LOG.info('Invitation seen, so the app will be terminating now.')
+            network.shutdown()
 
-            LOG.info('Adding event listeners to the application...')
-            client = network.aio_party(PARTY)
-            client.add_ledger_ready(lambda _: create('Main.PostmanRole', dict(postman=PARTY)))
-            client.add_ledger_created('Main.PostmanRole', _handle_postman_role)
+        LOG.info('Adding event listeners to the application...')
+        client = network.aio_party(PARTY)
+        client.add_ledger_ready(lambda _: create('Main.PostmanRole', dict(postman=PARTY)))
+        client.add_ledger_created('Main.PostmanRole', _handle_postman_role)
 
-            # run the manager "forever"; we'll stop ourselves manually when we see an author role
-            # because that means our call to invite an author was successful
-            client.add_ledger_created('Main.InviteAuthorRole', _invitation_seen)
-            network.run_forever()
+        # run the manager "forever"; we'll stop ourselves manually when we see an author role
+        # because that means our call to invite an author was successful
+        client.add_ledger_created('Main.InviteAuthorRole', _invitation_seen)
+        network.run_forever()
 
-            LOG.info('Application finished.')
+        LOG.info('Application finished.')
 
-    def test_set_static_time_two_clients(self):
-        """
-        Run a slightly complicated test involving manipulation of static time and multiple clients:
-         * Client 1 sends a command at ledger startup.
-         * Client 2 also listens for the command.
-         * When both Client 1 and Client 2 have heard the original command, Client 1 advances the
-           time and shuts down WITHOUT producing a new command.
-         * After Client 1 is shut down, Client 2 manually syncs its local time and submits a command
-           to the Sandbox.
-         * Observe Client 2 receives its corresponding event.
-        """
-        event_loop = get_event_loop()
-        with sandbox(TEMPLATE_DAML_FILE) as damli_proc:
-            test = _TestSetStaticTimeTwoClients(damli_proc.url)
-            event_loop.run_until_complete(test.main())
+
+def test_set_static_time_two_clients():
+    """
+    Run a slightly complicated test involving manipulation of static time and multiple clients:
+     * Client 1 sends a command at ledger startup.
+     * Client 2 also listens for the command.
+     * When both Client 1 and Client 2 have heard the original command, Client 1 advances the
+       time and shuts down WITHOUT producing a new command.
+     * After Client 1 is shut down, Client 2 manually syncs its local time and submits a command
+       to the Sandbox.
+     * Observe Client 2 receives its corresponding event.
+    """
+    event_loop = get_event_loop()
+    with sandbox(TEMPLATE_DAML_FILE) as damli_proc:
+        test = _TestSetStaticTimeTwoClients(damli_proc.url)
+        event_loop.run_until_complete(test.main())
 
 
 class _TestSetStaticTimeTwoClients:

--- a/python/tests/unit/test_template_meta.py
+++ b/python/tests/unit/test_template_meta.py
@@ -3,10 +3,8 @@
 
 
 from typing import Any, Dict
-from unittest import TestCase
 
-from dazl import create, exercise, TemplateMeta, ChoiceMeta
-from dazl.model.core import ContractId
+from dazl import create, exercise, ContractId, TemplateMeta, ChoiceMeta
 from dazl.model.types import UnresolvedTypeReference
 from dazl.model.types_dynamic import generated_type_proxy_root
 
@@ -34,29 +32,31 @@ def codegen_backends() -> Dict[str, Any]:
     }
 
 
-class TestCodgenMetas(TestCase):
-    def test_template_meta_construction(self):
-        for test_name, Sample in codegen_backends().items():
-            with self.subTest(test_name):
-                command = create(Sample(single=1))
-                self.assertEqual(command.template, UnresolvedTypeReference('Sample'))
+def test_template_meta_construction(subtests):
+    for test_name, Sample in codegen_backends().items():
+        with subtests.test(test_name):
+            command = create(Sample(single=1))
+            assert command.template == UnresolvedTypeReference('Sample')
 
-    def test_template_meta_deconstructed(self):
-        for test_name, Sample in codegen_backends().items():
-            with self.subTest(test_name):
-                command = create(Sample, dict(single=1))
-                self.assertEqual(command.template, UnresolvedTypeReference('Sample'))
 
-    def test_choice_meta_construction(self):
-        for test_name, Sample in codegen_backends().items():
-            with self.subTest(test_name):
-                cid = ContractId('1:0')
-                command = exercise(cid, Sample.Archive())
-                self.assertEqual(command.choice, 'Archive')
+def test_template_meta_deconstructed(subtests):
+    for test_name, Sample in codegen_backends().items():
+        with subtests.test(test_name):
+            command = create(Sample, dict(single=1))
+            assert command.template == UnresolvedTypeReference('Sample')
 
-    def test_choice_meta_deconstructed(self):
-        for test_name, Sample in codegen_backends().items():
-            with self.subTest(test_name):
-                cid = ContractId('1:0')
-                command = exercise(cid, Sample.Archive, {})
-                self.assertEqual(command.choice, 'Archive')
+
+def test_choice_meta_construction(subtests):
+    for test_name, Sample in codegen_backends().items():
+        with subtests.test(test_name):
+            cid = ContractId('1:0')
+            command = exercise(cid, Sample.Archive())
+            assert command.choice == 'Archive'
+
+
+def test_choice_meta_deconstructed(subtests):
+    for test_name, Sample in codegen_backends().items():
+        with subtests.test(test_name):
+            cid = ContractId('1:0')
+            command = exercise(cid, Sample.Archive, {})
+            assert command.choice == 'Archive'

--- a/python/tests/unit/test_template_reverse_globs.py
+++ b/python/tests/unit/test_template_reverse_globs.py
@@ -1,28 +1,28 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl.model.reading import template_reverse_globs
 
 
-class TestTemplateReverseGlobs(TestCase):
-    def test_non_primary_simple_unknown_module(self):
-        expected = ['*/MyTemplate', '*/*']
-        actual = list(template_reverse_globs(False, '*', 'MyTemplate'))
-        self.assertEqual(expected, actual)
+def test_non_primary_simple_unknown_module():
+    expected = ['*/MyTemplate', '*/*']
+    actual = list(template_reverse_globs(False, '*', 'MyTemplate'))
+    assert expected == actual
 
-    def test_primary_simple_unknown_module(self):
-        expected = ['*/MyTemplate']
-        actual = list(template_reverse_globs(True, '*', 'MyTemplate'))
-        self.assertEqual(expected, actual)
 
-    def test_non_primary_simple_known_module(self):
-        expected = ['0000dead0000beef/MyTemplate', '0000dead0000beef/*', '*/MyTemplate', '*/*']
-        actual = list(template_reverse_globs(False, '0000dead0000beef', 'MyTemplate'))
-        self.assertEqual(expected, actual)
+def test_primary_simple_unknown_module():
+    expected = ['*/MyTemplate']
+    actual = list(template_reverse_globs(True, '*', 'MyTemplate'))
+    assert expected == actual
 
-    def test_primary_simple_known_module(self):
-        expected = ['0000dead0000beef/MyTemplate']
-        actual = list(template_reverse_globs(True, '0000dead0000beef', 'MyTemplate'))
-        self.assertEqual(expected, actual)
+
+def test_non_primary_simple_known_module():
+    expected = ['0000dead0000beef/MyTemplate', '0000dead0000beef/*', '*/MyTemplate', '*/*']
+    actual = list(template_reverse_globs(False, '0000dead0000beef', 'MyTemplate'))
+    assert expected == actual
+
+
+def test_primary_simple_known_module():
+    expected = ['0000dead0000beef/MyTemplate']
+    actual = list(template_reverse_globs(True, '0000dead0000beef', 'MyTemplate'))
+    assert expected == actual

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl import sandbox, exercise, Party, simple_client
 from .dars import Simple
 
@@ -12,27 +10,24 @@ OperatorRole = 'Simple.OperatorRole'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-class TestThreadsafeMethods(TestCase):
+def test_threadsafe_methods():
+    with sandbox(Simple) as proc:
+        with simple_client(proc.url, PARTY) as client:
+            client.ready()
+            client.submit_create(OperatorRole, {'operator': PARTY})
 
-    def test_threadsafe_methods(self):
-        with sandbox(Simple) as proc:
-            with simple_client(proc.url, PARTY) as client:
-                client.ready()
-                client.submit_create(OperatorRole, {'operator': PARTY})
+            operator_cid, _ = client.find_one(OperatorRole)
 
-                operator_cid, _ = client.find_one(OperatorRole)
+            client.submit_exercise(operator_cid, 'PublishMany', dict(count=5))
 
-                client.submit_exercise(operator_cid, 'PublishMany', dict(count=5))
+            notifications = client.find_nonempty(OperatorNotification, {'operator': PARTY}, min_count=5)
+            contracts_to_delete = []
+            for cid, cdata in notifications.items():
+                if int(cdata['text']) <= 3:
+                    contracts_to_delete.append(cid)
 
-                notifications = client.find_nonempty(OperatorNotification, {'operator': PARTY}, min_count=5)
-                contracts_to_delete = []
-                for cid, cdata in notifications.items():
-                    if int(cdata['text']) <= 3:
-                        contracts_to_delete.append(cid)
+            client.submit([exercise(cid, 'Archive') for cid in contracts_to_delete])
 
-                client.submit([exercise(cid, 'Archive') for cid in contracts_to_delete])
+            client.submit_exercise(operator_cid, 'PublishMany', dict(count=3))
 
-                client.submit_exercise(operator_cid, 'PublishMany', dict(count=3))
-
-                print(client.find_active('*'))
-
+            print(client.find_active('*'))

--- a/python/tests/unit/test_type_substitutions.py
+++ b/python/tests/unit/test_type_substitutions.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import TestCase
-
 from dazl.model.types import TypeReference, ModuleRef, dotted_name, RecordType, \
     NamedArgumentList, \
     ListType, TypeVariable, TypeApp, SCALAR_TYPE_TEXT, SCALAR_TYPE_INTEGER, \
@@ -30,36 +28,35 @@ def type_var(name):
     return TypeVariable(name)
 
 
-class SubstitutionsTestCase(TestCase):
-    def test_simple_translate(self):
-        tr = simple_type_ref('Map')
-        tt = simple_type_ref('Tuple')
+def test_simple_translate():
+    tr = simple_type_ref('Map')
+    tt = simple_type_ref('Tuple')
 
-        tuple_type = record_type(tt, 'AB', _1=type_var('A'), _2=type_var('B'))
-        map_type = record_type(tr, 'KV', _1=list_type(TypeApp(tt, (type_var('K'), type_var('V')))))
+    tuple_type = record_type(tt, 'AB', _1=type_var('A'), _2=type_var('B'))
+    map_type = record_type(tr, 'KV', _1=list_type(TypeApp(tt, (type_var('K'), type_var('V')))))
 
-        psb = PackageStoreBuilder()
-        psb.add_type(tuple_type.name, tuple_type)
-        psb.add_type(map_type.name, map_type)
+    psb = PackageStoreBuilder()
+    psb.add_type(tuple_type.name, tuple_type)
+    psb.add_type(map_type.name, map_type)
 
-        test_case_type = TypeApp(tr, (SCALAR_TYPE_INTEGER, SCALAR_TYPE_TEXT))
+    test_case_type = TypeApp(tr, (SCALAR_TYPE_INTEGER, SCALAR_TYPE_TEXT))
 
-        def _1(context, actual: RecordType):
-            self.assertEqual(1, len(actual.named_args))
-            type_evaluate_dispatch_default_error(on_list=_2)(context, actual.named_args[0][1])
+    def _1(context, actual: RecordType):
+        assert 1 == len(actual.named_args)
+        type_evaluate_dispatch_default_error(on_list=_2)(context, actual.named_args[0][1])
 
-        def _2(context, inner_list_type: ListType):
-            type_evaluate_dispatch_default_error(on_record=_3)(context, inner_list_type.type_parameter)
+    def _2(context, inner_list_type: ListType):
+        type_evaluate_dispatch_default_error(on_record=_3)(context, inner_list_type.type_parameter)
 
-        def _3(context, inner_tuple_type: RecordType):
-            type_evaluate_dispatch_default_error(on_scalar=_4)(context, inner_tuple_type.named_args[0][1])
-            type_evaluate_dispatch_default_error(on_scalar=_5)(context, inner_tuple_type.named_args[1][1])
+    def _3(context, inner_tuple_type: RecordType):
+        type_evaluate_dispatch_default_error(on_scalar=_4)(context, inner_tuple_type.named_args[0][1])
+        type_evaluate_dispatch_default_error(on_scalar=_5)(context, inner_tuple_type.named_args[1][1])
 
-        def _4(context, first_param):
-            self.assertEqual(first_param, SCALAR_TYPE_INTEGER)
+    def _4(context, first_param):
+        assert first_param == SCALAR_TYPE_INTEGER
 
-        def _5(context, second_param):
-            self.assertEqual(second_param, SCALAR_TYPE_TEXT)
+    def _5(context, second_param):
+        assert second_param == SCALAR_TYPE_TEXT
 
-        type_evaluate_dispatch_default_error(on_record=_1)(
-            TypeEvaluationContext.from_store(psb.build()), test_case_type)
+    type_evaluate_dispatch_default_error(on_record=_1)(
+        TypeEvaluationContext.from_store(psb.build()), test_case_type)

--- a/python/tests/unit/test_util_log.py
+++ b/python/tests/unit/test_util_log.py
@@ -2,55 +2,56 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import unittest
-
 from dazl.util.io import LoggingStream
 
 
-class LoggingStreamTest(unittest.TestCase):
+def test_unterminated_write():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc')
+    assert [] == logger.lines
 
-    def test_unterminated_write(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc')
-        self.assertEqual(logger.lines, [])
 
-    def test_terminated_write(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc\n')
-        self.assertEqual(['abc'], logger.lines)
+def test_terminated_write():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc\n')
+    assert ['abc'] == logger.lines
 
-    def test_multiple_writes(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc')
-        stream.write('def\n')
-        self.assertEqual(['abcdef'], logger.lines)
 
-    def test_multiple_writes_of_lines(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc\n')
-        stream.write('def\n')
-        self.assertEqual(['abc', 'def'], logger.lines)
+def test_multiple_writes():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc')
+    stream.write('def\n')
+    assert ['abcdef'] == logger.lines
 
-    def test_multiple_writelines(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc')
-        stream.writelines(['def', 'ghi'])
-        stream.write('jkl\n')
-        self.assertEqual(['abcdef', 'ghi', 'jkl'], logger.lines)
 
-    def test_complex(self):
-        logger = MockLogger()
-        stream = LoggingStream(logger, None)
-        stream.write('abc')
-        stream.write('def\nghi\njkl')
-        stream.write('mno')
-        stream.write('\n')
-        self.assertEqual(['abcdef', 'ghi', 'jklmno'], logger.lines)
+def test_multiple_writes_of_lines():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc\n')
+    stream.write('def\n')
+    assert ['abc', 'def'] == logger.lines
+
+
+def test_multiple_writelines():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc')
+    stream.writelines(['def', 'ghi'])
+    stream.write('jkl\n')
+    assert ['abcdef', 'ghi', 'jkl'] == logger.lines
+
+
+def test_complex():
+    logger = MockLogger()
+    stream = LoggingStream(logger, None)
+    stream.write('abc')
+    stream.write('def\nghi\njkl')
+    stream.write('mno')
+    stream.write('\n')
+    assert ['abcdef', 'ghi', 'jklmno'] == logger.lines
 
 
 class MockLogger:

--- a/python/tests/unit/test_validate_template.py
+++ b/python/tests/unit/test_validate_template.py
@@ -2,18 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from unittest import TestCase
-
 from dazl.model.lookup import validate_template
 from dazl.model.types_dynamic import generated_type_proxy_root
 
 
-class TestValidateTemplate(TestCase):
+def test_generated_type_proxy_with_no_package_id():
+    # noinspection PyPep8Naming
+    Sample = generated_type_proxy_root(root_module_name='Sample')
 
-    def test_generated_type_proxy_with_no_package_id(self):
-        # noinspection PyPep8Naming
-        Sample = generated_type_proxy_root(root_module_name='Sample')
-
-        expected = ('*', 'Sample.Test.Template')
-        actual = validate_template(Sample.Test.Template)
-        self.assertEqual(expected, actual)
+    expected = ('*', 'Sample.Test.Template')
+    actual = validate_template(Sample.Test.Template)
+    assert expected == actual


### PR DESCRIPTION
Switch to using pytest-style tests (we are already using `pytest` as the test runner).

The primary impetus for this change is a major change to the way that the Sandbox is launched from within dazl tests due to changes in the way that Sandbox has started shipping since DAML SDK 0.13.39:
* dazl will now launch `daml sandbox` instead of trying to launch the Sandbox .jar from a well-known path. The `dazl.sandbox()` utility method is not compatible DAML SDK 0.13.39 and will be deprecated soon.
* The tests in dazl will finally run against official SDK images instead of selectively trying to download sandbox.jar from Bintray and launching it from there.
* *dazl will use a Pytest fixture in tests to talk to a long-running Sandbox, instead of controlling Sandbox processes*. The CircleCI image that runs Python tests will subsequently no longer need `java`, as this can now be considered an implementation detail of the DAML SDK Docker image.