### PR TITLE
python: Move most of the tests to run under a single sandbox

### DIFF
--- a/python/dazl/__init__.py
+++ b/python/dazl/__init__.py
@@ -77,7 +77,7 @@ __version__ = _get_version()
 
 
 from .damlsdk.sandbox import sandbox  # noqa
-from .client import run, simple_client, Network, SimplePartyClient, AIOPartyClient  # noqa
+from .client import run, simple_client, async_network, Network, SimplePartyClient, AIOPartyClient  # noqa
 from .model.core import ContractId, ContractData, DazlError, Party  # noqa
 from .model.writing import create, exercise, exercise_by_key, create_and_exercise, \
     Command, CreateCommand, ExerciseCommand, ExerciseByKeyCommand, CreateAndExerciseCommand  # noqa

--- a/python/dazl/client/__init__.py
+++ b/python/dazl/client/__init__.py
@@ -16,7 +16,8 @@ For a higher-level, more declarative API, see :mod:`dazl.query`.
 """
 
 from . import config
-from .api import simple_client, Network, PartyClient, AIOPartyClient, SimplePartyClient
+from .api import async_network, simple_client, Network, PartyClient, AIOPartyClient, \
+    SimplePartyClient
 from .bots import Bot, BotCollection, BotEntry
 from .runner import run
 from ._base_model import ExitCode, LedgerRun, CREATE_IF_MISSING, NONE_IF_MISSING, \

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -12,8 +12,10 @@ the Ledger API.
    :members:
 """
 import warnings
+from pathlib import Path
+
 from dataclasses import dataclass
-from typing import Any, Callable, Collection, Dict, NewType, Optional, Tuple, TypeVar, \
+from typing import Any, BinaryIO, Callable, Collection, Dict, NewType, Optional, Tuple, TypeVar, \
     Union, TYPE_CHECKING
 from datetime import datetime
 
@@ -154,6 +156,10 @@ class ContractContextualData:
     effective_at: datetime
     archived_at: 'Optional[datetime]'
     active: bool
+
+
+# Wherever the API expects a DAR, we can take a file path, `bytes`, or a byte buffer.
+Dar = Union[bytes, str, Path, BinaryIO]
 
 
 @dataclass(frozen=True)

--- a/python/dazl/scheduler/_invoker.py
+++ b/python/dazl/scheduler/_invoker.py
@@ -85,7 +85,8 @@ class Invoker:
         a default executor if one has not yet been set.
         """
         self.loop = get_event_loop()
-        self.executor = ThreadPoolExecutor()
+        if self.executor is None:
+            self.executor = ThreadPoolExecutor()
 
     def run_in_loop(self, func, timeout: float = 30.0):
         """

--- a/python/dazl/util/tools.py
+++ b/python/dazl/util/tools.py
@@ -5,7 +5,7 @@
 This module contains miscellaneous utility methods that don't really fit anywhere else.
 """
 
-from typing import Generator, Tuple, TypeVar, Iterable
+from typing import Collection, Generator, Iterable, List, Tuple, TypeVar, Union
 
 T = TypeVar('T')
 
@@ -49,3 +49,24 @@ def flatten(obj):
     for sublist in obj:
         ret.extend(sublist)
     return ret
+
+
+def as_list(obj: 'Union[None, T, Collection[Union[None, T]]]') -> 'List[T]':
+    """
+    Convert an object that is either nothing, a single object, or a collection, to a list of type
+    of that object.
+    """
+    from collections.abc import Iterable
+
+    if obj is None:
+        return []
+    elif isinstance(obj, str):
+        # strings are iterable, but it's almost never intended to be used in place of a list; if
+        # we're given a string, then assume what is wanted is a single list containing the full
+        # string instead of a list containing every character as an individual item
+        return [obj]
+    elif isinstance(obj, Iterable):
+        return [o for o in obj if o is not None]
+    else:
+        # assume we're dealing with a single object of the requested type
+        return [obj]

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import pytest
+
+
+@pytest.fixture(scope="session")
+def sandbox() -> str:
+    from dazl import sandbox as test_sandbox
+    with test_sandbox([]) as proc:
+        logging.info('Shared test sandbox started at %s', proc.url)
+        yield proc.url
+        logging.info('The tests are done. Shutting down the sandbox...')

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -4,14 +4,15 @@
 import datetime
 from decimal import Decimal
 
-from dazl import sandbox, create, Network
+import pytest
+
+from dazl import create, async_network
 from .dars import AllKindsOf
 
 
-PARTY = 'Operator'
 TEMPLATE = 'AllKindsOf.OneOfEverything'
 SOME_ARGS = dict(
-    operator=PARTY,
+    operator=None,  # this is filled in by each of the tests because Party allocation is random
     someBoolean=True,
     someInteger=5,
     someDecimal=Decimal(5.0),
@@ -28,16 +29,16 @@ SOME_ARGS = dict(
     theUnit=dict())
 
 
-def test_all_types():
-    test_case = AllTypesTestCase()
-    with sandbox(AllKindsOf) as proc:
-        network = Network()
-        network.set_config(url=proc.url)
+@pytest.mark.asyncio
+async def test_all_types(sandbox):
+    async with async_network(url=sandbox, dars=AllKindsOf) as network:
+        client = network.aio_new_party()
 
-        party_client = network.aio_party(PARTY)
-        party_client.add_ledger_ready(test_case.create_one_of_everything)
-        party_client.add_ledger_created(TEMPLATE, test_case.on_one_of_everything)
-        network.run_until_complete()
+        test_case = AllTypesTestCase(client.party)
+        client.add_ledger_ready(test_case.create_one_of_everything)
+        client.add_ledger_created(TEMPLATE, test_case.on_one_of_everything)
+
+        network.start()
 
     assert test_case.found_instance is not None, \
         'Expected to find an instance of OneOfEverything!'
@@ -46,35 +47,33 @@ def test_all_types():
         'There are either extra fields or missing fields!'
 
     for key in SOME_ARGS:
-        expected = SOME_ARGS.get(key)
-        actual = test_case.found_instance.get(key)
-        assert expected == actual, f'Failed to compare types for key: {key}'
+        if key != 'operator':
+            expected = SOME_ARGS.get(key)
+            actual = test_case.found_instance.get(key)
+            assert expected == actual, f'Failed to compare types for key: {key}'
 
 
-def test_maps():
-    with sandbox(AllKindsOf) as proc:
-        network = Network()
-        network.set_config(url=proc.url)
+@pytest.mark.asyncio
+async def test_maps(sandbox):
+    async with async_network(url=sandbox, dars=AllKindsOf) as network:
+        client = network.aio_new_party()
 
-        party_client = network.aio_party(PARTY)
-        party_client.add_ledger_ready(lambda e: create(
-            'AllKindsOf.MappyContract', {
-                'operator': PARTY,
-                'value': {'Map_internal': []}
-            }))
+        network.start()
 
-        network.run_until_complete()
+        await client.submit_create('AllKindsOf.MappyContract', {
+            'operator': client.party,
+            'value': {'Map_internal': []}
+        })
 
 
 class AllTypesTestCase:
-    def __init__(self):
+    def __init__(self, operator):
+        self.operator = operator
         self.found_instance = None
         self.archive_done = False
 
-    # noinspection PyUnusedLocal
-    @staticmethod
-    def create_one_of_everything(_):
-        return create(TEMPLATE, SOME_ARGS)
+    def create_one_of_everything(self, _):
+        return create(TEMPLATE, {**SOME_ARGS, "operator": self.operator})
 
     def on_one_of_everything(self, event):
         if event.cdata is not None:

--- a/python/tests/unit/test_cli_ls.py
+++ b/python/tests/unit/test_cli_ls.py
@@ -4,31 +4,24 @@
 """
 Tests to ensure that CLI commands work properly.
 """
-from dazl import sandbox
 from dazl.cli import _main
 
-from .dars import PostOffice
+
+def test_simple_ls(sandbox):
+    exit_code = _main(f'dazl ls --url {sandbox} --parties=Alice'.split(' '))
+    assert exit_code == 0
 
 
-def test_simple_ls():
-    with sandbox(dar_path=PostOffice) as proc:
-        exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice'.split(' '))
+def test_simple_ls_two_parties(sandbox):
+    exit_code = _main(f'dazl ls --url {sandbox} --parties=Alice,Bob'.split(' '))
 
     assert exit_code == 0
 
 
-def test_simple_ls_two_parties():
-    with sandbox(dar_path=PostOffice) as proc:
-        exit_code = _main(f'dazl ls --url {proc.url} --parties=Alice,Bob'.split(' '))
-
-    assert exit_code == 0
-
-
-def test_env_ls():
+def test_env_ls(sandbox):
     import os
-    with sandbox(dar_path=PostOffice) as proc:
-        os.environ['DAML_LEDGER_URL'] = proc.url
-        os.environ['DAML_LEDGER_PARTY'] = 'Alice'
-        exit_code = _main('dazl ls'.split(' '))
+    os.environ['DAML_LEDGER_URL'] = sandbox
+    os.environ['DAML_LEDGER_PARTY'] = 'Alice'
+    exit_code = _main('dazl ls'.split(' '))
 
     assert exit_code == 0

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -1,14 +1,11 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 from dazl.util.dar import DarFile
 from .dars import Pending
 
 
-@pytest.mark.skip('Something about the way dazl compiles DARs currently causes this field to be blank')
 def test_get_sdk_version():
     with DarFile(Pending) as dar:
         print(dar.get_manifest())
-        assert '0.13.18' == dar.get_sdk_version()
+        assert '0.13.32' == dar.get_sdk_version()

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -1,43 +1,52 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
+import pytest
 
-from dazl import sandbox, simple_client
+from dazl import async_network
 from .dars import DottedFields
 
 
-def test_record_dotted_fields_submit():
-    with sandbox(dar_path=DottedFields) as proc:
-        with simple_client(url=proc.url, party='Test') as client:
-            client.ready()
-            client.submit_create('DottedFields.American', {
-                'person': 'Test',
-                'address.address': '1 Test Place',
-                'address.city': 'Somewhere',
-                'address.state': 'ZZ',
-                'address.zip': '99999'
-            })
+@pytest.mark.asyncio
+async def test_record_dotted_fields_submit(sandbox):
+    async with async_network(url=sandbox, dars=DottedFields) as network:
+        client = network.aio_new_party()
 
-            logging.info(client.find_active('DottedFields.American'))
+        network.start()
+
+        await client.ready()
+        await client.submit_create('DottedFields.American', {
+            'person': client.party,
+            'address.address': '1 Test Place',
+            'address.city': 'Somewhere',
+            'address.state': 'ZZ',
+            'address.zip': '99999'
+        })
+
+        items = client.find_active('DottedFields.American')
+        assert len(items) == 1
 
 
-def test_variant_dotted_fields_submit():
-    with sandbox(dar_path=DottedFields) as proc:
-        with simple_client(url=proc.url, party='Test') as client:
-            client.ready()
-            client.submit_create('DottedFields.Person', {
-                'person': 'Test',
-                'address.US.address': '1 Test Place',
-                'address.US.city': 'Somewhere',
-                'address.US.state': 'ZZ',
-                'address.US.zip': '99999',
-                'address.UK.address': '',
-                'address.UK.locality': '',
-                'address.UK.city': '',
-                'address.UK.state': '',
-                'address.UK.postcode': '',
+@pytest.mark.asyncio
+async def test_variant_dotted_fields_submit(sandbox):
+    async with async_network(url=sandbox, dars=DottedFields) as network:
+        client = network.aio_new_party()
 
-            })
+        network.start()
 
-            logging.info(client.find_active('DottedFields.Person'))
+        await client.ready()
+        await client.submit_create('DottedFields.Person', {
+            'person': client.party,
+            'address.US.address': '1 Test Place',
+            'address.US.city': 'Somewhere',
+            'address.US.state': 'ZZ',
+            'address.US.zip': '99999',
+            'address.UK.address': '',
+            'address.UK.locality': '',
+            'address.UK.city': '',
+            'address.UK.state': '',
+            'address.UK.postcode': '',
+        })
+
+        items = client.find_active('DottedFields.Person')
+        assert len(items) == 1

--- a/python/tests/unit/test_dynamic_dar_loading.py
+++ b/python/tests/unit/test_dynamic_dar_loading.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
-from unittest import TestCase
 
 from dazl.model.types_store import PackageStore, PackageProvider, MemoryPackageProvider
 from dazl.protocols.v1.grpc import grpc_package_sync

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -1,39 +1,43 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import logging
+import uuid
 
-from dazl import create, exercise, sandbox, Network
+import pytest
+
+from dazl import async_network, create, exercise
 
 from .dars import PostOffice
 
 
-def test_parties_can_be_added_after_run_forever():
-    with sandbox(dar_path=PostOffice) as proc:
-        network = Network()
-        network.set_config(url=proc.url)
+@pytest.mark.asyncio
+async def test_parties_can_be_added_after_run_forever(sandbox):
+    async with async_network(url=sandbox, dars=PostOffice) as network:
+        operator_client = network.aio_new_party()
+        party_a_client = network.aio_new_party()
+        party_b_client = network.aio_new_party()
+        # TODO: Introduce a Party allocation API separate from client creation
+        party_c_party = str(uuid.uuid4())
 
-        operator = network.aio_party('Operator')
-        party_a = network.aio_party('Party A')
-        party_b = network.aio_party('Party B')
+        @operator_client.ledger_ready()
+        def operator_ready(event):
+            return create('Main.PostmanRole', {'postman': event.party})
 
-        @operator.ledger_ready()
-        def _(event):
-            return create('Main.PostmanRole', {'postman': 'Operator'})
-
-        @operator.ledger_created('Main.PostmanRole')
-        def __(event):
+        @operator_client.ledger_created('Main.PostmanRole')
+        def operator_role_created(event):
             return [exercise(event.cid, 'InviteParticipant', {'party': party, 'address': 'whatevs'})
-                    for party in ('Party A', 'Party B', 'Party C')]
+                    for party in (party_a_client.party, party_b_client.party, party_c_party)]
 
-        @party_a.ledger_created('Main.InviteAuthorRole')
-        async def _(event):
-            party_c = network.aio_party('Party C')
+        @party_a_client.ledger_created('Main.InviteAuthorRole')
+        async def party_a_accept_invite(_):
+            party_c = network.aio_party(party_c_party)
 
             @party_c.ledger_created('Main.AuthorRole')
-            def ___(event):
+            def party_c_role_created(_):
                 network.shutdown()
 
             cid, cdata = await party_c.find_one('Main.InviteAuthorRole')
             party_c.submit_exercise(cid, 'AcceptInviteAuthorRole')
 
-        network.run_forever()
+        network.start()
 

--- a/python/tests/unit/test_flask.py
+++ b/python/tests/unit/test_flask.py
@@ -4,42 +4,62 @@
 import json
 import logging
 from threading import Thread
+from time import sleep
 
-from dazl import simple_client, sandbox, create, LOG, setup_default_logger
-from dazl.client import SimplePartyClient
+from dazl import create, LOG, setup_default_logger, Network, SimplePartyClient
+from dazl.model.reading import ReadyEvent
 from .dars import PostOffice
 
 
-SAMPLE_PARTY = 'TestParty'
-
-
-def test_simple_flask_integration():
+def test_simple_flask_integration(sandbox):
     setup_default_logger(logging.INFO)
-    with sandbox(dar_path=PostOffice) as proc:
-        with simple_client(proc.url, SAMPLE_PARTY) as client:
-            # seed the ledger with some initial state
-            client.add_ledger_ready(create_initial_state)
 
-            LOG.info('Waiting for the client to be ready...')
-            client.ready()
-            LOG.info('Client is ready.')
+    network = Network()
+    network.set_config(url=sandbox)
+    client = network.simple_new_party()
 
-            # now start a Flask app
-            LOG.info('Starting up the flask app...')
-            main_thread = Thread(target=run_flask_app, args=(client, 9999))
-            main_thread.start()
+    # seed the ledger with some initial state
+    client.add_ledger_ready(create_initial_state)
 
-            returned_data = run_flask_test(9999)
-            assert returned_data == {'postman': SAMPLE_PARTY}
+    network.start_in_background()
 
-            main_thread.join(30)
-            if main_thread.is_alive():
-                raise Exception('The Flask thread should have terminated, but did not.')
+    LOG.info('Waiting for the client to be ready...')
+    client.ready()
+
+    # TODO: This is currently necessary because there is a bug that prevents ready() from waiting
+    #  on ledger_ready events even when those callbacks are added at the appropriate time.
+    sleep(10)
+
+    LOG.info('Client is ready.')
+
+    # now start a Flask app
+    LOG.info('Starting up the flask app...')
+    main_thread = Thread(target=run_flask_app, args=(client, 9999))
+    main_thread.start()
+
+    returned_data = run_flask_test(9999)
+    assert returned_data == {'postman': client.party}
+
+    network.shutdown()
+    network.join(30)
+
+    main_thread.join(30)
+    if main_thread.is_alive():
+        raise Exception('The Flask thread should have terminated, but did not.')
 
 
-def create_initial_state(_):
-    LOG.info('Creating the initial postman role contract...')
-    return create('Main.PostmanRole', dict(postman=SAMPLE_PARTY))
+def create_initial_state(event: 'ReadyEvent'):
+    try:
+        LOG.info('Uploading our DAR...')
+        event.client.ensure_dar(PostOffice)
+        while not event.package_store.resolve_template('Main.PostmanRole'):
+            logging.info("Waiting for our DAR to be uploaded...")
+            sleep(1)
+
+        LOG.info('DAR uploaded. Creating the initial postman role contract...')
+        return create('Main.PostmanRole', dict(postman=event.party))
+    except:
+        LOG.exception('Failed to set up our initial state!')
 
 
 def run_flask_app(client: SimplePartyClient, port: int) -> None:

--- a/python/tests/unit/test_ledger_api_types.py
+++ b/python/tests/unit/test_ledger_api_types.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-#pylint: disable=invalid-name,missing-docstring,no-self-use
-import unittest
 from datetime import datetime, timezone
 
 from dazl.model.core import ContractId
@@ -11,23 +9,22 @@ from dazl.util.prim_types import to_datetime
 DUMMY_TEMPLATE_ID = 'DummyTemplate'
 
 
-class ContractIdTest(unittest.TestCase):
-    def test_contract_id_as_dict_key(self):
-        cid_a = ContractId(template_id=DUMMY_TEMPLATE_ID, contract_id='1')
-        cid_b = ContractId(template_id=DUMMY_TEMPLATE_ID, contract_id='1')
-        test_dict = dict()
-        test_dict[cid_a] = 'hello world'
+def test_contract_id_as_dict_key():
+    cid_a = ContractId(template_id=DUMMY_TEMPLATE_ID, contract_id='1')
+    cid_b = ContractId(template_id=DUMMY_TEMPLATE_ID, contract_id='1')
+    test_dict = dict()
+    test_dict[cid_a] = 'hello world'
 
-        self.assertEqual(test_dict[cid_b], 'hello world')
+    assert test_dict[cid_b] == 'hello world'
 
 
-class DateTimeTest(unittest.TestCase):
-    def test_simple_date_parse(self):
-        expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
-        actual = to_datetime('2018-08-07T23:17:31.143080Z')
-        assert expected == actual
+def test_simple_date_parse():
+    expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
+    actual = to_datetime('2018-08-07T23:17:31.143080Z')
+    assert expected == actual
 
-    def test_simple_date_parse_with_nanos(self):
-        expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
-        actual = to_datetime('2018-08-07T23:17:31.143080698Z')
-        assert expected == actual
+
+def test_simple_date_parse_with_nanos():
+    expected = datetime(2018, 8, 7, 23, 17, 31, 143080, tzinfo=timezone.utc)
+    actual = to_datetime('2018-08-07T23:17:31.143080698Z')
+    assert expected == actual

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -1,43 +1,48 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import pytest
 
-from dazl import frozendict, sandbox, simple_client
+from dazl import async_network, frozendict
 
 from .dars import MapSupport
 
 
-def test_map_support():
-    with sandbox(MapSupport) as proc:
-        with simple_client(url=proc.url, party='Test') as client:
-            client.ready()
-            client.submit_create('MapSupport.Sample', {
-                'party': 'Test',
-                'mappings': {
-                    '65': 'A',
-                    '97': 'a'
-                },
-                'text': None
-            })
+@pytest.mark.asyncio
+async def test_map_support(sandbox):
+    async with async_network(url=sandbox, dars=MapSupport) as network:
+        client = network.aio_new_party()
 
-            logging.info(client.find_active('*'))
+        network.start()
+
+        await client.ready()
+        await client.submit_create('MapSupport.Sample', {
+            'party': client.party,
+            'mappings': {
+                '65': 'A',
+                '97': 'a'
+            },
+            'text': None
+        })
+
+        assert len(client.find_active('*')) == 1
 
 
 @pytest.mark.skip('Keys with arbitrary types are no longer supported. See the comments in MapSupport.daml.')
-def test_complicated_map_support():
-    with sandbox(MapSupport) as proc:
-        with simple_client(url=proc.url, party='Test') as client:
-            client.ready()
-            client.submit_create('MapSupport.ComplicatedSample', {
-                'party': 'Test',
-                # Note: Python `dict`s are not hashable, so the only way to write this out
-                # is to create a special dict as a key
-                'keyIsMap': {frozendict(A='b'): 'mmm'},
-                'keyIsRecord': {frozendict(x=2, y=4): 'rrr'},
-                'keyIsRecordWithTypeParam': {frozendict(x=2, y=4): 'rrr'},
-                'keyIsVariant': {frozendict(Apple=''): 'ttt'}
-            })
+async def test_complicated_map_support(sandbox):
+    # This test will be re-enabled when GenMap support lands in DAML-LF 1.9
+    async with async_network(url=sandbox, dars=MapSupport) as network:
+        client = network.aio_new_party()
 
-            logging.info(client.find_active('*'))
+        await client.ready()
+        await client.submit_create('MapSupport.ComplicatedSample', {
+            'party': 'Test',
+            # Note: Python `dict`s are not hashable, so the only way to write this out
+            # is to create a special dict as a key
+            'keyIsMap': {frozendict(A='b'): 'mmm'},
+            'keyIsRecord': {frozendict(x=2, y=4): 'rrr'},
+            'keyIsRecordWithTypeParam': {frozendict(x=2, y=4): 'rrr'},
+            'keyIsVariant': {frozendict(Apple=''): 'ttt'}
+        })
+
+        assert len(client.find_active('*')) == 1

--- a/python/tests/unit/test_select_nonempty.py
+++ b/python/tests/unit/test_select_nonempty.py
@@ -1,28 +1,29 @@
-# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from asyncio import wait_for, ensure_future
 
-from dazl import sandbox, exercise, Network, AIOPartyClient
+import pytest
+
+from dazl import async_network, exercise, AIOPartyClient
 from .dars import Simple
 
 
-PARTY = 'Operator'
 OperatorRole = 'Simple.OperatorRole'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-def test_select_template_retrieves_contracts():
+@pytest.mark.asyncio
+async def test_select_template_retrieves_contracts(sandbox):
     seen_notifications = []
-    with sandbox(Simple) as proc:
-        network = Network()
-        network.set_config(url=proc.url)
 
-        party_client = network.aio_party(PARTY)
-        party_client.add_ledger_created(OperatorNotification, lambda event: seen_notifications.append(event.cid))
-        network.run_until_complete(async_test_case(party_client))
+    async with async_network(url=sandbox, dars=Simple) as network:
+        client = network.aio_new_party()
+        client.add_ledger_created(OperatorNotification, lambda event: seen_notifications.append(event.cid))
 
-        data = party_client.find_active(OperatorNotification)
+        await network.aio_run(async_test_case(client), keep_open=False)
+
+        data = client.find_active(OperatorNotification)
 
     assert len(data) == 5
     assert len(seen_notifications) == 8
@@ -31,7 +32,7 @@ def test_select_template_retrieves_contracts():
 async def async_test_case(client: AIOPartyClient):
     await client.ready()
 
-    ensure_future(client.submit_create(OperatorRole, {'operator': PARTY}))
+    ensure_future(client.submit_create(OperatorRole, {'operator': client.party}))
 
     operator_cid, _ = await client.find_one(OperatorRole)
 
@@ -41,7 +42,7 @@ async def async_test_case(client: AIOPartyClient):
     # "too late" are not treated strangely
     await wait_for(client.ready(), timeout=0.1)
 
-    notifications = await client.find_nonempty(OperatorNotification, {'operator': PARTY}, min_count=5)
+    notifications = await client.find_nonempty(OperatorNotification, {'operator': client.party}, min_count=5)
     contracts_to_delete = []
     for cid, cdata in notifications.items():
         if int(cdata['text']) <= 3:

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -4,87 +4,82 @@
 import logging
 from asyncio import sleep
 
+import pytest
 from aiohttp import ClientSession
 
-from dazl import Network, sandbox, create, exercise_by_key
+from dazl import async_network, create, exercise_by_key, Network
 from dazl.model.core import Party
 from .dars import TestServer as TestServerDar
-
-
-Alice = Party("Alice")
-Bob = Party("Bob")
-Carol = Party("Carol")
 
 
 LOG = logging.getLogger('test_server')
 
 
-def test_server_endpoint():
+@pytest.mark.asyncio
+async def test_server_endpoint(sandbox):
     SERVER_PORT = 53390
-    with sandbox(TestServerDar) as proc:
-        bot_main(sandbox_url=proc.url, server_port=SERVER_PORT)
+    async with async_network(url=sandbox, dars=TestServerDar) as network:
+        network.set_config(server_port=SERVER_PORT)
+
+        alice_client = network.aio_new_party()
+        alice = alice_client.party
+
+        bob_client = network.aio_new_party()
+        bob = bob_client.party
+
+        carol_client = network.aio_new_party()
+        carol = carol_client.party
+
+        # create Person contracts for each party
+        for party in [alice, bob, carol]:
+            ensure_person_contract(network, party)
+
+        # have Bob start up "suspended"; we'll start up Bob from the outside
+        bob_bot = bob_client._impl.bots.add_new("Bob's Bot")
+        bob_bot.pause()
+
+        @bob_bot.ledger_created('TestServer.Person')
+        def bob_sends_a_message(_):
+            return exercise_by_key(
+                'TestServer:Person', bob, 'SayHello', {'receiver': alice, 'text': "Bob's ultra secret message"})
+
+        @carol_client.ledger_created('TestServer.Person')
+        def carol_sends_a_message(_):
+            return exercise_by_key(
+                'TestServer:Person', carol, 'SayHello', {'receiver': alice, 'text': "Carol's gonna Carol"})
+
+        # Carol will start Bob only once Alice has processed three events
+        await network.aio_run(client_main(network, SERVER_PORT, alice, bob, carol), keep_open=False)
 
 
 def ensure_person_contract(network: Network, party: Party):
     network.aio_party(party).add_ledger_ready(lambda _: create('TestServer:Person', dict(party=party)))
 
 
-def bot_main(sandbox_url, server_port):
-    """
-    The 'dazl app' being tested.
-    """
-
-    network = Network()
-    network.set_config(url=sandbox_url, server_port=server_port)
-
-    network.aio_party(Alice)
-    bob = network.aio_party(Bob)
-    carol = network.aio_party(Carol)
-
-    # create Person contracts for each party
-    for party in [Alice, Bob, Carol]:
-        ensure_person_contract(network, party)
-
-    # have Bob start up "suspended"; we'll start up Bob from the outside
-    bob_bot = bob._impl.bots.add_new("Bob's Bot")
-    bob_bot.pause()
-
-    @bob_bot.ledger_created('TestServer.Person')
-    def bob_sends_a_message(_):
-        return exercise_by_key(
-            'TestServer:Person', Bob, 'SayHello', {'receiver': Alice, 'text': "Bob's ultra secret message"})
-
-    @carol.ledger_created('TestServer.Person')
-    def carol_sends_a_message(_):
-        return exercise_by_key(
-            'TestServer:Person', Carol, 'SayHello', {'receiver': Alice, 'text': "Carol's gonna Carol"})
-
-    # Carol will start Bob only once Alice has processed three events
-    network.run_until_complete(client_main(network, server_port))
-
-
-async def client_main(network: Network, server_port: int):
+async def client_main(
+        network: Network, server_port: int,
+        alice: 'Party', bob: 'Party', carol: 'Party'):
     """
     The main method of a client running against the server endpoint exposed by the dazl app above.
     """
     LOG.info('client_main: started.')
     try:
         async with ClientSession() as session:
-            await wait_for_ready(session, server_port, [Alice, Bob, Carol])
+            await wait_for_ready(session, server_port, [alice, bob, carol])
 
             # start Bob from the administration endpoint
             bots_response = await session.get(f'http://localhost:{server_port}/bots')
             bots = await bots_response.json()
-            bobs_bots = [bot for bot in bots['bots'] if bot['party'] == Bob]
+            bobs_bots = [bot for bot in bots['bots'] if bot['party'] == bob]
             for bobs_bot in bobs_bots:
                 await session.post(f'http://localhost:{server_port}/bots/{bobs_bot["id"]}/state/resume')
 
             # now make sure Alice received Bob's message, and not Carol's (because Carol was never started)
-            alice = network.aio_party(Alice)
-            _, cdata = await alice.find_one('TestServer:Message')
+            alice_client = network.aio_party(alice)
+            _, cdata = await alice_client.find_one('TestServer:Message')
             LOG.info('Received message from %r: %r', cdata['sender'], cdata['text'])
 
-            all_messages = alice.find('TestServer:Message')
+            all_messages = alice_client.find('TestServer:Message')
             LOG.info('Alice has a total of %d message(s).', len(all_messages))
 
             if len(all_messages) > 1:

--- a/python/tests/unit/test_static_time.py
+++ b/python/tests/unit/test_static_time.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -9,6 +9,8 @@ import logging
 
 from asyncio import gather, get_event_loop, ensure_future
 from datetime import datetime
+
+import pytest
 
 from dazl import create, exercise, sandbox, Network, setup_default_logger
 
@@ -21,6 +23,8 @@ PARTY = 'POSTMAN'
 setup_default_logger(logging.DEBUG)
 
 
+@pytest.mark.skip(
+    "This test cannot coexist with other tests on the same sandbox because it manipulates static time.")
 def test_set_static_time():
     """
     Run a simple test involving manipulation of static time:
@@ -57,6 +61,8 @@ def test_set_static_time():
         LOG.info('Application finished.')
 
 
+@pytest.mark.skip(
+    "This test cannot coexist with other tests on the same sandbox because it manipulates static time.")
 def test_set_static_time_two_clients():
     """
     Run a slightly complicated test involving manipulation of static time and multiple clients:

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -1,33 +1,34 @@
 # Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from dazl import sandbox, exercise, Party, simple_client
+import uuid
+from dazl import exercise, Party, simple_client
 from .dars import Simple
 
 
-PARTY = Party('Operator')
+PARTY = Party(f'Operator-{uuid.uuid4()}')
 OperatorRole = 'Simple.OperatorRole'
 OperatorNotification = 'Simple.OperatorNotification'
 
 
-def test_threadsafe_methods():
-    with sandbox(Simple) as proc:
-        with simple_client(proc.url, PARTY) as client:
-            client.ready()
-            client.submit_create(OperatorRole, {'operator': PARTY})
+def test_threadsafe_methods(sandbox):
+    with simple_client(sandbox, PARTY) as client:
+        client.ensure_dar(Simple)
+        client.ready()
+        client.submit_create(OperatorRole, {'operator': PARTY})
 
-            operator_cid, _ = client.find_one(OperatorRole)
+        operator_cid, _ = client.find_one(OperatorRole)
 
-            client.submit_exercise(operator_cid, 'PublishMany', dict(count=5))
+        client.submit_exercise(operator_cid, 'PublishMany', dict(count=5))
 
-            notifications = client.find_nonempty(OperatorNotification, {'operator': PARTY}, min_count=5)
-            contracts_to_delete = []
-            for cid, cdata in notifications.items():
-                if int(cdata['text']) <= 3:
-                    contracts_to_delete.append(cid)
+        notifications = client.find_nonempty(OperatorNotification, {'operator': PARTY}, min_count=5)
+        contracts_to_delete = []
+        for cid, cdata in notifications.items():
+            if int(cdata['text']) <= 3:
+                contracts_to_delete.append(cid)
 
-            client.submit([exercise(cid, 'Archive') for cid in contracts_to_delete])
+        client.submit([exercise(cid, 'Archive') for cid in contracts_to_delete])
 
-            client.submit_exercise(operator_cid, 'PublishMany', dict(count=3))
+        client.submit_exercise(operator_cid, 'PublishMany', dict(count=3))
 
-            print(client.find_active('*'))
+        print(client.find_active('*'))


### PR DESCRIPTION
Move most of the tests to run under a single sandbox, but using different Parties.

The remaining tests that have not yet been moved over test more specialized features of dazl, so moving them over to a single sandbox instance is more complicated. Those will be addressed in a subsequent PR.

The TL;DR of the changes:

* Introduce `Network.aio_new_party` and `Network.simple_new_party`, which imply an allocation of a new `Party`. Note that the current implementation does not yet actually call `PartyManagementService`, though it may in the future. It _does_, however, guarantee that new `Party` literals are created (via `uuid`), which is useful to keep the tests isolated from each other.
* Hardcoded `Party` literals in tests have been removed.
* Allow `ensure_dar` to be created _before_ the `Network` is officially started.
* Introduce an `async_network` helper method to remove some of the more tedious boilerplate around creating a `Network`, assigning it a URL, and uploading DARs (and then waiting for those DARs to be fully uploaded).

This is a precursor to switching the tests to run against DAML SDK 1.x (as outlined by #75). As an added benefit, the tests take 7.5 minutes to run instead of 10 minutes (since Sandboxes aren't repeatedly being restarted).

