### PR TITLE
python: Minor bug fix to support running tests under Python 3.7/3.8

### DIFF
--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -157,6 +157,7 @@ class Bot:
                             await handler.callback(new_event)
                     except Exception:  # noqa
                         LOG.exception('An event handler in a bot has thrown an exception!')
+        LOG.debug('Party %s finished handling events.', self.party)
 
     def notify(self, event: 'BaseEvent') -> 'Awaitable[None]':
         """


### PR DESCRIPTION
Minor bug fix to support running tests under Python 3.7 and Python 3.8.

`pytest` uses the context parameter introduced to [`Future.add_done_callback`](https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.add_done_callback), but usage does not appear to be common in other contexts which is how this problem was not detected for so long. This allows certain `dazl` `asyncio` wrapper types to be used seamlessly with other `Future`s in this context.