### PR TITLE
python: Drop support for historical template formats.

### DIFF
--- a/_fixtures/src/post-office/integration-test.py
+++ b/_fixtures/src/post-office/integration-test.py
@@ -93,23 +93,23 @@ def run_test(url, keepalive=False):
 
     post_office = PostOffice()
 
-    postman_client.add_ledger_ready(lambda event: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
-    postman_client.add_ledger_created('Main.PostmanRole', lambda event: [exercise(event.cid, 'InviteParticipant', m) for m in members])
-    postman_client.add_ledger_created('Main.UnsortedLetter', post_office.sort_and_deliver_letter)
-    postman_client.add_ledger_created('Main.ReceiverRole', post_office.register_address)
-    postman_client.add_ledger_created('Main.SortedLetter', lambda event: exercise(event.cid, 'Deliver'))
+    postman_client.add_ledger_ready(lambda event: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
+    postman_client.add_ledger_created('Main:PostmanRole', lambda event: [exercise(event.cid, 'InviteParticipant', m) for m in members])
+    postman_client.add_ledger_created('Main:UnsortedLetter', post_office.sort_and_deliver_letter)
+    postman_client.add_ledger_created('Main:ReceiverRole', post_office.register_address)
+    postman_client.add_ledger_created('Main:SortedLetter', lambda event: exercise(event.cid, 'Deliver'))
 
-    @postman_client.ledger_exercised('Main.PostmanRole', 'InviteParticipant')
+    @postman_client.ledger_exercised('Main:PostmanRole', 'InviteParticipant')
     def log(event):
         LOG.info('Observing the exercise of an InviteParticipant: %s', event)
 
     for member_client in member_clients:
         bot = PartyBot(member_client.party)
         # every member automatically accepts
-        member_client.add_ledger_created('Main.InviteAuthorRole', lambda event: exercise(event.cid, 'AcceptInviteAuthorRole'))
-        member_client.add_ledger_created('Main.InviteReceiverRole', lambda event: exercise(event.cid, 'AcceptInviteReceiverRole'))
+        member_client.add_ledger_created('Main:InviteAuthorRole', lambda event: exercise(event.cid, 'AcceptInviteAuthorRole'))
+        member_client.add_ledger_created('Main:InviteReceiverRole', lambda event: exercise(event.cid, 'AcceptInviteReceiverRole'))
         # every member, upon joining, sends messages to five of their best friends
-        member_client.add_ledger_created('Main.AuthorRole', bot.send_to_five_friends)
+        member_client.add_ledger_created('Main:AuthorRole', bot.send_to_five_friends)
 
     try:
         if not keepalive:

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -243,8 +243,9 @@ class Network:
 
         The current thread does NOT block.
 
-        :return: ``None`` unless ``start()`` was called, in which case the coroutine that
-        corresponds to dazl's "main" is returned.
+        :return:
+            ``None`` unless ``start()`` was called, in which case the coroutine that
+            corresponds to dazl's "main" is returned.
         """
         self._impl.shutdown()
         return self._main_fut

--- a/python/dazl/damlast/daml_lf_1.py
+++ b/python/dazl/damlast/daml_lf_1.py
@@ -4,7 +4,6 @@
 # NOTE TO IMPLEMENTORS: A future version of this file is intended to be code-generated instead of
 # manually maintained. The makeup of this file is intentionally highly formulaic in order to
 # facilitate a smooth transition to automatically-generated data structures.
-import warnings
 
 from dataclasses import dataclass
 from enum import Enum
@@ -59,18 +58,6 @@ class ModuleRef:
         self._package_id = PackageRef(safe_cast(str, package_id))
         self._module_name = safe_cast(DottedName, module_name)
 
-    @property
-    def package_id(self) -> 'PackageRef':
-        warnings.warn(
-            "Do not use ModuleRef.package_id; use package_ref(...) instead.", DeprecationWarning)
-        return self._package_id
-
-    @property
-    def module_name(self) -> 'DottedName':
-        warnings.warn(
-            "Do not use ModuleRef.module_name; use module_name(...) instead.", DeprecationWarning)
-        return self._module_name
-
     def __eq__(self, other):
         return isinstance(other, ModuleRef) and \
                self._package_id == other._package_id and \
@@ -123,36 +110,6 @@ class _Name:
 
         self._module = safe_cast(ModuleRef, module)
         self._name = tuple(name)  # type: Tuple[str, ...]
-
-    @property
-    def module(self) -> 'ModuleRef':
-        warnings.warn(
-            "Do not use Name.module; you can use module_ref(...) instead.",
-            DeprecationWarning)
-        return self._module
-
-    @property
-    def name(self) -> 'Sequence[str]':
-        warnings.warn(
-            "Do not use Name.name; you can use module_local_name(...) instead.",
-            DeprecationWarning)
-        return self._name
-
-    @property
-    def full_name(self) -> str:
-        from .util import module_name
-        warnings.warn(
-            "Do not use Name.full_name; this format is no longer used, so it has no replacement.",
-            DeprecationWarning)
-        return f"{module_name(self)}.{'.'.join(self._name)}"
-
-    @property
-    def full_name_unambiguous(self):
-        from .util import package_local_name
-        warnings.warn(
-            "Do not use Name.full_name_unambiguous; use package_local_name(...) instead.",
-            DeprecationWarning)
-        return package_local_name(self)
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and \

--- a/python/dazl/model/types.py
+++ b/python/dazl/model/types.py
@@ -27,7 +27,6 @@ system.
 .. autoclass:: VariantType
 .. autoclass:: UnsupportedType
 """
-import warnings
 from typing import AbstractSet, Any, Callable, Collection, Dict, Mapping, NewType, Optional, \
     Sequence, Tuple, TypeVar, Union, TYPE_CHECKING
 
@@ -259,40 +258,6 @@ class TypeVariable(Type):
 class TypeReference(Type):
     def __init__(self, con: 'TypeConName'):
         self.con = con
-
-    @property
-    def module(self) -> 'ModuleRef':
-        from ..damlast.util import module_ref
-        warnings.warn(
-            "Do not use TypeReference.module; you can use module_ref(...) instead.",
-            DeprecationWarning)
-        return module_ref(self)
-
-    @property
-    def name(self) -> 'Sequence[str]':
-        warnings.warn(
-            "Do not use TypeReference.name; you can use module_local_name(...) instead.",
-            DeprecationWarning)
-        # noinspection PyProtectedMember
-        return self.con._name
-
-    @property
-    def full_name(self):
-        warnings.warn(
-            'Do not use TypeReference.full_name; this format is no longer used, "'
-            'so it has no replacement.', DeprecationWarning)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            return self.con.full_name
-
-    @property
-    def full_name_unambiguous(self):
-        from ..damlast.util import package_local_name
-        warnings.warn(
-            "Do not use TypeReference.full_name_unambiguous; use package_local_name(...) instead.",
-            DeprecationWarning)
-        return package_local_name(self)
 
     def __str__(self):
         return str(self.con)

--- a/python/dazl/protocols/v1/pb_parse_event.py
+++ b/python/dazl/protocols/v1/pb_parse_event.py
@@ -13,15 +13,16 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 from google.protobuf.empty_pb2 import Empty
 
 from ... import LOG
+from ...damlast.daml_lf_1 import ModuleRef, PackageRef, DottedName, TypeConName
 from ...model.core import ContractId
 from ...model.reading import BaseEvent, TransactionFilter, ContractCreateEvent, \
     TransactionStartEvent, TransactionEndEvent, ContractArchiveEvent, OffsetEvent, \
     ContractExercisedEvent, ActiveContractSetEvent
 from ...model.core import Party
 from ...model.types import RecordType, Type, VariantType, ContractIdType, ListType, \
-    TypeEvaluationContext, type_evaluate_dispatch_default_error, TextMapType, OptionalType
+    TypeEvaluationContext, type_evaluate_dispatch_default_error, TextMapType, OptionalType, TypeReference
 from ...model.types_store import PackageStore
-from ...util.prim_types import to_date, to_datetime, to_hashable, frozendict
+from ...util.prim_types import to_date, to_datetime
 
 
 @dataclass(frozen=True)
@@ -306,11 +307,10 @@ def to_created_event(
         context: 'Union[TransactionEventDeserializationContext, ActiveContractSetEventDeserializationContext]',
         cr: 'G.CreatedEvent') \
         -> 'Optional[ContractCreateEvent]':
-    search_str = f'{cr.template_id.module_name}:{cr.template_id.entity_name}@{cr.template_id.package_id}'
-
-    candidates = context.store.resolve_template_type(search_str)
+    type_ref = to_type_ref(cr.template_id)
+    candidates = context.store.resolve_template_type(type_ref)
     if len(candidates) == 0:
-        LOG.warning('Could not find metadata for %s!', search_str)
+        LOG.warning('Could not find metadata for %s!', type_ref)
         return None
     elif len(candidates) > 1:
         LOG.error('The template identifier %s is not unique within its metadata!', candidates)
@@ -332,11 +332,10 @@ def to_exercised_event(
         context: 'TransactionEventDeserializationContext',
         er: 'G.ExercisedEvent') \
         -> 'Optional[ContractExercisedEvent]':
-    search_str = f'{er.template_id.module_name}:{er.template_id.entity_name}@{er.template_id.package_id}'
-
-    candidates = context.store.resolve_template_type(search_str)
+    type_ref = to_type_ref(er.template_id)
+    candidates = context.store.resolve_template_type(type_ref)
     if len(candidates) == 0:
-        LOG.warning('Could not find metadata for %s!', search_str)
+        LOG.warning('Could not find metadata for %s!', type_ref)
         return None
     elif len(candidates) > 1:
         LOG.error('The template identifier %s is not unique within its metadata!', candidates)
@@ -347,7 +346,7 @@ def to_exercised_event(
     tt_context = TypeEvaluationContext.from_store(context.store)
     choice_candidates = context.store.resolve_choice(type_ref, er.choice)
     if len(candidates) == 0:
-        LOG.warning('Could not find metadata for %s!', search_str)
+        LOG.warning('Could not find metadata for %s!', type_ref)
         return None
     elif len(candidates) > 1:
         LOG.error('The template identifier %s is not unique within its metadata!', candidates)
@@ -378,11 +377,10 @@ def to_archived_event(
         context: 'TransactionEventDeserializationContext',
         ar: 'G.ArchivedEvent') \
         -> 'Optional[ContractArchiveEvent]':
-    search_str = f'{ar.template_id.module_name}:{ar.template_id.entity_name}@{ar.template_id.package_id}'
-
-    candidates = context.store.resolve_template_type(search_str)
+    type_ref = to_type_ref(ar.template_id)
+    candidates = context.store.resolve_template_type(type_ref)
     if len(candidates) == 0:
-        LOG.warning('Could not find metadata for %s!', search_str)
+        LOG.warning('Could not find metadata for %s!', type_ref)
         return None
     elif len(candidates) > 1:
         LOG.error('The template identifier %s is not unique within its metadata!', candidates)
@@ -394,6 +392,16 @@ def to_archived_event(
 
     cid = ContractId(ar.contract_id, type_ref)
     return context.contract_archived_event(cid, None, event_id, witness_parties)
+
+
+def to_type_ref(identifier: 'G.Identifier') -> 'TypeReference':
+    return TypeReference(
+        TypeConName(
+            ModuleRef(
+                PackageRef(identifier.package_id),
+                DottedName(identifier.module_name.split('.'))
+            ),
+            DottedName(identifier.entity_name.split('.')).segments))
 
 
 def to_natural_type(context: TypeEvaluationContext, data_type: Type, obj: 'G.Value') -> Any:

--- a/python/tests/profiling/test_memory.py
+++ b/python/tests/profiling/test_memory.py
@@ -22,7 +22,7 @@ def main(url: str):
 
     test_party = network.aio_party('TestA')
     test_party.add_ledger_ready(ready)
-    test_party.add_ledger_created('Main.PostmanRole', created)
+    test_party.add_ledger_created('Main:PostmanRole', created)
 
     other_party = network.aio_party('TestB')
     other_party.add_ledger_ready(ready)
@@ -34,7 +34,7 @@ def main(url: str):
 
 def ready(event: ReadyEvent):
     print('The ledger is now ready.')
-    return create('Main.PostmanRole', {'postman': event.party})
+    return create('Main:PostmanRole', {'postman': event.party})
 
 
 def created(event: ContractCreateEvent):

--- a/python/tests/tutorials/post_office/tutorial.py
+++ b/python/tests/tutorials/post_office/tutorial.py
@@ -42,7 +42,7 @@ def create_postman():
         with create_client(parties=all_parties, participant_url=url) as client_mgr:
             postman_client = client_mgr.new_client(POSTMAN_PARTY)
             postman_client.on_ready(
-                lambda _, __: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
+                lambda _, __: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
 
             ledger_run = client_mgr.run_until_complete()
             return ledger_run.exit_code
@@ -62,7 +62,7 @@ def inspect_ledger():
             try:
                 postman_client = client_mgr.new_client(POSTMAN_PARTY)
                 postman_client.on_ready(
-                    lambda _, __: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
+                    lambda _, __: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
 
                 client_mgr.register(inspector)
 
@@ -97,9 +97,9 @@ def invite_participants():
     def set_up(client_mgr, members):
         postman_client = client_mgr.new_client(POSTMAN_PARTY)
         postman_client.on_ready(
-            lambda _, __: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
+            lambda _, __: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
         postman_client.on_created(
-            'Main.PostmanRole',
+            'Main:PostmanRole',
             lambda cid, cdata: [cid.exercise('InviteParticipant', m) for m in members])
 
     def address(index):
@@ -138,18 +138,18 @@ def accept_invites():
     def set_up(client_mgr, members):
         postman_client = client_mgr.new_client(POSTMAN_PARTY)
         postman_client.on_ready(
-            lambda _, __: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
+            lambda _, __: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
         postman_client.on_created(
-            'Main.PostmanRole',
+            'Main:PostmanRole',
             lambda cid, cdata: [cid.exercise('InviteParticipant', m) for m in members])
 
         member_clients = [client_mgr.new_client(m['party']) for m in members]
         for member_client in member_clients:
             # every member automatically accepts
             member_client.on_created(
-                'Main.InviteAuthorRole', lambda cid, cdata: cid.exercise('AcceptInviteAuthorRole'))
+                'Main:InviteAuthorRole', lambda cid, cdata: cid.exercise('AcceptInviteAuthorRole'))
             member_client.on_created(
-                'Main.InviteReceiverRole', lambda cid, cdata: cid.exercise('AcceptInviteReceiverRole'))
+                'Main:InviteReceiverRole', lambda cid, cdata: cid.exercise('AcceptInviteReceiverRole'))
     # DOC_END: ACCEPT_INVITES
     return final_run_test(set_up)
 
@@ -164,20 +164,20 @@ def send_letters():
     def set_up(client_mgr, members):
         postman_client = client_mgr.new_client(POSTMAN_PARTY)
         postman_client.on_ready(
-            lambda _, __: create('Main.PostmanRole', dict(postman=POSTMAN_PARTY)))
+            lambda _, __: create('Main:PostmanRole', dict(postman=POSTMAN_PARTY)))
         postman_client.on_created(
-            'Main.PostmanRole',
+            'Main:PostmanRole',
             lambda cid, cdata: [cid.exercise('InviteParticipant', m) for m in members])
 
         member_clients = [client_mgr.new_client(m['party']) for m in members]
         for member_client in member_clients:
             # every member automatically accepts
             member_client.on_created(
-                'Main.InviteAuthorRole', lambda cid, cdata: cid.exercise('AcceptInviteAuthorRole'))
+                'Main:InviteAuthorRole', lambda cid, cdata: cid.exercise('AcceptInviteAuthorRole'))
             member_client.on_created(
-                'Main.InviteReceiverRole', lambda cid, cdata: cid.exercise('AcceptInviteReceiverRole'))
+                'Main:InviteReceiverRole', lambda cid, cdata: cid.exercise('AcceptInviteReceiverRole'))
             member_client.on_created(
-                'Main.AuthorRole', partial(send_five_letters, member_client.party_name))
+                'Main:AuthorRole', partial(send_five_letters, member_client.party_name))
 
     def send_five_letters(party_name, cid, cdata):
         if party_name == cdata['author']:

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -10,8 +10,8 @@ from dazl import async_network, create, Party
 
 from .dars import AllParty as AllPartyDar
 
-PrivateContract = 'AllParty.PrivateContract'
-PublicContract = 'AllParty.PublicContract'
+PrivateContract = 'AllParty:PrivateContract'
+PublicContract = 'AllParty:PublicContract'
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -10,7 +10,7 @@ from dazl import create, async_network
 from .dars import AllKindsOf
 
 
-TEMPLATE = 'AllKindsOf.OneOfEverything'
+TEMPLATE = 'AllKindsOf:OneOfEverything'
 SOME_ARGS = dict(
     operator=None,  # this is filled in by each of the tests because Party allocation is random
     someBoolean=True,
@@ -60,7 +60,7 @@ async def test_maps(sandbox):
 
         network.start()
 
-        await client.submit_create('AllKindsOf.MappyContract', {
+        await client.submit_create('AllKindsOf:MappyContract', {
             'operator': client.party,
             'value': {'Map_internal': []}
         })

--- a/python/tests/unit/test_complicated_types.py
+++ b/python/tests/unit/test_complicated_types.py
@@ -11,8 +11,8 @@ from .dars import Complicated as ComplicatedDar
 
 
 class Complicated:
-    OperatorRole = 'Complicated.OperatorRole'
-    OperatorFormulaNotification = 'Complicated.OperatorFormulaNotification'
+    OperatorRole = 'Complicated:OperatorRole'
+    OperatorFormulaNotification = 'Complicated:OperatorFormulaNotification'
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -15,7 +15,7 @@ async def test_record_dotted_fields_submit(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create('DottedFields.American', {
+        await client.submit_create('DottedFields:American', {
             'person': client.party,
             'address.address': '1 Test Place',
             'address.city': 'Somewhere',
@@ -23,7 +23,7 @@ async def test_record_dotted_fields_submit(sandbox):
             'address.zip': '99999'
         })
 
-        items = client.find_active('DottedFields.American')
+        items = client.find_active('DottedFields:American')
         assert len(items) == 1
 
 
@@ -35,7 +35,7 @@ async def test_variant_dotted_fields_submit(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create('DottedFields.Person', {
+        await client.submit_create('DottedFields:Person', {
             'person': client.party,
             'address.US.address': '1 Test Place',
             'address.US.city': 'Somewhere',
@@ -48,5 +48,5 @@ async def test_variant_dotted_fields_submit(sandbox):
             'address.UK.postcode': '',
         })
 
-        items = client.find_active('DottedFields.Person')
+        items = client.find_active('DottedFields:Person')
         assert len(items) == 1

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -1,6 +1,5 @@
-# Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-import logging
 import uuid
 
 import pytest
@@ -21,22 +20,22 @@ async def test_parties_can_be_added_after_run_forever(sandbox):
 
         @operator_client.ledger_ready()
         def operator_ready(event):
-            return create('Main.PostmanRole', {'postman': event.party})
+            return create('Main:PostmanRole', {'postman': event.party})
 
-        @operator_client.ledger_created('Main.PostmanRole')
+        @operator_client.ledger_created('Main:PostmanRole')
         def operator_role_created(event):
             return [exercise(event.cid, 'InviteParticipant', {'party': party, 'address': 'whatevs'})
                     for party in (party_a_client.party, party_b_client.party, party_c_party)]
 
-        @party_a_client.ledger_created('Main.InviteAuthorRole')
+        @party_a_client.ledger_created('Main:InviteAuthorRole')
         async def party_a_accept_invite(_):
             party_c = network.aio_party(party_c_party)
 
-            @party_c.ledger_created('Main.AuthorRole')
+            @party_c.ledger_created('Main:AuthorRole')
             def party_c_role_created(_):
                 network.shutdown()
 
-            cid, cdata = await party_c.find_one('Main.InviteAuthorRole')
+            cid, cdata = await party_c.find_one('Main:InviteAuthorRole')
             party_c.submit_exercise(cid, 'AcceptInviteAuthorRole')
 
         network.start()

--- a/python/tests/unit/test_event_order.py
+++ b/python/tests/unit/test_event_order.py
@@ -14,8 +14,8 @@ PARTY_COUNT = 10
 
 
 class Simple:
-    OperatorRole = 'Simple.OperatorRole'
-    OperatorNotification = 'Simple.OperatorNotification'
+    OperatorRole = 'Simple:OperatorRole'
+    OperatorNotification = 'Simple:OperatorNotification'
 
 
 def test_event_order(sandbox):

--- a/python/tests/unit/test_flask.py
+++ b/python/tests/unit/test_flask.py
@@ -52,12 +52,12 @@ def create_initial_state(event: 'ReadyEvent'):
     try:
         LOG.info('Uploading our DAR...')
         event.client.ensure_dar(PostOffice)
-        while not event.package_store.resolve_template('Main.PostmanRole'):
+        while not event.package_store.resolve_template('Main:PostmanRole'):
             logging.info("Waiting for our DAR to be uploaded...")
             sleep(1)
 
         LOG.info('DAR uploaded. Creating the initial postman role contract...')
-        return create('Main.PostmanRole', dict(postman=event.party))
+        return create('Main:PostmanRole', dict(postman=event.party))
     except:
         LOG.exception('Failed to set up our initial state!')
 
@@ -74,7 +74,7 @@ def run_flask_app(client: SimplePartyClient, port: int) -> None:
         func = request.environ.get('werkzeug.server.shutdown')
         func()
 
-        cid, cdata = client.find_one('Main.PostmanRole')
+        cid, cdata = client.find_one('Main:PostmanRole')
         return jsonify(cdata)
 
     app.run(host='localhost', port=port)

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -16,7 +16,7 @@ async def test_map_support(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create('MapSupport.Sample', {
+        await client.submit_create('MapSupport:Sample', {
             'party': client.party,
             'mappings': {
                 '65': 'A',
@@ -35,7 +35,7 @@ async def test_complicated_map_support(sandbox):
         client = network.aio_new_party()
 
         await client.ready()
-        await client.submit_create('MapSupport.ComplicatedSample', {
+        await client.submit_create('MapSupport:ComplicatedSample', {
             'party': 'Test',
             # Note: Python `dict`s are not hashable, so the only way to write this out
             # is to create a special dict as a key

--- a/python/tests/unit/test_pb_serialize.py
+++ b/python/tests/unit/test_pb_serialize.py
@@ -43,11 +43,11 @@ def dar_fixture() -> 'DarFixture':
 def test_serialize_create(dar_fixture):
     sut = ProtobufSerializer(dar_fixture.store)
 
-    command = CreateCommand('Pending.AccountRequest', dict(owner='SomeParty'))
+    command = CreateCommand('Pending:AccountRequest', dict(owner='SomeParty'))
 
     expected = G.Command()
     expected.create.template_id.MergeFrom(
-        dar_fixture.get_identifier('Pending.AccountRequest'))
+        dar_fixture.get_identifier('Pending:AccountRequest'))
     expected.create.create_arguments.fields.append(
         G.RecordField(label='owner', value=G.Value(party='SomeParty')))
     actual = sut.serialize_command(command)
@@ -58,14 +58,14 @@ def test_serialize_create(dar_fixture):
 def test_serialize_exercise(dar_fixture):
     sut = ProtobufSerializer(dar_fixture.store)
 
-    tref = dar_fixture.get_template_type('Pending.AccountRequest')
+    tref = dar_fixture.get_template_type('Pending:AccountRequest')
     cid = ContractId('#1:0', tref)
     command = ExerciseCommand(cid, 'CreateAccount', dict(accountId=42))
 
     expected = G.Command()
     expected.exercise.contract_id = '#1:0'
     expected.exercise.template_id.MergeFrom(
-        dar_fixture.get_identifier('Pending.AccountRequest'))
+        dar_fixture.get_identifier('Pending:AccountRequest'))
     expected.exercise.choice = 'CreateAccount'
     expected.exercise.choice_argument.record.fields.append(
         G.RecordField(label='accountId', value=G.Value(int64=42)))
@@ -77,11 +77,11 @@ def test_serialize_exercise(dar_fixture):
 def test_serialize_exercise_by_key(dar_fixture):
     sut = ProtobufSerializer(dar_fixture.store)
 
-    command = ExerciseByKeyCommand('Pending.Counter', 'SomeParty', 'Increment', {})
+    command = ExerciseByKeyCommand('Pending:Counter', 'SomeParty', 'Increment', {})
 
     expected = G.Command()
     expected.exerciseByKey.template_id.MergeFrom(
-        dar_fixture.get_identifier('Pending.Counter'))
+        dar_fixture.get_identifier('Pending:Counter'))
     expected.exerciseByKey.contract_key.party = 'SomeParty'
     expected.exerciseByKey.choice = 'Increment'
     expected.exerciseByKey.choice_argument.record.SetInParent()
@@ -94,11 +94,11 @@ def test_serialize_create_and_exercise(dar_fixture):
     sut = ProtobufSerializer(dar_fixture.store)
 
     command = CreateAndExerciseCommand(
-        'Pending.AccountRequest', dict(owner='SomeParty'), 'CreateAccount', dict(accountId=42))
+        'Pending:AccountRequest', dict(owner='SomeParty'), 'CreateAccount', dict(accountId=42))
 
     expected = G.Command()
     expected.createAndExercise.template_id.MergeFrom(
-        dar_fixture.get_identifier('Pending.AccountRequest'))
+        dar_fixture.get_identifier('Pending:AccountRequest'))
     expected.createAndExercise.create_arguments.fields.append(
         G.RecordField(label='owner', value=G.Value(party='SomeParty')))
     expected.createAndExercise.choice = 'CreateAccount'

--- a/python/tests/unit/test_pending.py
+++ b/python/tests/unit/test_pending.py
@@ -5,11 +5,11 @@ import pytest
 from dazl import async_network, create, exercise
 from .dars import Pending
 
-Counter = 'Pending.Counter'
-Account = 'Pending.Account'
-AccountRequest = 'Pending.AccountRequest'
+Counter = 'Pending:Counter'
+Account = 'Pending:Account'
+AccountRequest = 'Pending:AccountRequest'
 
-OperatorNotification = 'Simple.OperatorNotification'
+OperatorNotification = 'Simple:OperatorNotification'
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/test_select.py
+++ b/python/tests/unit/test_select.py
@@ -5,8 +5,8 @@ from dazl import async_network, create, exercise
 from .dars import Simple
 import pytest
 
-OperatorRole = 'Simple.OperatorRole'
-OperatorNotification = 'Simple.OperatorNotification'
+OperatorRole = 'Simple:OperatorRole'
+OperatorNotification = 'Simple:OperatorNotification'
 
 
 @pytest.mark.asyncio
@@ -32,7 +32,7 @@ async def test_select_unknown_template_retrieves_empty_set(sandbox):
 
         await client.submit_create(OperatorRole, {'operator': client.party})
 
-        data = client.find_active('NonExistentTemplate')
+        data = client.find_active('NonExistentModule:NonExistentTemplate')
 
     assert len(data) == 0
 

--- a/python/tests/unit/test_select_nonempty.py
+++ b/python/tests/unit/test_select_nonempty.py
@@ -9,8 +9,8 @@ from dazl import async_network, exercise, AIOPartyClient
 from .dars import Simple
 
 
-OperatorRole = 'Simple.OperatorRole'
-OperatorNotification = 'Simple.OperatorNotification'
+OperatorRole = 'Simple:OperatorRole'
+OperatorNotification = 'Simple:OperatorNotification'
 
 
 @pytest.mark.asyncio

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -38,12 +38,12 @@ async def test_server_endpoint(sandbox):
         bob_bot = bob_client._impl.bots.add_new("Bob's Bot")
         bob_bot.pause()
 
-        @bob_bot.ledger_created('TestServer.Person')
+        @bob_bot.ledger_created('TestServer:Person')
         def bob_sends_a_message(_):
             return exercise_by_key(
                 'TestServer:Person', bob, 'SayHello', {'receiver': alice, 'text': "Bob's ultra secret message"})
 
-        @carol_client.ledger_created('TestServer.Person')
+        @carol_client.ledger_created('TestServer:Person')
         def carol_sends_a_message(_):
             return exercise_by_key(
                 'TestServer:Person', carol, 'SayHello', {'receiver': alice, 'text': "Carol's gonna Carol"})

--- a/python/tests/unit/test_simple_client_api.py
+++ b/python/tests/unit/test_simple_client_api.py
@@ -15,7 +15,7 @@ def test_simple_client_api(sandbox):
     with simple_client(url=sandbox, party=party) as client:
         client.ready()
         logging.info('Submitting...')
-        client.submit_create('Main.PostmanRole', {'postman': party})
+        client.submit_create('Main:PostmanRole', {'postman': party})
         logging.info('getting contracts')
         contracts = client.find_active('*')
         logging.info('got the contracts')

--- a/python/tests/unit/test_static_dump.py
+++ b/python/tests/unit/test_static_dump.py
@@ -26,6 +26,6 @@ async def test_static_dump_and_tail(sandbox):
         await client.ready()
 
         for i in range(0, 5):
-            await client.submit_create('Main.PostmanRole', {'postman': client.party})
+            await client.submit_create('Main:PostmanRole', {'postman': client.party})
 
     assert len(seen_contracts) == 5

--- a/python/tests/unit/test_template_reverse_globs.py
+++ b/python/tests/unit/test_template_reverse_globs.py
@@ -16,18 +16,6 @@ def test_primary_simple_unknown_module():
     assert expected == actual
 
 
-def test_non_primary_simple_unknown_module_deprecated_style():
-    expected = ['*:MyModule:MyTemplate', '*:MyModule.MyTemplate', '*:*']
-    actual = list(template_reverse_globs(False, '*', 'MyModule.MyTemplate'))
-    assert expected == actual
-
-
-def test_primary_simple_unknown_module_deprecated_style():
-    expected = ['*:MyModule:MyTemplate']
-    actual = list(template_reverse_globs(True, '*', 'MyModule.MyTemplate'))
-    assert expected == actual
-
-
 def test_non_primary_simple_known_module():
     expected = ['0000dead0000beef:MyModule:MyTemplate', '0000dead0000beef:*', '*:MyModule:MyTemplate', '*:*']
     actual = list(template_reverse_globs(False, '0000dead0000beef', 'MyModule:MyTemplate'))

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -6,8 +6,8 @@ from .blocking_setup import blocking_setup
 from .dars import Simple
 
 
-OperatorRole = 'Simple.OperatorRole'
-OperatorNotification = 'Simple.OperatorNotification'
+OperatorRole = 'Simple:OperatorRole'
+OperatorNotification = 'Simple:OperatorNotification'
 
 
 def test_threadsafe_methods(sandbox):


### PR DESCRIPTION
Drop support for template references of the form `PKG:MODULE.ENTITY` (with a dot between modules and entities) and exclusively support `PKG:MODULE:ENTITY`(with a colon between modules and entities).

Annoyingly, most of the tests still used the old format given their age, so the majority of files touched were the tests.