### PR TITLE
python: Fix handling of Enum values.

### DIFF
--- a/_fixtures/src/all-kinds-of/AllKindsOf.daml
+++ b/_fixtures/src/all-kinds-of/AllKindsOf.daml
@@ -15,6 +15,9 @@ data MyPair a = MyPair with left: a; right: a
 data VPair a = Left a | Right a | Both (VPair a)
     deriving (Eq, Show)
 
+data Color = Red | Green | Blue
+    deriving (Eq, Show)
+
 template OneOfEverything
   with
     operator: Party
@@ -31,6 +34,7 @@ template OneOfEverything
     someNestedPair: MyPair (MyPair Int)
     someUglyNesting: VPair (MyPair (MyPair Int))
     someMeasurement: Measurement
+    someEnum: Color
     theUnit: ()
   where
     signatory operator

--- a/python/dazl/protocols/v1/pb_parse_event.py
+++ b/python/dazl/protocols/v1/pb_parse_event.py
@@ -503,8 +503,8 @@ def to_optional(context: TypeEvaluationContext, tt: Type, optional: 'G.Optional'
     return type_evaluate_dispatch_default_error(on_optional=process)(context, tt)
 
 
-def to_enum(enum: str) -> str:
-    return enum
+def to_enum(enum: 'Union[str, G.Enum]') -> str:
+    return getattr(enum, 'constructor', enum)
 
 
 def to_int64(int64: int) -> int:

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -26,6 +26,7 @@ SOME_ARGS = dict(
     someNestedPair=dict(left=dict(left=1, right=2), right=dict(left=3, right=4)),
     someUglyNesting=dict(Both=dict(Left=dict(left=dict(left=1, right=2), right=dict(left=3, right=4)))),
     someMeasurement=Decimal(10.0),
+    someEnum='Green',
     theUnit=dict())
 
 


### PR DESCRIPTION
Fix a problem that caused `Enum` Protobuf values not to be unpacked properly.