### PR TITLE
python: Miscellaneous small fixes/additions.

### DIFF
--- a/python/dazl/damlast/visitor.py
+++ b/python/dazl/damlast/visitor.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 from .daml_lf_1 import Expr, Type, ValName, BuiltinFunction, PrimCon, PrimLit, Case, Block, Update, \
     Scenario, Package, Module, FieldWithType, FieldWithExpr, VarWithType, Binding
 

--- a/python/dazl/model/types.py
+++ b/python/dazl/model/types.py
@@ -667,7 +667,7 @@ class TypeEvaluationContext:
     def resolve_var(self, var: TypeVariable) -> Type:
         return self.variables[var]
 
-    def with_vars(self, new_vars: Dict[TypeVariable, Type]) -> 'TypeEvaluationContext':
+    def with_vars(self, new_vars: 'Dict[TypeVariable, Type]') -> 'TypeEvaluationContext':
         confirmed_new_vars = {}
         for new_var, new_var_value in new_vars.items():
             if new_var == new_var_value:

--- a/python/dazl/model/writing.py
+++ b/python/dazl/model/writing.py
@@ -473,10 +473,10 @@ class AbstractSerializer(Serializer[TCommand, TValue]):
             LOG.warning('    %r', obj)
             raise
 
-    def serialize_commands(self, commands: Sequence[Command]) -> Sequence[TCommand]:
+    def serialize_commands(self, commands: 'Sequence[Command]') -> 'Sequence[TCommand]':
         return [self.serialize_command(cmd) for cmd in commands]
 
-    def serialize_command(self, command: Command) -> TCommand:
+    def serialize_command(self, command: 'Command') -> 'TCommand':
         if isinstance(command, CreateCommand):
             tt = _resolve_template_type(self.store, command.template)
             value = self.serialize_value(tt, command.arguments)

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -45,7 +45,7 @@ class LedgerNetwork:
         for any reason (such as fetching initial ledger metadata).
         """
 
-    async def ledger(self) -> LedgerMetadata:
+    async def ledger(self) -> 'LedgerMetadata':
         """
         Return information about the entire ledger.
         """

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -11,10 +11,23 @@ from toposort import toposort_flatten
 
 from ... import LOG
 from ...damlast.daml_lf_1 import Archive, DefDataType, DottedName, ModuleRef, PackageRef, TypeConName, ValName
+from ...damlast.pb_parse import ProtobufParser
 from ...damlast.types import get_old_type
 from ...model.types import TypeReference, RecordType, VariantType, EnumType, SCALAR_TYPE_UNIT, \
-    NamedArgumentList, ScalarType, TypeVariable, TemplateChoice, Template
+    NamedArgumentList, ScalarType, TypeVariable, TemplateChoice, Template, PackageId
 from ...model.types_store import PackageStore, PackageStoreBuilder
+
+
+def parse_archive(package_id: 'PackageId', archive_bytes: bytes) -> 'Archive':
+    """
+    Convert ``bytes`` into an :class:`Archive`.
+    """
+    archive_pb = parse_archive_payload(archive_bytes, package_id)
+
+    parser = ProtobufParser(package_id)
+    package = parser.parse_Package(archive_pb.daml_lf_1)
+
+    return Archive(package_id, package)
 
 
 def parse_archive_payload(raw_bytes: bytes, package_id: 'Optional[PackageRef]' = None) -> 'G.ArchivePayload':
@@ -190,6 +203,7 @@ def parse_daml_metadata_pb(package_id: 'PackageRef', metadata_pb: Any) -> 'Packa
         A :class:`PackageStore` with additional entries resulting from the parse of this archive.
     """
     LOG.debug("Parsing package ID: %r", package_id)
+
     from ...damlast.pb_parse import ProtobufParser
 
     parser = ProtobufParser(package_id)

--- a/python/dazl/util/prim_types.py
+++ b/python/dazl/util/prim_types.py
@@ -15,6 +15,7 @@ from typing import overload, Any, Mapping, Tuple, Union
 TimeDeltaConvertible = Union[int, float, Decimal, str, timedelta]
 
 DATETIME_ISO8601_Z_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+_VARIANT_KEYS = frozenset(["tag", "value"])
 
 
 @overload
@@ -194,9 +195,12 @@ class PrimitiveTypeConverter:
     to_timedelta = staticmethod(to_timedelta)
 
 
-def decode_variant_dict(obj: Any) -> Tuple[str, Any]:
-    if not isinstance(obj, dict):
+def decode_variant_dict(obj: Any) -> 'Tuple[str, Any]':
+    from collections.abc import Mapping
+    if not isinstance(obj, Mapping):
         raise ValueError(f'cannot coerce {obj!r} to a variant')
+    if _VARIANT_KEYS == obj.keys():
+        return obj["tag"], obj["value"]
     if len(obj) != 1:
         raise ValueError(f'variants must be encoded as single-key dicts (got {obj!r} instead)')
     key = list(obj)[0]

--- a/python/dazl/util/tools.py
+++ b/python/dazl/util/tools.py
@@ -5,9 +5,13 @@
 This module contains miscellaneous utility methods that don't really fit anywhere else.
 """
 
-from typing import Collection, Generator, Iterable, List, Tuple, TypeVar, Union
+from typing import Callable, Collection, Generator, Iterable, List, Mapping, Optional, Tuple, \
+    TypeVar, Union
 
 T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
+E = TypeVar('E', bound=Exception)
 
 
 def boundary_iter(obj: Iterable[T]) -> Generator[Tuple[bool, T], None, None]:
@@ -64,9 +68,45 @@ def as_list(obj: 'Union[None, T, Collection[Union[None, T]]]') -> 'List[T]':
         # strings are iterable, but it's almost never intended to be used in place of a list; if
         # we're given a string, then assume what is wanted is a single list containing the full
         # string instead of a list containing every character as an individual item
-        return [obj]
+        return [obj]  # type: ignore
     elif isinstance(obj, Iterable):
         return [o for o in obj if o is not None]
     else:
         # assume we're dealing with a single object of the requested type
         return [obj]
+
+
+def get_matches(mapping: 'Mapping[K, V]', key: 'K', exc_class: 'Optional[Callable[[K], E]]' = KeyError) \
+        -> 'Collection[V]':
+    """
+    Return the value (as a singleton collection) associated with a key. If the key is equal to the
+    special value ``"*"``, then all values are returned. If there is no mapping for the specified
+    key and an exception class is provided, an exception is raised. Otherwise, an empty collection
+    is returned.
+
+    This function should NOT be used if ``"*"`` _can_ be a valid key; the behavior in this case is
+    still to return all values, which could be confusing.
+
+    :param mapping:
+        A mapping to use to perform lookups.
+    :param key:
+        The key to lookup a value for, or the special value '*' to retrieve all values.
+    :param exc_class:
+        The exception to raise if this function would have returned an empty collection, or
+        ``None`` to allow empty collections to be returned.
+    :return:
+        * An empty collection if the supplied key does not have a mapping _and_ ``exc_class is not None``;
+        * A collection of one if a match is found for the supplied key;
+        * All values of the mapping if the key is `""*""`.
+    """
+    if key == '*':
+        return tuple(mapping.values())
+
+    value = mapping.get(key)
+    if value is None:
+        if exc_class is not None:
+            raise exc_class(key)
+        else:
+            return ()
+
+    return (value,)


### PR DESCRIPTION
* Fix a few imports used only for types.
* Add `parse_archive`, which should generally start to be favored in the codebase as the way to load DAML-LF archives. There are a few conventions scattered throughout the codebase on different parsing techniques and they should be consolidated.
* Add `get_matches`, which better codifies the behavior of the special `'*'` literal in certain contexts, such as fetching wildcard package ID and/or template names.