### PR TITLE
python: Adapt ContractId and Command classes to use new Types

### DIFF
--- a/python/dazl/client/_writer_verify.py
+++ b/python/dazl/client/_writer_verify.py
@@ -6,11 +6,11 @@ from typing import Any
 from ..model.core import ContractId
 from ..model.types import Type, UnsupportedType, VariantType, RecordType, ListType, \
     ContractIdType, TemplateChoice, TypeEvaluationContext, OptionalType, TextMapType, \
-    UnresolvedTypeReference, TypeReference, EnumType
+    TypeReference, EnumType
 from ..model.writing import Command, CreateCommand, ExerciseCommand, ExerciseByKeyCommand, \
     CreateAndExerciseCommand, AbstractSerializer
 from ..util.prim_types import to_int, to_str, to_decimal, to_date, to_datetime, \
-    unflatten_dotted_keys, to_hashable
+    unflatten_dotted_keys
 
 
 class ValidateError(ValueError):
@@ -28,29 +28,25 @@ class ValidateSerializer(AbstractSerializer[Command, Any]):
 
     def serialize_create_command(self, template_type: RecordType, template_args: Any) \
             -> CreateCommand:
-        return CreateCommand(template=template_type, arguments=template_args)
+        return CreateCommand(template=template_type.name.con, arguments=template_args)
 
     def serialize_exercise_command(
             self, contract_id: ContractId, choice_info: TemplateChoice, choice_args: Any) \
             -> ExerciseCommand:
-        if isinstance(contract_id.template_id, UnresolvedTypeReference):
-            tref = next(iter(self.store.resolve_template_type(contract_id.template_id)))
-            contract_id = ContractId(contract_id.contract_id, template_id=tref)
-
         return ExerciseCommand(contract=contract_id, choice=choice_info.name, arguments=choice_args)
 
     def serialize_exercise_by_key_command(
             self, template_ref: TypeReference, key_arguments: Any,
             choice_info: TemplateChoice, choice_arguments: Any) -> ExerciseByKeyCommand:
         return ExerciseByKeyCommand(
-            template=template_ref, contract_key=key_arguments,
+            template=template_ref.con, contract_key=key_arguments,
             choice=choice_info.name, choice_argument=choice_arguments)
 
     def serialize_create_and_exercise_command(
             self, template_type: RecordType, create_arguments: Any,
             choice_info: TemplateChoice, choice_arguments: Any) -> CreateAndExerciseCommand:
         return CreateAndExerciseCommand(
-            template=template_type, arguments=create_arguments,
+            template=template_type.name.con, arguments=create_arguments,
             choice=choice_info.name, choice_argument=choice_arguments)
 
     def serialize_unit(self, context: TypeEvaluationContext, obj: Any) -> Any:

--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -471,7 +471,7 @@ def _parse_args_dict(d: 'Mapping[str, Any]') -> 'Mapping[str, Any]':
             for key in param.deprecated_aliases:
                 if d.get(key) is not None:
                     warnings.warn(f'The {key} option is deprecated. Please use {fld.name} instead.',
-                                  DeprecationWarning)
+                                  DeprecationWarning, stacklevel=2)
                     value = d.get(key)
                     break
 

--- a/python/dazl/damlast/__init__.py
+++ b/python/dazl/damlast/__init__.py
@@ -15,12 +15,17 @@ encoding and decoding of values, see :mod:`dazl.values`.
 :mod:`dazl.damlast.daml_types`:
     Convenience functions for constructing DAML :class:`Type` objects.
 
+:mod:`dazl.damlast.lookup`:
+    Utilities for quickly resolving names to DAML-LF types/values.
+
 :mod:`dazl.damlast.parse`:
     Functions for parsing a DAML-LF Archive from its Protobuf definition.
 
 .. automodule:: dazl.damlast.daml_lf_1
     :members:
 .. automodule:: dazl.damlast.daml_types
+    :members:
+.. automodule:: dazl.damlast.lookup
     :members:
 .. automodule:: dazl.damlast.parse
     :members:

--- a/python/dazl/damlast/compat.py
+++ b/python/dazl/damlast/compat.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Compatibility methods
+---------------------
+
+These functions should only be used internally by code that is helping in the transition from the
+deprecated :class:`dazl.model.types.Type` hierarchy to :class:`dazl.damlast.daml_lf_1.Type`.
+These functions will be removed WITHOUT an intermediate deprecation warning, as they are considered
+internal only.
+"""
+import warnings
+
+from .daml_lf_1 import TypeConName
+from typing import Tuple, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # avoid import cycles; `dazl.model` should depend on `dazl.damlast`, and not the other way
+    # around
+    from ..model.types import Type as DeprecatedType, TypeReference as DeprecatedTypeReference
+
+
+def parse_template(template_id: 'Union[str, DeprecatedType, TypeConName]') \
+        -> 'Tuple[TypeConName, DeprecatedTypeReference]':
+    """
+    Return both the "new-style" Type and the "old-style" Type for _either_ a string, "new-style"
+    Type, or "old-style" Type. This is used in places where we can't easily mark a symbol as
+    deprecated (particularly, constructors for types that are NOT to be deprecated as part of this
+    transition).
+    """
+    from ..model.types import Type as DeprecatedType, TypeReference as DeprecatedTypeReference, \
+        UnresolvedTypeReference, RecordType
+    from ..damlast.lookup import parse_type_con_name
+
+    if isinstance(template_id, str):
+        name = parse_type_con_name(template_id)
+        return name, DeprecatedTypeReference(name)
+
+    elif isinstance(template_id, TypeConName):
+        return template_id, DeprecatedTypeReference(template_id)
+
+    elif isinstance(template_id, DeprecatedType):
+        warnings.warn(
+            'usage of dazl.model.types.Type is deprecated; use TypeConName instead',
+            DeprecationWarning, stacklevel=3)
+
+        if isinstance(template_id, DeprecatedTypeReference):
+            return template_id.con, template_id
+
+        elif isinstance(template_id, UnresolvedTypeReference):
+            name = parse_type_con_name(template_id.name)
+            return name, DeprecatedTypeReference(name)
+
+        elif isinstance(template_id, RecordType):
+            if template_id.name is None:
+                raise ValueError(
+                    'template_id must point to a named record that corresponds to a template')
+
+            return template_id.name.con, DeprecatedTypeReference(template_id.name.con)
+    else:
+        raise ValueError('template_id must be a TypeConName')

--- a/python/dazl/damlast/lookup.py
+++ b/python/dazl/damlast/lookup.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DAML-LF fast lookups
+--------------------
+"""
+
+from .daml_lf_1 import TypeConName, ModuleRef, DottedName
+
+
+__all__ = ['parse_type_con_name']
+
+
+def parse_type_con_name(val: str) -> 'TypeConName':
+    """
+    Parse the given string as a type constructor.
+    """
+    # TODO: validate_template should be deprecated and some of its remaining bits be moved in-line
+    #  but it's used too heavily in its current form at the moment. This is a local import to avoid
+    #  import cycles between dazl.damlast and dazl.model.
+    from ..model.lookup import validate_template
+
+    pkg, name = validate_template(val)
+    module_name, _, entity_name = name.rpartition(':')
+    module_ref = ModuleRef(pkg, DottedName(module_name.split('.')))
+    return TypeConName(module_ref, entity_name.split('.'))

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -72,7 +72,8 @@ def arrow_type(input: 'Type', output: 'Type') -> 'Type':
     the input type and returning the output type.
     """
     warnings.warn(
-        'arrow_type is deprecated; Use dazl.damlast.daml_types.Arrow instead', DeprecationWarning)
+        'arrow_type is deprecated; Use dazl.damlast.daml_types.Arrow instead', DeprecationWarning,
+        stacklevel=2)
     from .daml_types import Arrow
     return Arrow(input, output)
 
@@ -82,7 +83,8 @@ def list_type(elem_type: 'Type') -> 'Type':
     Convenience function for constructing a :class:`Type` of ``prim`` list.
     """
     warnings.warn(
-        'list_type is deprecated; Use dazl.damlast.daml_types.List instead', DeprecationWarning)
+        'list_type is deprecated; Use dazl.damlast.daml_types.List instead', DeprecationWarning,
+        stacklevel=2)
     from .daml_types import List
     return List(elem_type)
 

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -277,10 +277,10 @@ class EventKey:
         on_offset=lambda _: EventKey.offset(),
         on_transaction_start=lambda _: EventKey.transaction_start(),
         on_transaction_end=lambda _: EventKey.transaction_end(),
-        on_contract_created=lambda event: EventKey.contract_created(False, event.cid.template_id),
+        on_contract_created=lambda event: EventKey.contract_created(False, event.cid.value_type),
         on_contract_exercised=lambda event: EventKey.contract_exercised(
-            False, event.cid.template_id, event.choice),
-        on_contract_archived=lambda event: EventKey.contract_archived(False, event.cid.template_id),
+            False, event.cid.value_type, event.choice),
+        on_contract_archived=lambda event: EventKey.contract_archived(False, event.cid.value_type),
         on_packages_added=lambda event: EventKey.packages_added(
             initial=event.initial, changed=not event.initial))
 

--- a/python/dazl/pretty/table/fmt_pretty.py
+++ b/python/dazl/pretty/table/fmt_pretty.py
@@ -14,9 +14,7 @@ from typing import Iterable, Mapping, Sequence, AbstractSet, Callable
 from .model import Formatter, RowBuilder
 from ...damlast.daml_lf_1 import TypeConName
 from ...model.core import Party
-from ...model.types import TypeReference
 from ...model.types_store import PackageStore
-from ...util.typing import safe_cast
 
 __all__ = ['PrettyFormatter']
 
@@ -219,7 +217,6 @@ def group_by_name(entries: 'Iterable[RowBuilder]') -> 'Mapping[TypeConName, Sequ
     """
     entries_by_template = defaultdict(list)
     for entry in entries:
-        type_ref = safe_cast(TypeReference, entry.cid.template_id)
-        entries_by_template[type_ref.con].append(entry)
+        entries_by_template[entry.cid.value_type].append(entry)
 
     return {name: entries_by_template[name] for name in sorted(entries_by_template)}

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -17,7 +17,8 @@ from ... import LOG
 from .._base import LedgerClient, _LedgerConnection, LedgerConnectionOptions
 from .pb_parse_event import serialize_acs_request, serialize_transactions_request, \
     to_acs_events, to_transaction_events, BaseEventDeserializationContext
-from .pb_parse_metadata import parse_daml_metadata_pb, parse_archive_payload, find_dependencies
+from .pb_parse_metadata import parse_daml_metadata_pb, find_dependencies
+from ...damlast.parse import parse_archive_payload
 from ...model.core import Party, UserTerminateRequest, ConnectionTimeoutError
 from ...model.ledger import LedgerMetadata
 from ...model.network import HTTPConnectionSettings
@@ -229,7 +230,7 @@ def grpc_package_sync(package_provider: 'PackageProvider', store: 'PackageStore'
     for package_id in all_package_ids:
         if should_load(package_id):
             archive_payload = package_provider.fetch_package(package_id)
-            metadatas_pb[package_id] = parse_archive_payload(archive_payload, package_id)
+            metadatas_pb[package_id] = parse_archive_payload(package_id, archive_payload)
 
     metadatas_pb = find_dependencies(metadatas_pb, loaded_package_ids)
     for package_id, archive_payload in metadatas_pb.sorted_archives.items():

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -23,7 +23,9 @@ def parse_archive_payload(raw_bytes: bytes, package_id: 'Optional[PackageRef]' =
     Note that this function will temporarily increase Python's recursion limit to handle cases where
     parsing a DAML-LF archive requires deeper recursion limits.
     """
-    warnings.warn('Use dazl.damlast.parse.parse_archive_payload instead.', DeprecationWarning)
+    warnings.warn(
+        'Use dazl.damlast.parse.parse_archive_payload instead.', DeprecationWarning,
+        stacklevel=2)
 
     from ...damlast.parse import parse_archive_payload
     return parse_archive_payload(package_id, raw_bytes)

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -156,10 +156,11 @@ class DarFile:
 
 def parse_dalf(contents: bytes) -> 'PackageStore':
     from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import Archive
-    from ..protocols.v1.pb_parse_metadata import parse_archive_payload, parse_daml_metadata_pb
+    from ..damlast.parse import parse_archive_payload
+    from ..protocols.v1.pb_parse_metadata import parse_daml_metadata_pb
     a = Archive()
     a.ParseFromString(contents)
-    p = parse_archive_payload(a.payload)
+    p = parse_archive_payload(a.hash, a.payload)
     return parse_daml_metadata_pb(a.hash, p)
 
 

--- a/python/tests/unit/test_capture_app.py
+++ b/python/tests/unit/test_capture_app.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from dazl import ContractId
 from dazl.damlast.daml_lf_1 import TypeConName, ModuleRef, PackageRef, DottedName
-from dazl.model.types import TypeReference, dotted_name
+from dazl.model.types import dotted_name
 from dazl.model.types_store import PackageStore
 from dazl.pretty.table.fmt_pretty import PrettyFormatter
 from dazl.pretty.table.model import TableBuilder
@@ -19,10 +19,9 @@ def test_capture_handles_unknown_templates():
     name = TypeConName(
         ModuleRef(PackageRef("00"), DottedName(dotted_name("SomeModule"))),
         dotted_name("SomeUnknownTemplate"))
-    ref = TypeReference(con=name)
 
     table = TableBuilder()
-    table.add('A', ContractId('0:0', ref), dict(some_field='some_value'), datetime.utcnow())
+    table.add('A', ContractId('0:0', name), dict(some_field='some_value'), datetime.utcnow())
 
     lines = formatter.render(store, parties, table)
     output = '\n'.join(lines) + '\n'

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -4,13 +4,15 @@
 
 from unittest import TestCase
 
+from dazl.damlast.lookup import parse_type_con_name
 from dazl.model.core import ContractId, Party
-from dazl.model.types import UnresolvedTypeReference
 from dazl.model.writing import create, CommandBuilder, CommandDefaults, CommandPayload, CreateCommand, \
     ExerciseCommand
 
+
+SOME_TEMPLATE_NAME = parse_type_con_name('Sample:Untyped')
 SOME_PARTY = Party('SomeParty')
-SOME_CONTRACT_ID = ContractId('#0:0', UnresolvedTypeReference('Sample.Untyped'))
+SOME_CONTRACT_ID = ContractId('#0:0', SOME_TEMPLATE_NAME)
 DEFAULTS = CommandDefaults(
     default_party=SOME_PARTY,
     default_ledger_id='some_ledger',
@@ -25,7 +27,7 @@ class TestCommandBuilderTest(TestCase):
     """
 
     def test_single_create_untyped(self):
-        expr = create('Sample.Untyped', {"arg": 1})
+        expr = create('Sample:Untyped', {"arg": 1})
 
         expected = [CommandPayload(
             party=SOME_PARTY,
@@ -33,7 +35,7 @@ class TestCommandBuilderTest(TestCase):
             workflow_id=DEFAULTS.default_workflow_id,
             application_id=DEFAULTS.default_application_id,
             command_id=DEFAULTS.default_command_id,
-            commands=[CreateCommand(UnresolvedTypeReference('Sample.Untyped'), dict(arg=1))]
+            commands=[CreateCommand(SOME_TEMPLATE_NAME, dict(arg=1))]
         )]
         actual = CommandBuilder.coerce(expr).build(DEFAULTS)
 
@@ -49,7 +51,7 @@ class TestCommandBuilderTest(TestCase):
             workflow_id=DEFAULTS.default_workflow_id,
             application_id=DEFAULTS.default_application_id,
             command_id=DEFAULTS.default_command_id,
-            commands=[CreateCommand(UnresolvedTypeReference('Sample.Untyped'), dict(arg=1))]
+            commands=[CreateCommand(SOME_TEMPLATE_NAME, dict(arg=1))]
         )]
         actual = builder.build(DEFAULTS)
 
@@ -67,7 +69,7 @@ class TestCommandBuilderTest(TestCase):
                 workflow_id=DEFAULTS.default_workflow_id,
                 application_id=DEFAULTS.default_application_id,
                 command_id=DEFAULTS.default_command_id,
-                commands=[CreateCommand(UnresolvedTypeReference('Sample.Untyped'), dict(arg=1))]),
+                commands=[CreateCommand(SOME_TEMPLATE_NAME, dict(arg=1))]),
             CommandPayload(
                 party=SOME_PARTY,
                 ledger_id=DEFAULTS.default_ledger_id,
@@ -93,7 +95,7 @@ class TestCommandBuilderTest(TestCase):
             application_id=DEFAULTS.default_application_id,
             command_id=DEFAULTS.default_command_id,
             commands=[
-                CreateCommand(UnresolvedTypeReference('Sample.Untyped'), dict(arg=1)),
+                CreateCommand(SOME_TEMPLATE_NAME, dict(arg=1)),
                 ExerciseCommand(SOME_CONTRACT_ID, "SomeChoice", {"choiceArg": "value"})
             ]
         )]

--- a/python/tests/unit/test_pb_serialize.py
+++ b/python/tests/unit/test_pb_serialize.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 from dazl import CreateCommand, ExerciseCommand, CreateAndExerciseCommand, ExerciseByKeyCommand, \
     ContractId
-from dazl.model.types import TypeReference
+from dazl.damlast.daml_lf_1 import TypeConName
 from dazl.model.types_store import PackageStore
 from dazl.protocols.v1.pb_ser_command import ProtobufSerializer, as_identifier
 from dazl.protocols.v1 import model as G
@@ -21,10 +21,10 @@ class DarFixture:
     dar: DarFile
     store: PackageStore
 
-    def get_template_type(self, identifier: str) -> 'TypeReference':
+    def get_template_type(self, identifier: str) -> 'TypeConName':
         templates = self.store.resolve_template(identifier)
         for template in templates:
-            return template.data_type.name
+            return template.data_type.name.con
 
         raise AssertionError(f'Unknown template name: {identifier!r}')
 


### PR DESCRIPTION
Adapt `ContractId` and `Command` classes to understand and use `TypeConName`; deprecated old-style `Type` s. As part of the ongoing work to address #126, these types need to speak `daml.damlast.daml_lf_1.Type` instead of `dazl.model.types.Type`.

The fields of `ContractId` and `Command` that returned `TypeReference`/`Type` are now marked as deprecated. This preserves code that might be using type information, while also allowing a new value serializer to make use of the new types.