### PR TITLE
python: Invalidate tests that will soon no longer be valid.

### DIFF
--- a/python/tests/unit/test_dar_upload.py
+++ b/python/tests/unit/test_dar_upload.py
@@ -31,6 +31,10 @@ async def test_dar_uploads_near_startup(sandbox):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    'Background package polling will soon be disabled, and packages will be loaded on an as-needed '
+    'basis. When this happens, PackagesAddedEvent will be dropped. If this is still a use-case you '
+    'need, please write your own poller around lookup.package_ids.')
 async def test_package_events(sandbox):
     initial_events = []
     follow_up_events = []

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -8,6 +8,8 @@ from .dars import DottedFields
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    'These tests are temporarily disabled because the new encoder does not support this.')
 async def test_record_dotted_fields_submit(sandbox):
     async with async_network(url=sandbox, dars=DottedFields) as network:
         client = network.aio_new_party()
@@ -28,6 +30,8 @@ async def test_record_dotted_fields_submit(sandbox):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    'These tests are temporarily disabled because the new encoder does not support this.')
 async def test_variant_dotted_fields_submit(sandbox):
     async with async_network(url=sandbox, dars=DottedFields) as network:
         client = network.aio_new_party()

--- a/python/tests/unit/test_dynamic_dar_loading.py
+++ b/python/tests/unit/test_dynamic_dar_loading.py
@@ -3,12 +3,15 @@
 
 from pathlib import Path
 
+import pytest
+
 from dazl.model.types_store import PackageStore, PackageProvider, MemoryPackageProvider
 from dazl.protocols.v1.grpc import grpc_package_sync
 from dazl.util.dar import DarFile
 from .dars import AllKindsOf, Pending
 
 
+@pytest.mark.skip('PackageStore is deprecated; this functionality will soon be removed')
 def test_package_sync_multiple_loads():
     store = PackageStore.empty()
 

--- a/python/tests/unit/test_package_loading.py
+++ b/python/tests/unit/test_package_loading.py
@@ -17,6 +17,7 @@ from .dars import AllKindsOf
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip('This test is no longer valid, as we do not force packages to be loaded on startup')
 async def test_package_loading(sandbox):
     d = {}
 


### PR DESCRIPTION
In the next version of dazl, package loading will now "sometimes" be lazy. This changes the way that message serialization/parsing code works in a very fundamental way, which has also opened up opportunities to prune some code that is not often used.

* `PackageAddedEvent` is "almost" deprecated because it doesn't (and can't) work in a sane way with lazy package loading; code like the following will no longer work the same way (and the handler itself will eventually be removed):

    ```python
    @client.package_added():
    def handle(event):
        print('A new package came in!')
    ```

    In the next version of dazl, if you depend on a package, simply load it; package loading will be both lazier and more explicit, rather than trying to sync packages in the background and present a consistent coherent package universe to callbacks,

* Records and variants _currently_ support a form of dotted-field syntax that was intended to be used as part of code that enabled CSV support for `dazl`. Support for this feature relied on being able to continually and immediately resolve types down lots of possible paths, and it is harder to implement this feature with dynamic package loading. Since it is not very heavily used, support for this feature is planned to be dropped if/until it can be resurrected in an inexpensive way.

* The `PackageStore` class will soon be deprecated, so tests targeting that specific class are no long relevant.