### PR TITLE
python: Drop support for offsets in pre-DAML 1.0 ledgers.

### DIFF
--- a/python/dazl/client/_reader_sync.py
+++ b/python/dazl/client/_reader_sync.py
@@ -5,7 +5,7 @@ from asyncio import ensure_future, gather, sleep, Future
 from typing import Collection, List, Optional, Tuple, TYPE_CHECKING
 
 from .. import LOG
-from ..model.reading import sortable_offset_height, max_offset
+from ..model.reading import max_offset
 from ..util.asyncio_util import completed, named_gather
 
 if TYPE_CHECKING:
@@ -113,7 +113,7 @@ async def read_transactions(
            successfully or unsuccessfully.
     """
     tuples = await gather(*(pi.read_transactions(until_offset, raise_events) for pi in party_impls))
-    offsets = sorted({t[0] for t in tuples}, key=sortable_offset_height)
+    offsets = sorted({t[0] for t in tuples})
     futures = [ensure_future(t[1]) for t in tuples]
     futures = [fut for fut in futures if not fut.done()]
     if not futures:

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -211,6 +211,11 @@ class TransactionFilter:
     max_blocks: Optional[int]
     party_groups: Optional[Collection[str]]
 
+    def __post_init__(self):
+        if self.current_offset is not None and self.destination_offset is not None:
+            if self.current_offset > self.destination_offset:
+                raise ValueError('current_offset must be before destination_offset if both are specified')
+
 
 class EventKey:
 
@@ -314,19 +319,4 @@ def max_offset(offsets: 'Collection[str]') -> 'Optional[str]':
     :param offsets: A collection of offsets to examine.
     :return: The largest offset, or ``None`` if unknown.
     """
-    return max(offsets, key=sortable_offset_height) if offsets else None
-
-
-def sortable_offset_height(value: str) -> 'str':
-    if value:
-        try:
-            components = value.split('-', 3)
-            if len(components) == 1:
-                return f'{int(value):016d}'
-            elif len(components) >= 1:
-                return f'{int(components[1]):016d}'
-        except ValueError:
-            # newer versions of the DAML SDK no longer return offsets in a parseable format, but
-            # the strings themselves are naturally comparable
-            return value
-    return 0
+    return max(offsets) if offsets else None


### PR DESCRIPTION
The logic for `sortable_offset_height` was more complicated in pre-DAML SDK 1.0.0 ledgers:

https://github.com/digital-asset/daml/blob/6f8c3ad832ee0fa0c234c30d7312f73e703760f4/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/ledger_offset.proto#L17-L21

In post-DAML SDK 1.0.0 ledgers, the logic is much more straightforward:

https://github.com/digital-asset/daml/blob/f050da78c9c8727b889bdac286156f19e2f938c4/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_offset.proto#L17-L18

Drop the pre-DAML SDK 1.0.0 implementation as older ledgers are no longer supported.