### PR TITLE
python: Introduce dazl.damlast.pkgfile.DarFile

### DIFF
--- a/_fixtures/src/post-office/integration-test.py
+++ b/_fixtures/src/post-office/integration-test.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 from dazl import create, exercise, Network, write_acs
 
-logging.basicConfig()
-
 LOG = logging.getLogger('integration_test')
 
 POSTMAN_PARTY = 'Postman'
@@ -138,6 +136,9 @@ def _main():
     """
     import argparse
     import subprocess
+
+    logging.basicConfig(level=logging.INFO)
+
     from dazl.util import ProcessLogger, find_free_port, kill_process_tree, wait_for_process_port
 
     argparser = argparse.ArgumentParser()

--- a/python/dazl/cli/ls.py
+++ b/python/dazl/cli/ls.py
@@ -44,6 +44,6 @@ class ListAllCommand(CliCommand):
 
         for party in network.parties():
             await network.aio_party(party).ready()
+        metadata = await network.aio_global().metadata()
 
-        write_acs(sys.stdout, network, fmt=fmt, include_archived=include_archived)
-        await network.shutdown()
+        write_acs(sys.stdout, network, metadata.store, fmt=fmt, include_archived=include_archived)

--- a/python/dazl/damlast/__init__.py
+++ b/python/dazl/damlast/__init__.py
@@ -21,6 +21,9 @@ encoding and decoding of values, see :mod:`dazl.values`.
 :mod:`dazl.damlast.parse`:
     Functions for parsing a DAML-LF Archive from its Protobuf definition.
 
+:mod:`dazl.damlast.errors`:
+    Subclasses of :class:`Error` that may be thrown by classes in this package.
+
 .. automodule:: dazl.damlast.daml_lf_1
     :members:
 .. automodule:: dazl.damlast.daml_types
@@ -29,6 +32,8 @@ encoding and decoding of values, see :mod:`dazl.values`.
     :members:
 .. automodule:: dazl.damlast.parse
     :members:
+.. automodule:: dazl.damlast.errors
 """
 
+from .pkgfile import DarFile, CachedDarFile, get_dar_package_ids
 from .visitor import PackageVisitor, ModuleVisitor, ExprVisitor, TypeVisitor, IdentityTypeVisitor

--- a/python/dazl/damlast/errors.py
+++ b/python/dazl/damlast/errors.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Error types
+-----------
+
+.. autoclass:: PackageNotFoundError
+.. autoclass:: NameNotFoundError
+"""
+
+from typing import Any, TYPE_CHECKING
+
+from ..model.core import DazlError
+
+if TYPE_CHECKING:
+    from . import daml_lf_1
+
+__all__ = ['PackageNotFoundError', 'NameNotFoundError']
+
+
+class PackageNotFoundError(DazlError):
+    """
+    Raised when a :class:`Package` was expected but could not be found.
+
+    This error can also be raised in places where types/values are being resolved; it is an
+    indication that the operation MAY succeed if the package of the specified ID is fetched and
+    the original option retried.
+    """
+
+    def __init__(self, ref: 'daml_lf_1.PackageRef'):
+        super().__init__(ref)
+        self.ref = ref
+
+
+class NameNotFoundError(DazlError):
+    """
+    Raised when a :class:`daml_lf_1.DefDataType`, :class:`daml_lf_1.DefValue`, or
+    :class:`daml_lf_1.DefTemplate` of a specific name was expected, but could not be found.
+
+    Typically this error is raised when the *package ID* is valid, but the name is not. Because
+    package IDs are immutable, this error is not normally retryable.
+    """
+
+    def __init__(self, ref: 'Any'):
+        super().__init__(ref)
+        self.ref = ref

--- a/python/dazl/damlast/pkgfile.py
+++ b/python/dazl/damlast/pkgfile.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from io import BytesIO
+from os import PathLike
+from pathlib import Path
+from typing import AbstractSet, BinaryIO, Collection, Generator, Mapping, Optional, Union
+from zipfile import ZipFile
+
+from .daml_lf_1 import Archive, Package, PackageRef
+from .parse import parse_archive
+
+from .._gen.com.daml.daml_lf_dev import daml_lf_pb2 as pb
+
+# Wherever the API expects a DAR, we can take a file path, `bytes`, or a byte buffer.
+Dar = Union[bytes, str, Path, BinaryIO]
+
+__all__ = ['Dar', 'DarFile', 'CachedDarFile', 'get_dar_package_ids']
+
+
+class DarFile:
+    """
+    Provides access to the contents of a .dar file.
+
+    This conforms to the :class:`PackageProvider` protocol.
+
+    This class is _not_ thread-safe.
+    """
+
+    def __init__(self, dar: 'Dar'):
+        """
+        Initialize a new DarFile.
+
+        :param dar:
+            A path to a file (either expressed as str or pathlib.Path), a bytes blob, or a buffer.
+        """
+        if isinstance(dar, str):
+            self.filename = dar
+            self._buf = None
+            self._zip = ZipFile(self.filename)
+
+        elif isinstance(dar, PathLike):
+            self.filename = dar.__fspath__()
+            self._buf = None
+            self._zip = ZipFile(self.filename)
+
+        elif isinstance(dar, bytes):
+            self.filename = None
+            self._buf = BytesIO(dar)
+            self._zip = ZipFile(self._buf)
+
+        elif hasattr(dar, 'read'):
+            # file-like object (buffers, files, etc.)
+            self.filename = None
+            self._buf = None
+            self._zip = ZipFile(dar)
+
+        else:
+            raise TypeError('DarFile only understands file paths or binary blobs')
+
+    def __enter__(self) -> 'DarFile':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        self._zip.close()
+        if self._buf is not None:
+            self._buf.close()
+
+    def manifest(self) -> 'Optional[Mapping[str, str]]':
+        """
+        Return the contents of the manifest of this DAR.
+        """
+        names = self._zip.namelist()
+        if 'META-INF/MANIFEST.MF' in names:
+            manifest_bytes = self._zip.read('META-INF/MANIFEST.MF')
+            manifest = {}
+            for line in manifest_bytes.decode('utf-8').splitlines():
+                name, _, value = line.partition(':')
+                manifest[name] = value.strip()
+            return manifest
+        else:
+            return None
+
+    def sdk_version(self) -> 'Optional[str]':
+        """
+        Return the SDK version used to compile this dar (if this information is available).
+        """
+        manifest = self.manifest()
+        return manifest.get('Sdk-Version') if manifest is not None else None
+
+    def archives(self) -> 'Collection[Archive]':
+        """
+        Return :class:`Archive` instances from this :class:`DarFile`.
+
+        :class:`CachedDarFile` is a better choice than `DarFile` if this method is frequently called
+        on the same :class:`DarFile`, as package parsing is an expensive operation.
+        """
+        return [parse_archive(a.hash, a.payload) for a in self._pb_archives()]
+
+    def package(self, package_id: 'PackageRef') -> 'Package':
+        """
+        Return the :class:`Package` corresponding to the specified :class:`PackageRef`.
+
+        This function is somewhat inefficient as it must check every DALF for the specified package
+        ID. The :method:`DarFile.archives` function should be used if it is known that all archives
+        in a DAR are to be accessed, or use a :class:`CachedDarFile` instance if random access of
+        packages by package ID are needed.
+        """
+        for a in self._pb_archives():
+            if a.hash == package_id:
+                return parse_archive(a.hash, a.payload).package
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        """
+        Return the set of package IDs from this DAR.
+        """
+        return frozenset(a.hash for a in self._pb_archives())
+
+    def _dalf_names(self) -> 'Generator[str, None, None]':
+        """
+        Return a generator over the names of DALF files in this DarFile.
+        """
+        return (name for name in self._zip.namelist() if name.endswith('.dalf'))
+
+    def _pb_archives(self) -> 'Generator[pb.Archive, None, None]':
+        """
+        Return a generator over :class:`pb.Archive` instances. Crucially, the Protobuf messages
+        contain DAML-LF as a ``bytes`` field that has not yet been parsed.
+        """
+        for name in self._dalf_names():
+            contents = self._zip.read(name)
+
+            a = pb.Archive()
+            a.ParseFromString(contents)
+            yield a
+
+
+class CachedDarFile:
+    """
+    A caching variation of :class:`DarFile`.
+
+    :class:`CachedDarFile` tries to do disk operations only once, and hold onto their results in
+    memory. This will generally improve performance at the expense of increased memory usage.
+    """
+
+    def __init__(self, dar: 'Dar'):
+        self._dar = dar
+        from threading import Lock
+        self._lock = Lock()
+        self._archives = None
+
+    def archives(self) -> 'Collection[Archive]':
+        if self._archives is None:
+            with self._lock:
+                if self._archives is None:
+                    with DarFile(self._dar) as dar:
+                        self._archives = dar.archives()
+        return self._archives
+
+    def package(self, package_id: 'PackageRef') -> 'Package':
+        # TODO: This import needs to be local as long as the dazl.util.dar module still exists
+        #  to avoid import cycles. Move this to the top of the file when dazl.util.dar is removed.
+        from .errors import PackageNotFoundError
+
+        for archive in self.archives():
+            if archive.hash == package_id:
+                return archive.package
+
+        raise PackageNotFoundError(package_id)
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        return frozenset([archive.hash for archive in self.archives()])
+
+
+def get_dar_package_ids(dar: 'Dar') -> 'AbstractSet[PackageRef]':
+    """
+    Return the package IDs for a DAR.
+    """
+    with DarFile(dar) as dar_file:
+        return dar_file.package_ids()

--- a/python/dazl/pretty/table/write.py
+++ b/python/dazl/pretty/table/write.py
@@ -9,6 +9,7 @@ from typing import Optional, TextIO, TYPE_CHECKING
 
 from .fmt_base import get_formatter
 from .model import TableBuilder
+from ...model.types_store import PackageStore
 
 if TYPE_CHECKING:
     from ...client import Network
@@ -19,6 +20,7 @@ __all__ = ['write_acs']
 def write_acs(
         buf: 'TextIO',
         network: 'Network',
+        store: 'PackageStore' = None,
         fmt: 'Optional[str]' = None,
         include_archived: bool = False) \
         -> None:
@@ -29,6 +31,7 @@ def write_acs(
         The buffer to write to.
     :param network:
         The network to write data from.
+    :param store:
     :param fmt:
         Format of the output; currently either ``"json"`` or ``"pretty"``.
     :param include_archived:
@@ -48,6 +51,8 @@ def write_acs(
             for cid, cdata in client.find_active('*').items():
                 table.add(party, cid, cdata, None)
 
-    metadata = network.simple_global().metadata()
-    for line in formatter.render(metadata.store, parties, table):
+    if store is None:
+        store = network.simple_global().metadata().store
+
+    for line in formatter.render(store, parties, table):
         buf.write(line + '\n')

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from io import BytesIO
-from os import path
-from pathlib import Path
-from typing import Dict, Collection, Mapping, Optional, Sequence, TYPE_CHECKING
-from zipfile import ZipFile
 
-from ..util.path_util import pathify
+import warnings
+from io import BytesIO
+from typing import AbstractSet, Collection, Mapping, Optional, Sequence, TYPE_CHECKING
+
+
+from ..damlast.daml_lf_1 import PackageRef
+from ..damlast.parse import parse_archive
+from ..damlast.pkgfile import Dar, DarFile as _DarFile
 
 if TYPE_CHECKING:
-    from ..model.core import Dar
-    from ..model.types import PackageId, PackageIdSet
     from ..model.types_store import PackageStore, PackageProvider
 
 
@@ -18,152 +18,122 @@ def get_archives(contents: bytes) -> 'Mapping[str, bytes]':
     """
     Attempt to parse the specified contents as either a DALF or a DAR, and return a mapping of
     package IDs to DALF bytes.
+    This class is deprecated as it assumes and expose use of a :class:`PackageStore` and
+
+    :class:`Type`, all of which are deprecated.
 
     :param contents: A byte array to attempt to parse.
     :return: Return a mapping from package ID to byte contents.
     """
+    warnings.warn(
+        'get_archives is deprecated. For DAR parsing, use dazl.damlast.DarFile instead. '
+        'There is no replacement for DALF parsing.', DeprecationWarning, stacklevel=2)
+
     if contents[0:4] == b'PK\03\04':
         with BytesIO(contents) as buf:
-            with DarFile(buf) as dar:
-                return dar.get_archives()
-    else:
-        # parse as a single DALF
-        from ..protocols.v1.pb_parse_metadata import parse_archive_payload
-        a = parse_archive_payload(contents)
-        return {a.hash: contents}
+            with _DarFile(buf) as dar:
+                # noinspection PyProtectedMember
+                return {name: dar._zip.read(name) for name in dar._dalf_names()}
+
+    raise Exception(
+        'get_archives(...) only works on DAR files, and is additionally deprecated. '
+        'Use dazl.damlast.DarFile instead.')
 
 
-class DarFile:
+class DarFile(_DarFile):
     """
     Provides access to the contents of a .dar file.
     """
     def __init__(self, dar: 'Dar'):
-        if isinstance(dar, (str, Path)):
-            self._buf = None
-            self.dar_path = pathify(dar)
-            self.dar_contents = ZipFile(str(self.dar_path))
-        elif isinstance(dar, bytes):
-            self._buf = BytesIO(dar)
-            self.dar_path = None
-            self.dar_contents = ZipFile(self._buf)
-        else:
-            self._buf = None
-            self.dar_path = None
-            self.dar_contents = ZipFile(dar)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._buf is not None:
-            self._buf.close()
-        self.close()
-
-    def close(self):
-        self.dar_contents.close()
+        super().__init__(dar)
+        warnings.warn(
+            'dazl.util.dar.DarFile is deprecated; please use dazl.damlast.DarFile instead.',
+            DeprecationWarning, stacklevel=2)
 
     def read_metadata(self) -> 'PackageStore':
+        warnings.warn(
+            'read_metadata is deprecated. For DAR parsing, use dazl.damlast.DarFile instead. '
+            'There is no replacement for DALF parsing.', DeprecationWarning, stacklevel=2)
+        # noinspection PyProtectedMember
+        from ..protocols.v1.pb_parse_metadata import _parse_daml_metadata_pb
         from ..model.types_store import PackageStore
         store = PackageStore.empty()
-        dalf_names = self.get_dalf_names()
-        for dalf_name in dalf_names:
-            contents = self.dar_contents.read(dalf_name)
-            store.register_all(parse_dalf(contents))
+
+        for archive in self.archives():
+            store.register_all(_parse_daml_metadata_pb(archive))
         return store
 
     def get_archives(self) -> 'Mapping[str, bytes]':
         """
         Return a mapping from package ID to byte contents.
         """
-        from ..protocols.v1.pb_parse_metadata import parse_archive_payload
-        archives = {}  # type: Dict[str, bytes]
-        for dalf_name in self.get_dalf_names():
-            contents = self.dar_contents.read(dalf_name)
-            payload = parse_archive_payload(contents)
-            archives[payload.hash] = contents
-        return archives
+        warnings.warn(
+            'get_archives is deprecated; there is no replacement.',
+            DeprecationWarning)
+        return {a.hash: a.payload for a in self._pb_archives()}
 
     def get_dalf_names(self) -> 'Sequence[str]':
-        dalf_names = []
-        for name in self.dar_contents.namelist():
-            _, ext = path.splitext(name)
-            if ext == '.dalf':
-                dalf_names.append(name)
-        return dalf_names
+        warnings.warn(
+            'get_dalf_names is deprecated; there is no replacement.',
+            DeprecationWarning, stacklevel=2)
+        return list(self._dalf_names())
 
     def get_manifest(self) -> 'Optional[Mapping[str, str]]':
         """
         Return the contents of the manifest of this DAR.
-        :return:
         """
-        names = self.dar_contents.namelist()
-        if 'META-INF/MANIFEST.MF' in names:
-            manifest_bytes = self.dar_contents.read('META-INF/MANIFEST.MF')
-            manifest = {}
-            for line in manifest_bytes.decode('utf-8').splitlines():
-                print(line)
-                name, _, value = line.partition(':')
-                manifest[name] = value.strip()
-            return manifest
-        else:
-            return None
+        warnings.warn(
+            'get_manifest() is deprecated; use manifest() instead.',
+            DeprecationWarning, stacklevel=2)
+        return self.manifest()
 
     def get_sdk_version(self) -> 'Optional[str]':
         """
         Return the SDK version used to compile this dar (if this information is available).
-        """
-        manifest = self.get_manifest()
-        return manifest.get('Sdk-Version') if manifest is not None else None
 
-    def get_package_ids(self) -> 'PackageIdSet':
+        This method is deprecated; use dazl.damlast..DarFile
+        """
+        warnings.warn(
+            'get_sdk_version() is deprecated; use sdk_versions() instead.',
+            DeprecationWarning, stacklevel=2)
+        return self.sdk_version()
+
+    def get_package_ids(self) -> 'AbstractSet[PackageRef]':
         """
         Return the set of package IDs from this DAR.
         """
-        # In order to make this call perform more quickly, we read the Archive object, but not any
-        # of its contents.
-        package_ids = set()
-        for dalf_name in self.get_dalf_names():
-            from ..model.types import PackageId
-            from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import Archive
-
-            contents = self.dar_contents.read(dalf_name)
-
-            a = Archive()
-            a.ParseFromString(contents)
-
-            package_ids.add(PackageId(a.hash))
-
-        return frozenset(package_ids)
+        warnings.warn(
+            'get_package_ids() is deprecated; please use package_ids() instead.',
+            DeprecationWarning, stacklevel=2)
+        return self.package_ids()
 
     def get_package_provider(self) -> 'PackageProvider':
-        from typing import Dict
+        warnings.warn(
+            'get_package_provider() is deprecated; use the methods of the '
+            'dazl.damlast.PackageProvider protocol as implemented on DarFile directly.',
+            DeprecationWarning)
         from ..model.types_store import MemoryPackageProvider
-        from ..damlast.daml_lf_1 import PackageRef
-        from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import Archive
-
-        packages = {}  # type: Dict[PackageRef, bytes]
-        dalf_names = self.get_dalf_names()
-        for dalf_name in dalf_names:
-            contents = self.dar_contents.read(dalf_name)
-
-            a = Archive()
-            a.ParseFromString(contents)
-
-            packages[a.hash] = a.payload
-
-        return MemoryPackageProvider(packages)
+        return MemoryPackageProvider(self.get_archives())
 
 
 def parse_dalf(contents: bytes) -> 'PackageStore':
+    warnings.warn(
+        'parse_dalf is deprecated, as PackageStore and Type are deprecated.',
+        DeprecationWarning, stacklevel=2)
+    # noinspection PyProtectedMember
+    from ..protocols.v1.pb_parse_metadata import _parse_daml_metadata_pb
     from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import Archive
-    from ..damlast.parse import parse_archive_payload
-    from ..protocols.v1.pb_parse_metadata import parse_daml_metadata_pb
     a = Archive()
     a.ParseFromString(contents)
-    p = parse_archive_payload(a.hash, a.payload)
-    return parse_daml_metadata_pb(a.hash, p)
+    return _parse_daml_metadata_pb(parse_archive(a.hash, a.payload))
 
 
-def get_dar_package_ids(dar: 'Dar') -> 'Collection[PackageId]':
-    with DarFile(dar) as dar_file:
-        return dar_file.get_package_ids()
+def get_dar_package_ids(dar: 'Dar') -> 'Collection[PackageRef]':
+    warnings.warn(
+        'dazl.util.dar.get_dar_package_ids is deprecated; '
+        'please use dazl.damlast.get_dar_package_ids instead.', DeprecationWarning, stacklevel=2)
+
+    # This is a local import to get around circular dependencies; also the replacement function
+    # is the same name as our own
+    from ..damlast.pkgfile import get_dar_package_ids
+    return get_dar_package_ids(dar)

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from dazl.util.dar import DarFile
+from dazl.damlast import DarFile
 from .dars import Pending
 
 
 def test_get_sdk_version():
     with DarFile(Pending) as dar:
-        print(dar.get_manifest())
-        assert '1.3.0' == dar.get_sdk_version()
+        print(dar.manifest())
+        assert '1.3.0' == dar.sdk_version()

--- a/python/tests/unit/test_historical_dar_parsing.py
+++ b/python/tests/unit/test_historical_dar_parsing.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 from dazl import LOG
-from dazl.util.dar import DarFile
+from dazl.damlast import DarFile
 
 ARCHIVES: Path = Path(__file__).absolute().parent.parent.parent.parent / '_fixtures' / 'archives'
 
@@ -17,7 +17,7 @@ def test_dar_version_compatibility(subtests):
         short_dar = dar.relative_to(ARCHIVES)
         with subtests.test(str(short_dar)):
             dar_file = DarFile(dar)
-            metadata = dar_file.read_metadata()
-            LOG.info('Successfully read %s with package IDs %r.', short_dar,
-                     metadata.package_ids())
+            archives = dar_file.archives()
+            LOG.info('Successfully read %s with package IDs %r.',
+                     short_dar, [a.hash for a in archives])
 

--- a/python/tests/unit/test_package_loading.py
+++ b/python/tests/unit/test_package_loading.py
@@ -11,8 +11,8 @@ from operator import setitem
 import pytest
 
 from dazl import async_network
+from dazl.damlast import DarFile
 from dazl.model.types_store import PackageStore
-from dazl.util.dar import DarFile
 from .dars import AllKindsOf
 
 


### PR DESCRIPTION
Deprecate `dazl.util.dar.DarFile` and its API for fetching data as a `PackageStore`.

The new `DarFile` is a bit lighter-weight and does not do any internal caching, and parsing happens _synchronously_. Asynchronous parsing (to avoid blocking the main thread) will be handled by a new dedicated package loader in an upcoming PR.