### PR TITLE
python: Add convenience functions for constructing Type objects

### DIFF
--- a/python/dazl/damlast/__init__.py
+++ b/python/dazl/damlast/__init__.py
@@ -12,10 +12,15 @@ encoding and decoding of values, see :mod:`dazl.values`.
 :mod:`dazl.damlast.daml_lf_1`:
     The full definition of a DAML-LF Archive.
 
+:mod:`dazl.damlast.daml_types`:
+    Convenience functions for constructing DAML :class:`Type` objects.
+
 :mod:`dazl.damlast.parse`:
     Functions for parsing a DAML-LF Archive from its Protobuf definition.
 
 .. automodule:: dazl.damlast.daml_lf_1
+    :members:
+.. automodule:: dazl.damlast.daml_types
     :members:
 .. automodule:: dazl.damlast.parse
     :members:

--- a/python/dazl/damlast/builtins.py
+++ b/python/dazl/damlast/builtins.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Sequence
 
 from ._builtins_meta import BuiltinTable, Builtin
 from .daml_lf_1 import BuiltinFunction, Expr, PrimLit, Type
-from .util import list_type, var, STRING
+from . import daml_types as daml
 
 builtins = BuiltinTable()
 
@@ -18,7 +18,7 @@ builtins = BuiltinTable()
 @builtins.add
 class Concat(Builtin):
     name = 'DA.Internal.Prelude:concat'
-    args = list_type(list_type(var('x'))),
+    args = daml.List(daml.List(daml.var('x'))),
 
     def evaluate(self, _: 'Sequence[Type]', args: 'Sequence[Any]') -> 'Any':
         xxs = args[0]
@@ -42,7 +42,7 @@ class Concat(Builtin):
 @builtins.add
 class Show(Builtin):
     name = 'GHC.Show:show'
-    args = (STRING, STRING)
+    args = (daml.Text, daml.Text)
 
     def evaluate(self, _: 'Sequence[Type]', args: 'Sequence[Any]') -> 'Any':
         return str(args[1])
@@ -54,7 +54,7 @@ class Show(Builtin):
 @builtins.add
 class AppendText(Builtin):
     builtin = BuiltinFunction.APPEND_TEXT
-    args = (STRING, STRING)
+    args = (daml.Text, daml.Text)
 
     def evaluate(self, _: 'Sequence[Type]', args: 'Sequence[Any]') -> 'Any':
         return args[0] + args[1]

--- a/python/dazl/damlast/daml_types.py
+++ b/python/dazl/damlast/daml_types.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DAML Types
+----------
+
+Constants and constructor functions for the various primitive DAML types.
+"""
+from typing import Mapping
+
+from .daml_lf_1 import PrimType, Type, TypeConName, FieldWithType, TypeSynName
+
+__all__ = [
+    # Type.Var
+    'var',
+
+    # Type.Con
+    'con',
+
+    # Type.Prim
+    'Unit', 'Bool', 'Int', 'Decimal', 'Text', 'Time', 'Party', 'List', 'Update', 'Scenario',
+    'Date', 'ContractId', 'Optional', 'Arrow', 'TextMap', 'Numeric', 'Any', 'TypeRep', 'Map',
+
+    # Type.Struct
+    'struct',
+
+    # Type.ForAll (intentionally omitted)
+
+    # Type.Syn
+    'syn',
+]
+
+
+# region Variables (Type.Var)
+
+def var(a: str, *args: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``a`` (a type variable of the specified
+    name).
+    """
+    return Type(var=Type.Var(a, args=tuple(args)))
+
+
+# endregion
+
+# region Constructors (Type.Con)
+
+def con(tycon: 'TypeConName', *args: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is a reference to a :class:`DefDataType` (a record, variant,
+    or enum).
+
+    :param tycon: The fully-qualified name of the type constructor.
+    :param args: Type arguments (only applicable if the type is a generic type).
+    """
+    return Type(con=Type.Con(tycon=tycon, args=tuple(args)))
+
+
+# endregion
+
+# region Primitive types (Type.Prim)
+
+def _prim_type(pt: 'PrimType', *a: 'Type') -> 'Type':
+    return Type(prim=Type.Prim(prim=pt, args=tuple(a)))
+
+
+# DAML's unit type (``()``).
+Unit = _prim_type(PrimType.UNIT)
+
+# DAML's boolean type (``Bool``).
+Bool = _prim_type(PrimType.BOOL)
+
+# DAML's 64-bit integer type (``Int``).
+Int = _prim_type(PrimType.INT64)
+
+# DAML's historical decimal type (``Decimal``). You should generally use :func:`Numeric`(10)
+# instead, which means the same thing.
+Decimal = _prim_type(PrimType.DECIMAL)
+
+# DAML's text type (``Text``).
+Text = _prim_type(PrimType.TEXT)
+
+# DAML's datetime type (``Time``).
+Time = _prim_type(PrimType.TIMESTAMP)
+
+# DAML's Party type (``Party``).
+Party = _prim_type(PrimType.PARTY)
+
+
+# noinspection PyPep8Naming
+def List(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``[a]`` (a list of objects).
+    """
+    return Type(prim=Type.Prim(PrimType.LIST, args=(a,)))
+
+
+# noinspection PyPep8Naming
+def Update(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``Update a``.
+
+    This type is not normally used in ``dazl`` since we are primarily concerned with serializable
+    types; it is included for completeness.
+    """
+    return Type(prim=Type.Prim(PrimType.UPDATE, args=(a,)))
+
+
+# noinspection PyPep8Naming
+def Scenario(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``Scenario a``.
+
+    This type is not normally used in ``dazl`` since we are primarily concerned with serializable
+    types; it is included for completeness.
+    """
+    return Type(prim=Type.Prim(PrimType.SCENARIO, args=(a,)))
+
+
+# DAML's Date type (``Date``).
+Date = _prim_type(PrimType.DATE)
+
+
+# noinspection PyPep8Naming
+def ContractId(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``ContractId a``.
+
+    No checking is done to verify that the argument refers to a valid template.
+    """
+    return Type(prim=Type.Prim(PrimType.CONTRACT_ID, args=(a,)))
+
+
+# noinspection PyPep8Naming
+def Optional(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``Optional a`` (either ``Some a`` or
+    ``None``).
+    """
+    return Type(prim=Type.Prim(PrimType.OPTIONAL, args=(a,)))
+
+
+# noinspection PyPep8Naming
+def Arrow(a: 'Type', b: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``a -> b`` (a function type).
+
+    This type is not normally used in ``dazl`` since we are primarily concerned with serializable
+    types; it is included for completeness.
+    """
+    return _prim_type(PrimType.ARROW, a, b)
+
+
+# noinspection PyPep8Naming
+def TextMap(a: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``TextMap a``.
+    """
+    return _prim_type(PrimType.TEXTMAP, a)
+
+
+# noinspection PyPep8Naming
+def Numeric(n: int) -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``Numeric n``.
+    """
+    return _prim_type(PrimType.NUMERIC, Type(nat=n))
+
+
+# DAML's DA.Internal.LF.Any type.
+#
+# This type is not normally used in ``dazl`` since we are primarily concerned with serializable
+# types; it is included for completeness.
+Any = _prim_type(PrimType.ANY)
+
+# DAML's DA.Internal.LF.TypeRep type.
+#
+# This type is not normally used in ``dazl`` since we are primarily concerned with serializable
+# types; it is included for completeness.
+TypeRep = _prim_type(PrimType.TYPE_REP)
+
+
+# noinspection PyPep8Naming
+def Map(k: 'Type', v: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is equivalent to ``Map k v``.
+    """
+    return _prim_type(PrimType.GENMAP, k, v)
+
+
+# endregion
+
+# region Type.Forall
+
+# A forall convenience constructor function is intentionally omitted.
+
+# endregion
+
+# region Type.Struct
+
+def struct(fields: 'Mapping[str, Type]'):
+    """
+    Construct a DAML :class:`Type` that is equivalent to a structural tuple type (``(a, b, ...)``).
+
+    :param fields:
+        A map of field names to their types. DAML-LF structs generally define structs as having
+        field names ``"_1"``, ``"_2"``, ``"_3"``, and so on.
+    """
+    return Type(tuple=Type.Tuple(fields=tuple(
+        [FieldWithType(field, typ) for field, typ in fields.items()])))
+
+
+# endregion
+
+# region Type.Syn
+
+def syn(tysyn: 'TypeSynName', *args: 'Type') -> 'Type':
+    """
+    Construct a DAML :class:`Type` that is a reference to another type.
+
+    :param tysyn: The fully-qualified name of the type synonym.
+    :param args: Type arguments (only applicable if the type is a generic type).
+    """
+    return Type(syn=Type.Syn(tysyn=tysyn, args=tuple(args)))
+
+# endregion

--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-
+import warnings
 from typing import Callable, Optional
 
 from ._base import T
@@ -10,11 +9,10 @@ from ..util.typing import safe_cast
 from .daml_lf_1 import Type, PrimType
 
 
-STRING = Type(prim=Type.Prim(prim=PrimType.TEXT, args=()))
-
-
 def var(var_: str) -> 'Type':
-    return Type(var=Type.Var(var_, ()))
+    warnings.warn('dazl.damlast.types.var is deprecated; use dazl.damlast.daml_types.var instead.')
+    from .daml_types import var as _var
+    return _var(var_)
 
 
 def match_prim_type(

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
+import warnings
 from typing import Mapping, Optional, Sequence, Union, TYPE_CHECKING
 from .daml_lf_1 import DefValue, Expr, ModuleRef, Type, PrimType, Kind, UNIT, TypeVarWithKind, _Name, PackageRef, \
     DottedName
@@ -10,12 +10,10 @@ if TYPE_CHECKING:
     from ..model.types_store import PackageStore
 
 
-STRING = Type(prim=Type.Prim(prim=PrimType.TEXT, args=()))
-PARTY_TYPE = Type(prim=Type.Prim(prim=PrimType.PARTY, args=()))
-
-
 def var(var: str) -> 'Type':
-    return Type(var=Type.Var(var, ()))
+    warnings.warn('dazl.damlast.util.var is deprecated; use dazl.damlast.daml_types.var instead.')
+    from .daml_types import var as _var
+    return _var(var)
 
 
 def values_by_module(store: 'PackageStore') \
@@ -73,14 +71,20 @@ def arrow_type(input: 'Type', output: 'Type') -> 'Type':
     Convenience function for constructing a :class:`Type` of ``prim`` that is an abstraction taking
     the input type and returning the output type.
     """
-    return Type(prim=Type.Prim(PrimType.ARROW, (input, output)))
+    warnings.warn(
+        'arrow_type is deprecated; Use dazl.damlast.daml_types.Arrow instead', DeprecationWarning)
+    from .daml_types import Arrow
+    return Arrow(input, output)
 
 
 def list_type(elem_type: 'Type') -> 'Type':
     """
     Convenience function for constructing a :class:`Type` of ``prim`` list.
     """
-    return Type(prim=Type.Prim(PrimType.LIST, (elem_type,)))
+    warnings.warn(
+        'list_type is deprecated; Use dazl.damlast.daml_types.List instead', DeprecationWarning)
+    from .daml_types import List
+    return List(elem_type)
 
 
 def type_var_with_kind(var: str, type: Kind = Kind(star = UNIT)):

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -9,8 +9,9 @@ from .util import maybe_parentheses, indent
 from .. import LOG
 from ..damlast.daml_lf_1 import DefDataType, DefTemplate, Expr, Type, Case, Block, \
     Update, Scenario, PrimType, TypeConName
-from ..damlast.util import def_value, list_type, module_name, PARTY_TYPE
-from ..model.types import ModuleRef, Type as OldType, TypeReference
+from ..damlast import daml_types as daml
+from ..damlast.util import def_value, module_name
+from ..model.types import ModuleRef, Type as OldType
 from ..model.types_store import PackageStore
 
 
@@ -60,7 +61,7 @@ class PythonPrettyPrint(PrettyPrintBase):
         template_full_name = str(TypeConName(self.context.current_module, def_data_type.name.segments))
         template_name = def_data_type.name.segments[-1]
         slot_names = tuple(fwt.field for fwt in def_data_type.record.fields) if def_data_type.record else ()
-        signatories_def = def_value('signatories', list_type(PARTY_TYPE), template.signatories) if template is not None else None
+        signatories_def = def_value('signatories', daml.List(daml.Party), template.signatories) if template is not None else None
 
         if template is not None:
             lines = []

--- a/python/tests/unit/test_pretty_daml.py
+++ b/python/tests/unit/test_pretty_daml.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from dazl.damlast.daml_lf_1 import DottedName, PackageRef, TypeConName
+from dazl.damlast.daml_lf_1 import DottedName, ModuleRef, PackageRef, TypeConName
+from dazl.damlast import daml_types as daml
 from dazl.pretty import DamlPrettyPrinter, PrettyOptions
 from dazl.util.dar import DarFile
 from .dars import Pending
@@ -18,9 +19,7 @@ def test_render_list_of_party_old():
 
 
 def test_render_list_of_party_new():
-    from dazl.damlast.daml_lf_1 import PrimType, Type
-
-    type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(Type(prim=Type.Prim(prim=PrimType.PARTY, args=())),)))
+    type_ = daml.List(daml.Party)
 
     expected = '[Party]'
     actual = str(type_)
@@ -29,7 +28,7 @@ def test_render_list_of_party_new():
 
 
 def test_render_list_of_contract_type_con_old():
-    from dazl.model.types import ContractIdType, ListType, ModuleRef, TypeReference
+    from dazl.model.types import ContractIdType, ListType, TypeReference
 
     module_ref = ModuleRef(package_id=PackageRef('00000000000000000000000000000000'), module_name=DottedName(('ABC',)))
     type_ref = TypeReference(con=TypeConName(module=module_ref, name=('DefGhi',)))
@@ -42,13 +41,9 @@ def test_render_list_of_contract_type_con_old():
 
 
 def test_render_list_of_contract_type_con_new():
-    from dazl.damlast.daml_lf_1 import PrimType, Type
-    from dazl.model.types import ModuleRef, TypeReference
-
     module_ref = ModuleRef(package_id=PackageRef('00000000000000000000000000000000'), module_name=DottedName(('ABC',)))
-    con_type = Type(con=Type.Con(tycon=TypeConName(module=module_ref, name=('DefGhi',)), args=()))
-    cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
-    type_ = Type(prim=Type.Prim(prim=PrimType.LIST, args=(cid_type,)))
+    name = TypeConName(module=module_ref, name=('DefGhi',))
+    type_ = daml.List(daml.ContractId(daml.con(name)))
 
     expected = '[ContractId ABC:DefGhi]'
     actual = str(type_)
@@ -57,7 +52,7 @@ def test_render_list_of_contract_type_con_new():
 
 
 def test_render_update_of_contract_type_con_old():
-    from dazl.model.types import ContractIdType, UpdateType, ModuleRef, TypeReference
+    from dazl.model.types import ContractIdType, UpdateType, TypeReference
 
     module_ref = ModuleRef(package_id=PackageRef('00000000000000000000000000000000'), module_name=DottedName(('ABC',)))
     type_ref = TypeReference(con=TypeConName(module=module_ref, name=('DefGhi',)))
@@ -70,13 +65,9 @@ def test_render_update_of_contract_type_con_old():
 
 
 def test_render_update_of_contract_type_con_new():
-    from dazl.damlast.daml_lf_1 import PrimType, Type
-    from dazl.model.types import ModuleRef, TypeReference
-
     module_ref = ModuleRef(package_id=PackageRef('00000000000000000000000000000000'), module_name=DottedName(('ABC',)))
-    con_type = Type(con=Type.Con(tycon=TypeConName(module=module_ref, name=('DefGhi',)), args=()))
-    cid_type = Type(prim=Type.Prim(prim=PrimType.CONTRACT_ID, args=(con_type,)))
-    type_ = Type(prim=Type.Prim(prim=PrimType.UPDATE, args=(cid_type,)))
+    name = TypeConName(module=module_ref, name=('DefGhi',))
+    type_ = daml.Update(daml.ContractId(daml.con(name)))
 
     expected = 'Update (ContractId ABC:DefGhi)'
     actual = str(type_)


### PR DESCRIPTION
Add convenience functions for constructing `dazl.damlast.daml_lf_1.Type` objects.

The only place these objects are currently constructed en masse is in `ProtobufParser` (https://github.com/digital-asset/dazl-client/blob/4baab66825ae061014d9045ec64e212c7df27572/python/dazl/damlast/pb_parse.py); however, ideally `ProtobufParser` remains hermetic and possibly code-generated, so I've opted to _not_ repoint constructions of `Type` objects to these functions. However, there are some tests where these types are constructed; this usage has been replaced with the convenience functions, which hopefully illustrate how these utility functions can aid readability at the call site.

These functions are intended to be used in shimming code that converts usages of `dazl.model.types.Type` to `dazl.damlast.daml_lf_1.Type`, where user-code will need to instantiate appropriate "new-style" `Type`s and the verboseness of constructing a `dazl.damlast.daml_lf_1.Type` would hinder code readability.