### PR TITLE
python: Upgrade tests to run under DAML SDK 1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
       - run:
           command: curl -sSL https://get.daml.com/ | sh
       - run:
-          command: PATH=$PATH:~/.daml/bin daml install 0.13.32
+          command: PATH=$PATH:~/.daml/bin daml install 1.3.0
       - save_cache:
-          key: daml-sdk-0.13.32
+          key: daml-sdk-1.3.0
           paths:
             - "~/.daml"
       - restore_cache:

--- a/_fixtures/src/all-kinds-of/daml.yaml
+++ b/_fixtures/src/all-kinds-of/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: all-kinds-of
 version: 1.0.0
 source: AllKindsOf.daml

--- a/_fixtures/src/all-party/daml.yaml
+++ b/_fixtures/src/all-party/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: all-party
 version: 1.0.0
 source: AllParty.daml

--- a/_fixtures/src/complicated/daml.yaml
+++ b/_fixtures/src/complicated/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: complicated
 version: 1.0.0
 source: Complicated.daml

--- a/_fixtures/src/dotted-fields/daml.yaml
+++ b/_fixtures/src/dotted-fields/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: dotted-fields
 version: 1.0.0
 source: DottedFields.daml

--- a/_fixtures/src/map-support/daml.yaml
+++ b/_fixtures/src/map-support/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: map-support
 version: 1.0.0
 source: MapSupport.daml

--- a/_fixtures/src/pending/daml.yaml
+++ b/_fixtures/src/pending/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: pending
 version: 1.0.0
 source: Pending.daml

--- a/_fixtures/src/post-office/daml.yaml
+++ b/_fixtures/src/post-office/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: post-office
 version: 1.0.0
 source: Main.daml

--- a/_fixtures/src/simple/daml.yaml
+++ b/_fixtures/src/simple/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: simple
 version: 1.0.0
 source: Simple.daml

--- a/_fixtures/src/test-server/daml.yaml
+++ b/_fixtures/src/test-server/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: test-server
 version: 1.0.0
 source: TestServer.daml

--- a/_fixtures/src/upload-test/daml.yaml
+++ b/_fixtures/src/upload-test/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.32
+sdk-version: 1.3.0
 name: upload-test
 version: 1.0.0
 source: UploadTest.daml

--- a/python/dazl/damlast/daml_lf_1.py
+++ b/python/dazl/damlast/daml_lf_1.py
@@ -458,7 +458,8 @@ class Type:
             tysyn: 'Callable[[Type.Syn], T]',
             forall: 'Callable[[Type.Forall], T]',
             tuple: 'Callable[[Type.Tuple], T]',
-            nat: 'Callable[[int], T]') -> 'T':
+            nat: 'Callable[[int], T]',
+            syn: 'Callable[[Type.Syn], T]') -> 'T':
         if self._Sum_name == 'var':
             return var(self._Sum_value)
         elif self._Sum_name == 'con':
@@ -473,8 +474,10 @@ class Type:
             return tuple(self._Sum_value)
         elif self._Sum_name == 'nat':
             return nat(self._Sum_value)
+        elif self._Sum_name == 'syn':
+            return syn(self._Sum_value)
         else:
-            raise Exception('invalid _Sum_name value')
+            raise Exception(f'invalid _Sum_name value: {self._Sum_name}')
 
     def __setattr__(self, key, value):
         raise Exception('Type is a read-only object')

--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -93,7 +93,8 @@ def get_old_type(daml_type: 'Type') -> 'OldType':
         _old_type_syn,
         _old_forall_type,
         lambda tuple_: UnsupportedType('Tuple'),
-        lambda nat: UnsupportedType('Nat'))
+        lambda nat: UnsupportedType('Nat'),
+        lambda _: UnsupportedType('Syn'))
 
 
 def _old_type_var(var_: 'Type.Var') -> 'OldType':

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -298,7 +298,8 @@ class DamlPrettyPrinter(PrettyPrintBase):
                 tysyn=self.visit_type_syn,
                 forall=self.visit_type_forall,
                 tuple=self.visit_type_tuple,
-                nat=self.visit_type_nat)
+                nat=self.visit_type_nat,
+                syn=self.visit_type_syn)
         elif isinstance(type, UpdateType):
             type_str = self.visit_type_prim(type)
         elif isinstance(type, ForAllType):
@@ -407,6 +408,9 @@ class DamlPrettyPrinter(PrettyPrintBase):
 
         elif PrimType.TEXTMAP == prim_type:
             return self._visit_type_app(('TextMap', *prim.args))
+
+        elif PrimType.TYPE_REP == prim.prim:
+            return '???'
 
         elif PrimType.ANY == prim_type:
             return 'Any'

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -371,6 +371,8 @@ class PythonPrettyPrint(PrettyPrintBase):
             return f'Callable[[{", ".join(type_strings[:-1])}], {type_strings[-1]}]'
         elif PrimType.TEXTMAP == prim.prim:
             return f'Map[{self.visit_type(prim.args[0])},  {self.visit_type(prim.args[1])}]'
+        elif PrimType.TYPE_REP == prim.prim:
+            return '???'
         else:
             raise ValueError(f'unknown Type.Prim: {prim!r}')
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -10,7 +10,7 @@ import subprocess
 
 from dazl.util import ProcessLogger, find_free_port, kill_process_tree, wait_for_process_port
 
-DEFAULT_SDK_VERSION = '0.13.32'
+DEFAULT_SDK_VERSION = '1.3.0'
 SANDBOX_START_TIMEOUT = timedelta(seconds=10)
 
 
@@ -45,7 +45,7 @@ def sandbox() -> str:
     # Running dazl's tests against a different Sandbox merely requires the DAML_SDK_VERSION
     # variable be set to a different value
     if 'DAML_SDK_VERSION' not in env:
-        env['DAML_SDK_VERSION'] = '0.13.32'
+        env['DAML_SDK_VERSION'] = DEFAULT_SDK_VERSION
 
     process = subprocess.Popen(
         ['daml', 'sandbox', '--port', str(port)],

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -8,4 +8,4 @@ from .dars import Pending
 def test_get_sdk_version():
     with DarFile(Pending) as dar:
         print(dar.get_manifest())
-        assert '0.13.32' == dar.get_sdk_version()
+        assert '1.3.0' == dar.get_sdk_version()


### PR DESCRIPTION
python: Upgrade tests to run under DAML SDK 1.3.0, and include some minor bug fixes for some of the more esoteric parts of the codebase that had incompatibilities with 1.3.0 that had gone undetected to this point.