### PR TITLE
python: Introduce SymbolLookup and PackageLoader

### DIFF
--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -30,6 +30,7 @@ from .. import LOG
 from .bots import Bot, BotCollection
 from .config import AnonymousNetworkConfig, NetworkConfig, PartyConfig
 from ._base_model import IfMissingPartyBehavior, CREATE_IF_MISSING
+from ..damlast import get_dar_package_ids
 from ..metrics import MetricEvents
 from ..model.core import ContractsState, ContractMatch, \
     ContractContextualData, ContractContextualDataCollection, Dar
@@ -41,7 +42,6 @@ from ..model.writing import EventHandlerResponse
 from ..prim import ContractId, ContractData, Party, TimeDeltaLike, to_party
 from ..scheduler import RunLevel, validate_install_signal_handlers
 from ..util.asyncio_util import await_then
-from ..util.dar import get_dar_package_ids
 from ..util.io import get_bytes
 from ._events import EventHandler, AEventHandler, EventHandlerDecorator, AEventHandlerDecorator, \
     fluentize

--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -72,6 +72,16 @@ class URLConfig:
         param_type=SECONDS_TYPE,
         default_value=DEFAULT_CONNECT_TIMEOUT_SECONDS)
 
+    eager_package_fetch: Optional[bool] = config_field(
+        'whether to fetch all packages on startup',
+        param_type=BOOLEAN_TYPE,
+        default_value=True)
+
+    package_lookup_timeout: Optional[float] = config_field(
+        'number of seconds before giving up on a package',
+        param_type=SECONDS_TYPE,
+        default_value=DEFAULT_CONNECT_TIMEOUT_SECONDS)
+
     application_name: Optional[str] = config_field(
         'The name that this application uses to identify itself to the ledger.',
         param_type=STRING_TYPE,

--- a/python/dazl/client/pkg_loader.py
+++ b/python/dazl/client/pkg_loader.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from asyncio import ensure_future, get_event_loop, gather, wait_for, sleep
+from datetime import timedelta
+from concurrent.futures import ThreadPoolExecutor
+from typing import AbstractSet, Awaitable, Callable, Dict, Set, TypeVar
+
+from .. import LOG
+from ..damlast.daml_lf_1 import Archive, Package, PackageRef
+from ..damlast.pkgfile import Dar
+from ..damlast.errors import PackageNotFoundError, NameNotFoundError
+from ..damlast.lookup import MultiPackageLookup
+from ..model.core import DazlError
+from ..model.lookup import validate_template
+
+if sys.version_info >= (3, 7):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
+
+__all__ = ['SyncPackageService', 'PackageLoader']
+
+
+T = TypeVar('T')
+
+DEFAULT_TIMEOUT = timedelta(seconds=30)
+
+
+class SyncPackageService(Protocol):
+    """
+    A service that synchronously provides package information.
+    """
+
+    def package_bytes(self, package_id: 'PackageRef') -> bytes:
+        raise NotImplementedError('SyncPackageService.package_bytes requires an implementation')
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        raise NotImplementedError('SyncPackageService.package_ids requires an implementation')
+
+
+class PackageLoader:
+    """
+    Loader for packages from a remote PackageService.
+
+    This class handles retries and backoffs, and avoids having more than one request in flight for
+    the same package ID. It is intended to be shared by all local clients that may need package
+    information.
+    """
+
+    def __init__(
+            self,
+            package_lookup: 'MultiPackageLookup',
+            conn: 'SyncPackageService' = None,
+            timeout: 'timedelta' = DEFAULT_TIMEOUT):
+        self._package_lookup = package_lookup
+        self._conn = conn
+        self._timeout = timeout
+        self._loading_futs = dict()  # type: Dict[PackageRef, Awaitable[Package]]
+        self._parsing_futs = dict()  # type: Dict[PackageRef, Awaitable[Archive]]
+        self._executor = ThreadPoolExecutor(3)
+
+    def set_connection(self, conn):
+        self._conn = conn
+
+    async def do_with_retry(self, fn: 'Callable[[], T]') -> 'T':
+        """
+        Perform a synchronous action that assumes the existence of one or more packages. In the
+        event the function raises :class:`PackageNotFoundError` or a wildcarded
+        :class:`NameNotFoundError`, the required package/type is fetched and the operation retried.
+
+        If, after a retry, an expected package or type could not be found, the exception is
+        re-raised to the caller.
+
+        :param fn: A function to invoke.
+        :return: The result of that function.
+        """
+        failed_types = set()  # type: Set[str]
+        failed_packages = set()  # type: Set[PackageRef]
+        while True:
+            try:
+                return fn()
+
+            except PackageNotFoundError as ex:
+                # every time we fail serialization due to a missing package or type,
+                # try to resolve it; remember what we tried, because if we fail again
+                # for the same reason it is likely fatal
+                if ex.ref in failed_packages:
+                    # we already looked for this package and couldn't find it; this will
+                    # never succeed
+                    raise
+                failed_packages.add(ex.ref)
+                await self.load(ex.ref)
+
+            except NameNotFoundError as ex:
+                if ex.ref in failed_types:
+                    # we already looked for this type and couldn't find it; this will
+                    # never succeed
+                    LOG.verbose(
+                        "Failed to find name %s in all known packages, "
+                        "even after fetching the latest.",
+                        ex.ref)
+                    raise
+
+                pkg_id, name = validate_template(ex.ref)
+                if pkg_id == '*':
+                    # we don't know what package contains this type, so we have no
+                    # choice but to look in all known packages
+                    LOG.verbose(
+                        "Failed to find name %s in all known packages, "
+                        "so loading ALL packages...", name)
+                    failed_types.add(ex.ref)
+                    await self.load_all()
+                else:
+                    # we know what package this type comes from, but it did not contain
+                    # the required type
+                    LOG.warning("Found package %s, but it did not include type %s", pkg_id, name)
+                    raise
+
+    async def preload(self, *contents: 'Dar') -> None:
+        """
+        Populate a :class:`PackageCache` with types from DARs.
+
+        :param contents:
+            One or more DARs to load into a local package cache.
+        """
+
+    async def load(self, ref: 'PackageRef') -> 'Package':
+        """
+        Load a package ID from the remote server. If the package has additional dependencies, they
+        are also loaded.
+
+        :param ref: One or more :class:`PackageRef`s.
+        :raises: PackageNotFoundError if the package could not be resolved
+        """
+        # If the package has already been loaded, then skip all the expensive I/O stuff
+        try:
+            return self._package_lookup.package(ref)
+        except PackageNotFoundError:
+            pass
+
+        # If we already have a request in-flight, simply return that same Future to our caller;
+        # do not try to schedule a new request
+        fut = self._loading_futs.get(ref)
+        if fut is None:
+            fut = ensure_future(self._load_and_parse_package(ref))
+            self._loading_futs[ref] = fut
+        package = await fut
+
+        _ = self._loading_futs.pop(ref, None)
+        _ = self._parsing_futs.pop(ref, None)
+
+        return package
+
+    async def _load_and_parse_package(self, package_id: 'PackageRef') -> 'Package':
+        from ..damlast.parse import parse_archive
+
+        LOG.info("Loading package: %s", package_id)
+
+        loop = get_event_loop()
+        conn = self._conn
+        if conn is None:
+            raise DazlError('a connection is not configured')
+
+        archive_bytes = await wait_for(
+            self.__fetch_package_bytes(conn, package_id), timeout=self._timeout.total_seconds())
+
+        LOG.info("Loaded for package: %s, %d bytes", package_id, len(archive_bytes))
+
+        # we only ever want a package to be parsed once; it could be that there were multiple
+        # attempts to load a package in flight (though this shouldn't happen either)
+        fut = self._parsing_futs.get(package_id)
+        if fut is None:
+            fut = ensure_future(loop.run_in_executor(
+                self._executor, lambda: parse_archive(package_id, archive_bytes)))
+            self._parsing_futs[package_id] = fut
+
+        archive = await fut
+        self._package_lookup.add_archive(archive)
+        return archive.package
+
+    async def __fetch_package_bytes(self, conn, package_id):
+        loop = get_event_loop()
+        sleep_interval = 1
+
+        while True:
+            # noinspection PyBroadException
+            try:
+                return await loop.run_in_executor(
+                    self._executor, lambda: conn.package_bytes(package_id))
+            except Exception:
+                # We tried fetching the package but got an error. Retry, backing off to waiting as
+                # much as 30 seconds between each attempt.
+                await sleep(sleep_interval)
+                sleep_interval = min(sleep_interval * 2, 30)
+                LOG.exception("Failed to fetch package; this will be retried.")
+
+    async def load_all(self):
+        """
+        Load all packages from the remote server.
+        """
+        loop = get_event_loop()
+
+        package_ids = set(await loop.run_in_executor(self._executor, self._conn.package_ids))
+        package_ids -= self._package_lookup.package_ids()
+        if package_ids:
+            await gather(*(self.load(package_id) for package_id in package_ids))

--- a/python/dazl/damlast/__init__.py
+++ b/python/dazl/damlast/__init__.py
@@ -21,10 +21,14 @@ encoding and decoding of values, see :mod:`dazl.values`.
 :mod:`dazl.damlast.parse`:
     Functions for parsing a DAML-LF Archive from its Protobuf definition.
 
+:mod:`dazl.damlast.protocols`:
+    Protocols (interfaces) for components in this package.
+
 :mod:`dazl.damlast.errors`:
     Subclasses of :class:`Error` that may be thrown by classes in this package.
 
 .. automodule:: dazl.damlast.daml_lf_1
+
     :members:
 .. automodule:: dazl.damlast.daml_types
     :members:
@@ -33,6 +37,8 @@ encoding and decoding of values, see :mod:`dazl.values`.
 .. automodule:: dazl.damlast.parse
     :members:
 .. automodule:: dazl.damlast.errors
+.. automodule:: dazl.damlast.protocols
+
 """
 
 from .pkgfile import DarFile, CachedDarFile, get_dar_package_ids

--- a/python/dazl/damlast/lookup.py
+++ b/python/dazl/damlast/lookup.py
@@ -6,10 +6,24 @@ DAML-LF fast lookups
 --------------------
 """
 
-from .daml_lf_1 import TypeConName, ModuleRef, DottedName
+# Implementation notes:
+#
+# The code in here is fairly monotonous and boilerplate heavy. However, being too creative here can
+# potentially lead to performance degradations, particularly at application startup where type and
+# template lookups by name are very frequent. Please be conscious of the runtime costs of
+# modifications in this file!
 
+import threading
+from types import MappingProxyType
+from typing import Any, Collection, Dict, NoReturn, Iterable, Optional, Tuple, AbstractSet
 
-__all__ = ['parse_type_con_name']
+from .daml_lf_1 import Archive, DefDataType, DefValue, DefTemplate, DottedName, ModuleRef, \
+    PackageRef, TemplateChoice, TypeConName, ValName, Package
+from .errors import NameNotFoundError, PackageNotFoundError
+from .protocols import SymbolLookup
+from ..model.lookup import validate_template
+
+__all__ = ['parse_type_con_name', 'EmptyLookup', 'PackageLookup', 'MultiPackageLookup']
 
 
 def parse_type_con_name(val: str) -> 'TypeConName':
@@ -25,3 +39,331 @@ def parse_type_con_name(val: str) -> 'TypeConName':
     module_name, _, entity_name = name.rpartition(':')
     module_ref = ModuleRef(pkg, DottedName(module_name.split('.')))
     return TypeConName(module_ref, entity_name.split('.'))
+
+
+def empty_lookup_impl(ref: 'Any') -> 'NoReturn':
+    pkg, _ = validate_template(ref)
+    if pkg != '*':
+        raise PackageNotFoundError(pkg)
+    else:
+        raise NameNotFoundError(ref)
+
+
+class EmptyLookup(SymbolLookup):
+    """
+    A :class:`SymbolLookup` that trivially throws for all of its functions.
+
+    This can be used where a :class:`SymbolLookup` instance is useful but an implementation is not
+    required.
+
+    All methods are implemented such that if the provided ref has a package ID,
+    :class:`PackageNotFoundError` is thrown; otherwise, :class:`NameNotFoundError` is thrown.
+    """
+
+    __slots__ = ()
+
+    def data_type_name(self, ref: 'Any') -> 'NoReturn':
+        return empty_lookup_impl(ref)
+
+    def data_type(self, ref: 'Any') -> 'NoReturn':
+        return empty_lookup_impl(ref)
+
+    def value(self, ref: 'Any') -> 'NoReturn':
+        return empty_lookup_impl(ref)
+
+    def template_name(self, ref: 'Any') -> 'NoReturn':
+        return empty_lookup_impl(ref)
+
+    def template(self, ref: 'Any') -> 'NoReturn':
+        return empty_lookup_impl(ref)
+
+
+class PackageLookup(SymbolLookup):
+    """
+    Caching structure to make lookups on type names within a :class:`Package` faster.
+    """
+
+    def __init__(self, archive: 'Archive'):
+        self.archive = archive
+
+        data_types = {}  # type: Dict[str, Tuple[TypeConName, DefDataType]]
+        values = {}  # type: Dict[str, Tuple[ValName, DefValue]]
+        templates = {}  # type: Dict[str, Tuple[TypeConName, DefTemplate]]
+        for module in self.archive.package.modules:
+            module_ref = ModuleRef(archive.hash, module.name)
+
+            for dt in module.data_types:
+                dt_name = TypeConName(module_ref, dt.name.segments)
+                data_types[f'{module.name}:{dt.name}'] = (dt_name, dt)
+
+            for value in module.values:
+                value_name = ValName(module_ref, value.name_with_type.name)
+                values[f'{module.name}:{value.name_with_type.name}'] = (value_name, value)
+
+            for tmpl in module.templates:
+                tmpl_name = TypeConName(module_ref, tmpl.tycon.segments)
+                templates[f'{module.name}:{tmpl.tycon}'] = (tmpl_name, tmpl)
+
+        self._data_types = MappingProxyType(data_types)
+        self._values = MappingProxyType(values)
+        self._templates = MappingProxyType(templates)
+
+    def archives(self) -> 'Collection[Archive]':
+        return [self.archive]
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        return frozenset([self.archive.hash])
+
+    def data_type_name(self, ref: 'Any') -> 'TypeConName':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            dt_name = self.local_data_type_name(name)
+            if dt_name is not None:
+                return dt_name
+
+        raise NameNotFoundError(ref)
+
+    def data_type(self, ref: 'Any') -> 'DefDataType':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            dt = self.local_data_type(name)
+            if dt is not None:
+                return dt
+
+        raise NameNotFoundError(ref)
+
+    def local_data_type_name(self, name: str) -> 'Optional[TypeConName]':
+        r = self._data_types.get(name)
+        return r[0] if r is not None else None
+
+    def local_data_type(self, name: str) -> 'Optional[DefDataType]':
+        """
+        Variation of :meth:`data_type` that assumes the name is already scoped to this package.
+        Unlike :meth:`data_type`, this method returns ``None`` in the case of no match.
+
+        You should not normally use this method directly, and instead prefer to use the methods of
+        the :class:`SymbolLookup` protocol.
+
+        :param name:
+            A name to search for. Must be of the form ``"ModuleName:EntityName"``, where both
+            modules and entities are dot-delimited.
+        :return:
+            Either a matching :class:`DefDataType`, or ``None`` if no match.
+        """
+        r = self._data_types.get(name)
+        return r[1] if r is not None else None
+
+    def value(self, ref: 'Any') -> 'DefValue':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            dt = self.local_value(name)
+            if dt is not None:
+                return dt
+
+        raise NameNotFoundError(ref)
+
+    def local_value(self, name: str) -> 'Optional[DefValue]':
+        """
+        Variation of :meth:`data_type` that assumes the name is already scoped to this package.
+        Unlike :meth:`data_type`, this method returns ``None`` in the case of no match.
+
+        You should not normally use this method directly, and instead prefer to use the methods of
+        the :class:`SymbolLookup` protocol.
+
+        :param name:
+            A name to search for. Must be of the form ``"ModuleName:EntityName"``, where both
+            modules and entities are dot-delimited.
+        :return:
+            Either a matching :class:`DefDataType`, or ``None`` if no match.
+        """
+        r = self._values.get(name)
+        return r[1] if r is not None else None
+
+    def template_names(self, ref: 'Any') -> 'Collection[TypeConName]':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            if name == '*':
+                return self.local_template_names()
+            elif name in self._templates:
+                n, _ = self._templates.get(name)
+                return n
+        return []
+
+    def template_name(self, ref: 'Any') -> 'TypeConName':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            tmpl = self.local_template_name(name)
+            if tmpl is not None:
+                return tmpl
+
+        raise NameNotFoundError(ref)
+
+    def template(self, ref: 'Any') -> 'DefTemplate':
+        pkg, name = validate_template(ref)
+        if pkg == self.archive.hash or pkg == '*':
+            tmpl = self.local_template(name)
+            if tmpl is not None:
+                return tmpl
+
+        raise NameNotFoundError(ref)
+
+    def local_template_names(self) -> 'Collection[TypeConName]':
+        return [n for n, _ in self._templates.values()]
+
+    def local_template_name(self, name: str) -> 'Optional[TypeConName]':
+        r = self._templates.get(name)
+        return r[0] if r is not None else None
+
+    def local_template(self, name: str) -> 'Optional[DefTemplate]':
+        """
+        Variation of :meth:`data_type` that assumes the name is already scoped to this package.
+        Unlike :meth:`data_type`, this method returns ``None`` in the case of no match.
+
+        You should not normally use this method directly, and instead prefer to use the methods of
+        the :class:`SymbolLookup` protocol.
+
+        :param name:
+            A name to search for. Must be of the form ``"ModuleName:EntityName"``, where both
+            modules and entities are dot-delimited.
+        :return:
+            Either a matching :class:`DefDataType`, or ``None`` if no match.
+        """
+        r = self._templates.get(name)
+        return r[1] if r is not None else None
+
+
+class MultiPackageLookup(SymbolLookup):
+    """
+    Combines lookups across multiple archives.
+    """
+
+    def __init__(self, archives: 'Optional[Collection[Archive]]' = None):
+        self._lock = threading.Lock()
+        self._cache = {}  # type: Dict[PackageRef, PackageLookup]
+        if archives is not None:
+            self.add_archive(*archives)
+
+    def archives(self) -> 'Collection[Archive]':
+        """
+        Return the list of known archives.
+        """
+        return [lookup.archive for lookup in self._cache.values()]
+
+    def add_archive(self, *a: 'Archive') -> None:
+        """
+        Add one or more :class:`Archive`s to this lookup.
+
+        This method is thread-safe, but note that :class:`MultiPackageLookup` allows dirty reads for
+        performance reasons.
+
+        :param a: One or more :class:`Archive`s to add.
+        """
+        new_lookups = {ar.hash: PackageLookup(ar) for ar in a}
+        with self._lock:
+            # replace the old cache with a new one, incorporating values from both the existing
+            # cache and the new lookups that came in. When there is a key conflict between the two
+            # APIs, always prefer the existing cache to provide stability to callers.
+            self._cache = {**new_lookups, **self._cache}
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        return set(self._cache)
+
+    def package(self, ref: 'PackageRef') -> 'Package':
+        lookup = self._cache.get(ref)
+        if lookup is not None:
+            return lookup.archive.package
+
+        raise PackageNotFoundError(ref)
+
+    def data_type_name(self, ref: 'Any') -> 'TypeConName':
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            dt_name = lookup.local_data_type_name(name)
+            if dt_name is not None:
+                return dt_name
+
+        raise NameNotFoundError(ref)
+
+    def data_type(self, ref: 'Any') -> 'DefDataType':
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            dt = lookup.local_data_type(name)
+            if dt is not None:
+                return dt
+
+        raise NameNotFoundError(ref)
+
+    def value(self, ref: 'Any') -> 'DefValue':
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            val = lookup.local_value(name)
+            if val is not None:
+                return val
+
+        raise NameNotFoundError(ref)
+
+    def template_names(self, ref: 'Any') -> 'Collection[TypeConName]':
+        names = []
+
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            if name == '*':
+                names.extend(lookup.local_template_names())
+            else:
+                n = lookup.local_template_name(name)
+                if n is not None:
+                    names.append(n)
+
+        return names
+
+    def template_name(self, ref: 'Any') -> 'TypeConName':
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            n = lookup.local_template_name(name)
+            if n is not None:
+                return n
+
+        raise NameNotFoundError(ref)
+
+    def template(self, ref: 'Any') -> 'DefTemplate':
+        pkg, name = validate_template(ref)
+        for lookup in self._lookups(pkg):
+            tmpl = lookup.local_template(name)
+            if tmpl is not None:
+                return tmpl
+
+        raise NameNotFoundError(ref)
+
+    def _lookups(self, ref: 'PackageRef') -> 'Iterable[PackageLookup]':
+        """
+        Return the individual :class:`PackageLookup` objects that should be consulted based on the
+        :class:`PackageRef`.
+
+        :param ref:
+            A :class:`PackageRef` to look for.
+        :return:
+            A collection of :class:`PackageLookup` objects that match the :class:`PackageRef`. This
+            collection is never empty.
+        :raises PackageNotFoundError:
+            if the :class:`PackageRef` points to a package that is not present in this lookup.
+        """
+        if ref == '*':
+            return self._cache.values()
+
+        lookup = self._cache.get(ref)
+        if lookup is not None:
+            return lookup,
+
+        raise PackageNotFoundError(ref)
+
+
+def find_choice(template: 'DefTemplate', name: str) -> 'TemplateChoice':
+    """
+    Find a choice in a :class:`DefTemplate`. If the choice could not be found,
+    :class:`NameNotFoundError` is raised.
+    """
+    for choice in template.choices:
+        if choice.name == name:
+            return choice
+
+    raise NameNotFoundError(f'choice {name}')

--- a/python/dazl/damlast/protocols.py
+++ b/python/dazl/damlast/protocols.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from typing import AbstractSet, Any, TYPE_CHECKING, Collection
+
+if sys.version_info >= (3, 7):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .daml_lf_1 import DefDataType, DefTemplate, DefValue, Package, PackageRef, TypeConName, Archive
+
+__all__ = ['PackageProvider', 'SymbolLookup']
+
+
+@runtime_checkable
+class PackageProvider(Protocol):
+    """
+    Structural interface for a class that can synchronously provide package data.
+
+    If a requested package could not be found, :class:`PackageNotFoundError` should be raised; the
+    functions of this protocol should never return ``None``.
+    """
+
+    def package(self, ref: 'PackageRef') -> 'Package':
+        """
+        Return the :class:`Package` for the specified :class:`PackageRef`.
+
+        :param ref:
+            The package ID to look up.
+        :return:
+            The Package corresponding to this package ID.
+        :raises PackageNotFoundError:
+            if the package could not be found
+        """
+        raise NotImplementedError('PackageProvider.package must be implemented')
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        """
+        Return all package IDs that are known to this :class:`PackageProvider`.
+
+        Implementations are allowed to return larger sets of packages over time, but should
+        generally never omit a package ID that was previously returned.
+
+        :return:
+            A set of package IDs.
+        """
+        raise NotImplementedError('PackageProvider.package_ids must be implemented')
+
+
+@runtime_checkable
+class SymbolLookup(Protocol):
+    """
+    Structural interface for a class that can synchronously provide type/value information.
+
+    If a requested _package_ could not be found, :class:`PackageNotFoundError` is raised.
+    If a requested package is known to this :class:`SymbolLookup` but the name is unknown, then
+    :class:`NameNotFoundError` is raised. Callers can use this to disambiguate between errors that
+    are retryable (missing packages can be fetched) and non-retryable (names within a known package,
+    if they do not currently exist, will NEVER exist).
+    """
+
+    def archives(self) -> 'Collection[Archive]':
+        """
+        Return the archives that are known to this lookup.
+        """
+        raise NotImplementedError('SymbolLookup.archives must be implemented')
+
+    def package_ids(self) -> 'AbstractSet[PackageRef]':
+        """
+        Return the package IDs that are known to this lookup.
+        """
+        raise NotImplementedError('SymbolLookup.package_ids must be implemented')
+
+    def data_type_name(self, ref: 'Any') -> 'TypeConName':
+        """
+        Return the :class:`TypeConName` that refers to a :class:`DefDataType` that is known to
+        exist in this lookup.
+
+        If this method succeeds, :meth:`data_type` with the returned :class:`TypeConName` as an
+        argument should also always succeed.
+        """
+        raise NotImplementedError('SymbolLookup.data_type_name must be implemented')
+
+    def data_type(self, ref: 'Any') -> 'DefDataType':
+        """
+        Return the :class:`DefDataType` for the specified name.
+        """
+        raise NotImplementedError('SymbolLookup.data_type must be implemented')
+
+    def value(self, ref: 'Any') -> 'DefValue':
+        """
+        Return the :class:`DefValue` for the specified name.
+        """
+        raise NotImplementedError('SymbolLookup.value must be implemented')
+
+    def template_names(self, ref: 'Any') -> 'Collection[TypeConName]':
+        """
+        Return all template names that are currently known that are a match for the query. Either
+        :class:`PackageRef` or the template name can be `*`.
+
+        Unlike the other methods of this class, this function should return an empty list in the
+        case of a match failure; :class:`PackageNotFoundError` or :class:`NameNotFoundError` are
+        never thrown.
+        """
+        raise NotImplementedError('SymbolLookup.template_names must be implemented')
+
+    def template_name(self, ref: 'Any') -> 'TypeConName':
+        """
+        Return the :class:`TypeConName` that refers to a :class:`DefTemplate` that is known to
+        exist in this lookup.
+
+        If this method succeeds, :meth:`data_type` with the returned :class:`TypeConName` as an
+        argument should also always succeed.
+        """
+        raise NotImplementedError('SymbolLookup.template_name must be implemented')
+
+    def template(self, ref: 'Any') -> 'DefTemplate':
+        """
+        Return the :class:`DefTemplate` for the specified name.
+        """
+        raise NotImplementedError('SymbolLookup.template must be implemented')

--- a/python/dazl/model/ledger.py
+++ b/python/dazl/model/ledger.py
@@ -4,20 +4,43 @@
 """
 Types that describe the behavior of the ledger itself.
 """
+import warnings
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING
 
 from .types_store import PackageStore
 from .writing import Serializer
 
 
-@dataclass(frozen=True)
+if TYPE_CHECKING:
+    from ..client.pkg_loader import PackageLoader
+
+
+@dataclass(init=False, frozen=True)
 class LedgerMetadata:
     """
     Attributes that are invariant with respect to any party on the ledger.
     """
     ledger_id: str
-    store: PackageStore
-    serializer: Serializer[Any, Any]
+    package_loader: 'PackageLoader'
+    serializer: 'Serializer'
     protocol_version: str
+    _store: 'PackageStore'
+
+    def __init__(self, ledger_id, package_loader, serializer, protocol_version, store):
+        object.__setattr__(self, 'ledger_id', ledger_id)
+        object.__setattr__(self, 'package_loader', package_loader)
+        object.__setattr__(self, 'serializer', serializer)
+        object.__setattr__(self, 'protocol_version', protocol_version)
+        object.__setattr__(self, '_store', store)
+
+    @property
+    def store(self) -> 'PackageStore':
+        if self._store is None:
+            raise Exception('eager_package_fetch is disabled, which disables the PackageStore')
+
+        warnings.warn('PackageStore is deprecated; use SymbolLookup '
+                      '(accessible from Network.lookup) instead.',
+                      DeprecationWarning, stacklevel=2)
+        return self._store

--- a/python/dazl/model/lookup.py
+++ b/python/dazl/model/lookup.py
@@ -40,9 +40,10 @@ def validate_template(template: Any) -> 'Tuple[str, str]':
             return pkgid, f'{m}:{e}'
 
         elif len(components) == 2:
-            # one colon, so assume the package ID is unspecified
+            # one colon, so assume the package ID is unspecified UNLESS the second component is a
+            # wildcard; then we assume the wildcard means any module name and entity name
             m, e = components
-            return '*', f'{m}:{e}'
+            return ('*', f'{m}:{e}') if e != '*' else (m, '*')
 
         elif len(components) == 1:
             # no colon whatsoever

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -63,6 +63,7 @@ from .core import ContractId, ContractData, ContractContextualData, Party
 from .lookup import template_reverse_globs, validate_template
 from .types import TypeReference
 from .types_store import PackageStore
+from ..damlast.protocols import SymbolLookup
 
 
 T = TypeVar('T')
@@ -75,10 +76,11 @@ class BaseEvent:
     """
 
     client: 'Any'
-    party: Optional[Party]
-    time: Optional[datetime]
+    party: 'Optional[Party]'
+    time: 'Optional[datetime]'
     ledger_id: str
-    package_store: PackageStore
+    lookup: 'SymbolLookup'
+    package_store: 'PackageStore'
 
     def acs_find_active(self, template: Union[TypeReference, str], match=None):
         return self.client.find_active(template, match)

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from typing import Optional, Sequence, Union
 
 from .. import LOG
+from ..damlast.protocols import SymbolLookup
 from ..model.core import Party
 from ..model.ledger import LedgerMetadata
 from ..model.network import HTTPConnectionSettings
@@ -21,7 +22,10 @@ from ..util.typing import safe_optional_cast, safe_cast
 
 @dataclass(frozen=True)
 class LedgerConnectionOptions:
+    lookup: 'SymbolLookup'
     connect_timeout: 'Optional[timedelta]'
+    package_lookup_timeout: 'Optional[timedelta]'
+    eager_package_fetch: bool
 
 
 class LedgerNetwork:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import timedelta
 
 import pytest
@@ -65,3 +66,9 @@ def sandbox() -> str:
         # sure that we find and destroy them too if the parent process doesn't kill its own children
         # quickly enough.
         kill_process_tree(process)
+
+
+@pytest.fixture()
+def executor() -> 'ThreadPoolExecutor':
+    with ThreadPoolExecutor(3) as executor:
+        yield executor

--- a/python/tests/unit/dars.py
+++ b/python/tests/unit/dars.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from pathlib import Path
 from typing import Mapping
 
-from dazl import setup_default_logger
 from dazl.util.io import find_nearest_ancestor
 
 DAZL_ROOT = find_nearest_ancestor('.dazl-root', Path(__file__).resolve()).parent

--- a/python/tests/unit/test_damlast_lookup.py
+++ b/python/tests/unit/test_damlast_lookup.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dazl.damlast import DarFile
+from dazl.damlast.lookup import MultiPackageLookup
+from .dars import AllKindsOf
+
+
+def test_wildcard_template_names():
+    with DarFile(AllKindsOf) as dar:
+        lookup = MultiPackageLookup(dar.archives())
+
+    # make sure that looking for templates, wildcarded by package ref, actually work and return
+    # things
+    names = [name for ref in lookup.package_ids() for name in lookup.template_names(f"{ref}:*")]
+    assert len(names) == 2

--- a/python/tests/unit/test_pkg_loader.py
+++ b/python/tests/unit/test_pkg_loader.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from asyncio import get_event_loop, ensure_future, sleep
+from threading import Event
+
+# noinspection PyPackageRequirements
+import pytest
+
+from dazl.client.pkg_loader import PackageLoader
+from dazl.damlast import DarFile
+from dazl.damlast.daml_lf_1 import PackageRef
+from dazl.damlast.lookup import MultiPackageLookup
+
+from .dars import AllKindsOf
+
+
+ALL_KINDS_OF_PKG_REF = PackageRef("e32da8a173e9667e1cd6557a12bf3edbbb6e5a9eb017c3363280ba0b22100bc4")
+
+
+def load_some_bytes():
+    with DarFile(AllKindsOf) as dar:
+        # noinspection PyProtectedMember
+        for a in dar._pb_archives():
+            return a.hash, a.payload
+    raise Exception()
+
+
+@pytest.mark.asyncio
+async def test_pkg_loader_only_fetches_once(executor):
+    pkg_ref, contents = load_some_bytes()
+
+    class MockPackageService:
+        def __init__(self):
+            self.call_count = 0
+
+        def package_bytes(self, package_id: 'PackageRef') -> bytes:
+            self.call_count += 1
+            if package_id != pkg_ref:
+                raise Exception
+            return contents
+
+    conn = MockPackageService()
+    lookup = MultiPackageLookup()
+    loader = PackageLoader(lookup, conn)
+
+    # first, call the PackageLoader.load coroutine
+    pkg1 = await loader.load(pkg_ref)
+
+    # now call it again
+    pkg2 = await loader.load(pkg_ref)
+
+    # we should have only called package_bytes once
+    assert conn.call_count == 1
+
+    # the two Package objects that come back should be identical; creating Package objects are
+    # expensive but they are also immutable, so the two calls should return the same instance
+    # as an optimization
+    assert pkg1 is pkg2
+
+
+@pytest.mark.asyncio
+async def test_pkg_loader_consolidates_concurrent_fetch(executor):
+    loop = get_event_loop()
+    pkg_ref, contents = load_some_bytes()
+
+    evt1 = Event()
+    evt2 = Event()
+
+    class MockPackageService:
+        def __init__(self):
+            self.call_count = 0
+
+        def package_bytes(self, package_id: 'PackageRef') -> bytes:
+            self.call_count += 1
+            if package_id != pkg_ref:
+                raise Exception
+            evt1.set()
+            evt2.wait()
+            return contents
+
+    conn = MockPackageService()
+    lookup = MultiPackageLookup()
+    loader = PackageLoader(lookup, conn)
+
+    # first, call the PackageLoader.load coroutine
+    fut1 = ensure_future(loader.load(pkg_ref))
+
+    # wait until we are definitely in the MockPackageService.package_bytes call in one of
+    # PackageLoader's background threads
+    await loop.run_in_executor(executor, lambda: evt1.wait())
+
+    # now schedule a _second_ PackageLoader.load coroutine; because the first one is still in
+    # progress, this should NOT result in a second call to
+    # MockPackageService.package_bytes
+    fut2 = ensure_future(loader.load(pkg_ref))
+
+    # allow coroutines some time to screw things up
+    await sleep(0.1)
+
+    # make sure that neither call to PackageLoader.load has actually come back yet
+    assert not fut1.done()
+    assert not fut2.done()
+
+    # now unblock MockPackageService.package_bytes, which will return our bytes
+    evt2.set()
+
+    # grab the results from both async PackageLoader.load coroutine calls
+    pkg1 = await fut1
+    pkg2 = await fut2
+
+    # we should have only called package_bytes once
+    assert conn.call_count == 1
+
+    # the two Package objects that come back should be identical; creating Package objects are
+    # expensive but they are also immutable, so the two calls should return the same instance
+    # as an optimization
+    assert pkg1 is pkg2
+

--- a/python/tests/unit/test_pkg_loader_do_with_retry.py
+++ b/python/tests/unit/test_pkg_loader_do_with_retry.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# noinspection PyPackageRequirements
+import pytest
+
+from dazl.client.pkg_loader import PackageLoader
+from dazl.damlast import DarFile
+from dazl.damlast.daml_lf_1 import PackageRef, TypeConName
+from dazl.damlast.errors import NameNotFoundError
+from dazl.damlast.lookup import MultiPackageLookup
+from dazl.damlast.util import package_ref
+
+from .dars import AllKindsOf
+
+
+ALL_KINDS_OF_PKG_REF = PackageRef("e32da8a173e9667e1cd6557a12bf3edbbb6e5a9eb017c3363280ba0b22100bc4")
+
+
+class PackageLoaderTest:
+    def __init__(self, template_name):
+        self.lookup = MultiPackageLookup()
+        self.loader = PackageLoader(self.lookup, DarFile(AllKindsOf))
+        self.call_order = []
+        self.template_name = template_name
+
+        # the lookup should always start out empty
+        assert len(self.lookup.archives()) == 0
+
+    def some_fn(self) -> 'TypeConName':
+        try:
+            name = self.lookup.template_name(self.template_name)
+            self.call_order.append("good call")
+            return name
+        except:
+            self.call_order.append("exception")
+            raise
+
+
+@pytest.mark.asyncio
+async def test_pkg_loader_do_with_retry_unspecified_package():
+    test = PackageLoaderTest(f"{ALL_KINDS_OF_PKG_REF}:AllKindsOf:OneOfEverything")
+
+    # call a function with a loader wrapper
+    name = await test.loader.do_with_retry(test.some_fn)
+
+    # the lookup now has only one archive, corresponding to the package ref that we loaded;
+    # first, we had to have an exception raised; then we get the call that succeeds
+    assert len(test.lookup.archives()) == 1
+    assert package_ref(name) == ALL_KINDS_OF_PKG_REF
+    assert test.call_order == ['exception', 'good call']
+
+
+@pytest.mark.asyncio
+async def test_pkg_loader_do_with_retry_specified_package():
+    test = PackageLoaderTest("*:AllKindsOf:OneOfEverything")
+
+    # call a function with a loader wrapper
+    name = await test.loader.do_with_retry(test.some_fn)
+
+    # the lookup now has only one archive, corresponding to the package ref that we loaded;
+    # first, we had to have an exception raised; then we get the call that succeeds
+    assert len(test.lookup.archives()) > 1
+    assert package_ref(name) == ALL_KINDS_OF_PKG_REF
+    assert test.call_order == ['exception', 'good call']
+
+
+@pytest.mark.asyncio
+async def test_pkg_loader_do_with_retry_will_fail_on_unknown_templates():
+    test = PackageLoaderTest('*:Nonsense:Nonsense')
+
+    # call a function with a loader wrapper
+    try:
+        await test.loader.do_with_retry(test.some_fn)
+        assert False, "This call was not supposed to succeed"
+    except NameNotFoundError:
+        # a NameNotFoundError is what we are expecting here
+        pass
+    except Exception:
+        # any other exception is unexpected
+        raise
+
+    # all packages will have been loaded; the function will have been called twice, and raise
+    # exceptions both times
+    assert len(test.lookup.archives()) >= 1
+    assert test.call_order == ['exception', 'exception']


### PR DESCRIPTION
Introduce `SymbolLookup` and `PackageLoader`, the intended replacements for `PackageStore`.

`PackageLookup` and `SymbolLookup` aren't wired into any of the infrastructure of `dazl` yet; that will be coming in a subsequent PR.

This change actually manages to be backwards/forwards compatible because `PackageLookup`, a lazier version of `PackageStore`, doesn't actually contain any packages until they are requested; this means if for whatever reason a version of `dazl` were cut on this commit, the `PackageStore` would continue to try to remain up-to-date in its currently "almost working" state, and the `PackageLookup` would simply remain empty.