### PR TITLE
python: Improvements to logging infrastructure.

### DIFF
--- a/_fixtures/src/post-office/integration-test.py
+++ b/_fixtures/src/post-office/integration-test.py
@@ -9,9 +9,9 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from dazl import create, exercise, setup_default_logger, Network, write_acs
+from dazl import create, exercise, Network, write_acs
 
-setup_default_logger()
+logging.basicConfig()
 
 LOG = logging.getLogger('integration_test')
 

--- a/python/dazl/_logging.py
+++ b/python/dazl/_logging.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Logging utilities used in `dazl`.
+
+This is an internal API and not meant to be used directly outside of dazl; symbols declared in this
+file may change at any time.
+"""
+
+import logging
+import sys
+from functools import partial
+from time import time
+from typing import Type, cast
+
+__all__ = ['LOG', 'VERBOSE', 'configure']
+
+# A custom logging level below "DEBUG". This is used within dazl for messages that are rarely
+# important enough to be printed, even within tests, but still occasionally have value when
+# debugging particular blocks of code.
+VERBOSE = 5
+logging.addLevelName(VERBOSE, 'VERBOSE')
+
+# If a custom logger type was set before dazl was loaded, respect it by using it as our logger's
+# base class.
+# noinspection PyTypeChecker
+Logger = logging.getLoggerClass()  # type: Type[logging.Logger]
+
+
+class ExtendedLogger(Logger):  # type: ignore
+    """
+    A logger with additional utility logging functions used within dazl.
+    """
+
+    def verbose(self, msg, *args, **kwargs):
+        """
+        Log a message with level ``VERBOSE`` on this logger.
+        """
+        self.log(VERBOSE, msg, *args, **kwargs)
+
+    def verbose_timed(self, msg, *args, **kwargs) -> 'TimedLogMessageContext':
+        """
+        Log a message with level ``VERBOSE`` on the logger, additionally annotating the log message
+        with the time it took to complete the block.
+        """
+        return TimedLogMessageContext(self, VERBOSE, msg, args, kwargs)
+
+    def debug_timed(self, msg, *args, **kwargs) -> 'TimedLogMessageContext':
+        """
+        Log a message with level ``DEBUG`` on the logger, additionally annotating the log message
+        with the time it took to complete the block.
+        """
+        return TimedLogMessageContext(self, logging.DEBUG, msg, args, kwargs)
+
+    def info_timed(self, msg, *args, **kwargs) -> 'TimedLogMessageContext':
+        """
+        Log a message with level ``INFO`` on the logger, additionally annotating the log message
+        with the time it took to complete the block.
+        """
+        return TimedLogMessageContext(self, logging.INFO, msg, args, kwargs)
+
+
+# Create our Logger with our special type that has all of our goodies.
+logging.setLoggerClass(ExtendedLogger)
+LOG = cast(ExtendedLogger, logging.getLogger('dazl'))
+
+# There is a chance that someone instantiated a logger using our name already. If that's the case,
+# then it is too late to specify the actual class instance used and `LOG` will not have the
+# functions declared on it that we expect. So make sure that we specifically add methods to _our_
+# logger.
+#
+# An alternate implementation would have been to simply assign our custom logging functions directly
+# to an instance logger without playing games with `logger.setLoggerClass`; but we don't, because
+# mypy/IDEs won't understand what is going on; we'd be using "reflection" instead of giving
+# mypy/IDEs a simple class (ExtendedLogger) to key off of.
+for field in dir(ExtendedLogger):
+    if not field.startswith('__') and not hasattr(LOG, field):
+        setattr(LOG, field, partial(getattr(ExtendedLogger, field), LOG))
+
+# This is essentially a runtime assertion that our logging functions have been defined properly.
+LOG.verbose('dazl logging has been loaded.')
+
+# Restore the original Logger type.
+logging.setLoggerClass(Logger)
+
+
+class TimedLogMessageContext:
+    """
+    A simple ContextManager that logs a message at the specified logging level, additionally with
+    timing information. If an exception is thrown in the block, that exception is instead logged.
+    """
+
+    __slots__ = 'logger', 'log_level', 'msg', 'args', 'kwargs', 'start'
+
+    def __init__(self, logger, log_level, msg, args, kwargs):
+        self.logger = logger
+        self.log_level = log_level
+        self.msg = msg
+        self.args = args
+        self.kwargs = kwargs
+        self.start = None
+
+    def __enter__(self):
+        self.start = time()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        elapsed_ms = (time() - self.start) * 1000.0
+        if exc_type is not None:
+            self.logger.exception(
+                self.msg + " (%0.2f ms)", *self.args, elapsed_ms,
+                exc_info=(exc_type, exc_val, exc_tb), **self.kwargs)
+        else:
+            self.logger.log(
+                self.log_level, self.msg + " (%0.2f ms)",
+                *self.args, elapsed_ms, **self.kwargs)
+
+
+did_configure = False
+
+
+def configure(level=logging.INFO):
+    """
+    Set up a default logger format and stream handler with sensible defaults.
+    """
+    root = logging.getLogger()
+    global did_configure
+    if not did_configure:
+        did_configure = True
+    else:
+        root.warning('configure being called more than once!')
+        return
+
+    logging.captureWarnings(True)
+
+    root.setLevel(level)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("[%(levelname)7s] %(asctime)s | %(name)-7s | %(message)s")
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)

--- a/python/dazl/cli/__init__.py
+++ b/python/dazl/cli/__init__.py
@@ -8,13 +8,13 @@ Simple command-line handlers.
 import logging
 from typing import List, Sequence
 
-from .. import setup_default_logger
 from ..model.core import ConfigurationError
 from ._base import CliCommand
 from .ls import ListAllCommand
 from .metadata import PrintMetadataCommand
 from .upload import UploadCommand
 from .version import VersionCommand
+from .._logging import configure as configure_logger
 
 COMMANDS = [
     ListAllCommand(),
@@ -60,7 +60,7 @@ def run(cmd, args) -> int:
     if log_level is None:
         log_level = logging.WARNING
 
-    setup_default_logger(level=log_level)
+    configure_logger(level=log_level)
     return cmd.execute(parsed_args)
 
 

--- a/python/dazl/client/runner.py
+++ b/python/dazl/client/runner.py
@@ -5,26 +5,25 @@
 Simple methods for instantiating an application written against dazl that incorporate common usage
 patterns.
 """
-
-import logging
+import warnings
 from argparse import ArgumentParser
 from typing import Callable
 
-from ..util.logging import setup_default_logger
 from ..client.api import Network
 from ..client.config import configure_parser, NetworkConfig
 
 
 def run(init: 'Callable[[Network], None]'):
+    warnings.warn("dazl.run is deprecated", DeprecationWarning, stacklevel=2)
+
     if init is None:
         raise ValueError('The init callback cannot be None')
-    setup_default_logger(logging.INFO)
+
     arg_parser = ArgumentParser()
 
     configure_parser(arg_parser, config_file_support=True)
     args = arg_parser.parse_args()
 
-    print(args)
     config = NetworkConfig.get_config(args)
     network = Network()
     network.set_config(config)

--- a/python/dazl/util/io.py
+++ b/python/dazl/util/io.py
@@ -6,11 +6,9 @@ Utilities for dealing with the file system.
 """
 
 import socket
-import sys
-from io import BufferedIOBase, SEEK_SET
+from io import BufferedIOBase
 from pathlib import Path
-from types import TracebackType
-from typing import BinaryIO, TextIO, Optional, Type, Iterator, Iterable, List, Union, overload
+from typing import BinaryIO, Optional, Union, overload
 
 
 @overload
@@ -94,99 +92,3 @@ def find_nearest_ancestor(file_name: str, relative_to: Union[str, Path]) -> 'Opt
                 return None
             else:
                 relative_to = new_relative_to
-
-
-class StdoutStreamWrapper(TextIO):
-    """
-    Wrapper for ``sys.stdout`` that can cope with it being reassigned at will (like the ``unittest``
-    module does). This allows for log output to be more usefully associated with tests.
-    """
-
-    def __enter__(self) -> TextIO:
-        return sys.stdout.__enter__()
-
-    @property
-    def buffer(self):
-        return sys.stdout.buffer
-
-    def closed(self):
-        return sys.stdout.closed
-
-    def close(self) -> None:
-        return sys.stdout.close()
-
-    @property
-    def name(self):
-        return sys.stdout.name
-
-    @property
-    def encoding(self):
-        return sys.stdout.encoding
-
-    @property
-    def errors(self):
-        return sys.stdout.errors
-
-    @property
-    def mode(self):
-        return sys.stdout.mode
-
-    @property
-    def newlines(self):
-        return sys.stdout.newlines
-
-    @property
-    def line_buffering(self):
-        return sys.stdout.line_buffering
-
-    def fileno(self) -> int:
-        return sys.stdout.fileno()
-
-    def flush(self) -> None:
-        sys.stdout.flush()
-
-    def isatty(self) -> bool:
-        return sys.stdout.isatty()
-
-    def read(self, size: int = -1) -> str:
-        return sys.stdout.read(size)
-
-    def readable(self) -> bool:
-        return sys.stdout.readable()
-
-    def readline(self, limit: int = -1) -> str:
-        return sys.stdout.readline(limit)
-
-    def readlines(self, hint: int = -1) -> List[str]:
-        return sys.stdout.readlines(hint)
-
-    def seek(self, offset: int, whence: int = SEEK_SET) -> int:
-        return sys.stdout.seek(offset, whence)
-
-    def seekable(self) -> bool:
-        return sys.stdout.seekable()
-
-    def tell(self) -> int:
-        return sys.stdout.tell()
-
-    def truncate(self, size: Optional[int] = None) -> int:
-        return sys.stdout.truncate(size)
-
-    def writable(self) -> bool:
-        return sys.stdout.writable()
-
-    def write(self, s: str) -> int:
-        return sys.stdout.write(s)
-
-    def writelines(self, lines: Iterable[str]) -> None:
-        return sys.stdout.writelines(lines)
-
-    def __next__(self) -> str:
-        return next(sys.stdout)
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(sys.stdout)
-
-    def __exit__(self, t: Optional[Type[BaseException]], value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> bool:
-        return sys.stdout.__exit__(t, value, traceback)

--- a/python/dazl/util/logging.py
+++ b/python/dazl/util/logging.py
@@ -3,52 +3,24 @@
 
 """
 Utilities for working with the built-in `logging` module.
+
+This module will be removed soon!
 """
 import logging
-import threading
-from typing import cast
+import warnings
 
-from ..util.io import StdoutStreamWrapper
+from .._logging import configure, VERBOSE
 
-VERBOSE = 5
 
-LOG_LOCK = threading.Lock()
-_default_logger_init = False
+__all__ = ['VERBOSE', 'setup_default_logger']
 
 
 def setup_default_logger(level=logging.INFO):
     """
     Sets up a default logger with sensible defaults.
+
+    This function is deprecated, and there is no replacement; you should instead configure your own
+    logging output as suitable for your needs (``logging.basicConfig()`` may suffice).
     """
-    root = logging.getLogger()
-    global _default_logger_init
-    if not _default_logger_init:
-        _default_logger_init = True
-    else:
-        root.warning('setup_default_logger being called more than once!')
-        return
-
-    logging.captureWarnings(True)
-
-    root.setLevel(level)
-    stream_handler = logging.StreamHandler(StdoutStreamWrapper())
-    formatter = logging.Formatter("[%(levelname)7s] %(asctime)s | %(name)-7s | %(message)s")
-    stream_handler.setFormatter(formatter)
-    root.addHandler(stream_handler)
-
-
-def log_verbose(logger: 'logging.Logger', msg, *args, **kwargs) -> None:
-    return logger.log(5, msg, *args, **kwargs)
-
-
-class _LoggerWithVerbose:
-    def verbose(self, msg, *args, **kwargs) -> None:
-        logger = cast(logging.Logger, self)
-        return log_verbose(logger, msg, *args, **kwargs)
-
-
-class LoggerWithVerbose(logging.Logger, _LoggerWithVerbose):
-    pass
-
-
-logging.addLevelName(VERBOSE, 'VERBOSE')
+    warnings.warn("dazl.setup_default_logger is deprecated", DeprecationWarning, stacklevel=2)
+    configure(level)

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 cache_dir=../.cache/pytest
+log_cli = True
+log_cli_level = DEBUG
 testpaths =
     tests/unit

--- a/python/tests/profiling/test_memory.py
+++ b/python/tests/profiling/test_memory.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test to check for memory leaks on long-running clients when connected to a ledger that isn't really
 doing much other than ticking time.
@@ -11,7 +14,9 @@ import sys
 from asyncio import get_event_loop
 from datetime import datetime
 
-from dazl import create, setup_default_logger, Network
+from dazl import create, Network
+# noinspection PyProtectedMember
+from dazl._logging import configure as configure_logger
 from dazl.model.reading import ContractCreateEvent, ReadyEvent
 from pympler import muppy, summary
 
@@ -51,5 +56,5 @@ def dump_state():
 
 
 if __name__ == '__main__':
-    setup_default_logger()
+    configure_logger()
     main(sys.argv[1])

--- a/python/tests/unit/dars.py
+++ b/python/tests/unit/dars.py
@@ -12,9 +12,6 @@ DAZL_ROOT = find_nearest_ancestor('.dazl-root', Path(__file__).resolve()).parent
 DAML_ROOT = DAZL_ROOT / 'python' / 'tests' / 'resources'
 
 
-setup_default_logger(logging.DEBUG)
-
-
 def load_dars() -> 'Mapping[str, Path]':
     """
     Ensure that the DARs in the test project are all pre-cooked.

--- a/python/tests/unit/test_flask.py
+++ b/python/tests/unit/test_flask.py
@@ -6,14 +6,12 @@ import logging
 from threading import Thread
 from time import sleep
 
-from dazl import create, LOG, setup_default_logger, Network, SimplePartyClient
+from dazl import create, LOG, Network, SimplePartyClient
 from dazl.model.reading import ReadyEvent
 from .dars import PostOffice
 
 
 def test_simple_flask_integration(sandbox):
-    setup_default_logger(logging.INFO)
-
     network = Network()
     network.set_config(url=sandbox)
     client = network.simple_new_party()


### PR DESCRIPTION
python: Improvements to logging infrastructure.
* Move the logging code to `dazl/_logging.py`.
* Deprecate `dazl.setup_default_logger`; applications should instead prefer to configure their own loggers (simply calling `logging.basicConfig()` is a good-enough alternative for most applications).
* Use `pytest`'s native support for logging the output of loggers, rather than the slightly more indirect route of writing log output to stdout, and then having `pytest` look at stdout.
* Before #66, `dazl` used Python's built-in `unittest` framework, which has no integration with Python's built-in `logging` framework. `dazl.util.io.StdoutStreamWrapper` existed solely to support `logger`/`unittest` integration, so it has been dropped.
* Add `LOG.verbose_timed`, `LOG.debug_timed`, and `LOG.info_timed`, all which produce context managers that can be used to easily log potentially long-running blocks of code.