### PR TITLE
python: Fix a package load race condition

### DIFF
--- a/python/dazl/cli/ls.py
+++ b/python/dazl/cli/ls.py
@@ -33,8 +33,12 @@ class ListAllCommand(CliCommand):
 
         network = Network()
         network.set_config(final_config)
+        network.set_config(eager_package_fetch=False)
         if include_archived:
             network.set_config(use_acs_service=False)
+
+        for party in args.parties:
+            network.aio_party(party)
 
         network.run_until_complete(self._main(network, fmt, include_archived))
         return 0
@@ -42,8 +46,11 @@ class ListAllCommand(CliCommand):
     async def _main(self, network: 'Network', fmt: str, include_archived: bool):
         import sys
 
+        LOG.debug('Starting our parties...')
         for party in network.parties():
             await network.aio_party(party).ready()
+            LOG.debug('Party %s is ready.', party)
         metadata = await network.aio_global().metadata()
+        LOG.debug('Our parties are now ready.')
 
         write_acs(sys.stdout, network, metadata.store, fmt=fmt, include_archived=include_archived)

--- a/python/dazl/client/_network_client_impl.py
+++ b/python/dazl/client/_network_client_impl.py
@@ -355,12 +355,8 @@ class _NetworkImpl:
         await wait_for(self.__ensure_package_ids(package_ids), to_timedelta(timeout).total_seconds())
 
     async def __ensure_package_ids(self, package_ids: 'Collection[str]'):
-        from asyncio import sleep
         metadata = await self.aio_metadata()
-        package_id_set = set(package_ids)
-        while not package_id_set.issubset(metadata._store.package_ids()):
-            # just sit here, waiting for our packages to show up in the store
-            await sleep(1)
+        await gather(*(metadata.package_loader.load(pkg_ref) for pkg_ref in package_ids))
 
     # region Event Handler Management
 

--- a/python/dazl/client/_writer_verify.py
+++ b/python/dazl/client/_writer_verify.py
@@ -3,20 +3,14 @@
 
 from typing import Any
 
-from ..model.core import ContractId
-from ..model.types import Type, UnsupportedType, VariantType, RecordType, ListType, \
-    ContractIdType, TemplateChoice, TypeEvaluationContext, OptionalType, TextMapType, \
-    TypeReference, EnumType
-from ..model.writing import Command, CreateCommand, ExerciseCommand, ExerciseByKeyCommand, \
+from ..damlast.daml_lf_1 import TypeConName
+from ..prim import ContractId
+from ..model.writing import CreateCommand, ExerciseCommand, ExerciseByKeyCommand, \
     CreateAndExerciseCommand, AbstractSerializer
-from ..prim import to_int, to_str, to_decimal, to_date, to_datetime, to_record
+from ..values import CanonicalMapper
 
 
-class ValidateError(ValueError):
-    pass
-
-
-class ValidateSerializer(AbstractSerializer[Command, Any]):
+class ValidateSerializer(AbstractSerializer):
     """
     A serializer that doesn't actually write to an on-wire form, but merely does lightweight
     conversion and give on-wire serialization the best chance of succeeding.
@@ -25,181 +19,27 @@ class ValidateSerializer(AbstractSerializer[Command, Any]):
     a background thread for eventual writing to the Ledger API.
     """
 
-    def serialize_create_command(self, template_type: RecordType, template_args: Any) \
-            -> CreateCommand:
-        return CreateCommand(template=template_type.name.con, arguments=template_args)
+    mapper = CanonicalMapper()
+
+    def serialize_create_command(self, name: 'TypeConName', template_args: 'Any') \
+            -> 'CreateCommand':
+        return CreateCommand(template=name, arguments=template_args)
 
     def serialize_exercise_command(
-            self, contract_id: ContractId, choice_info: TemplateChoice, choice_args: Any) \
-            -> ExerciseCommand:
-        return ExerciseCommand(contract=contract_id, choice=choice_info.name, arguments=choice_args)
+            self, contract_id: 'ContractId', choice_name: str, choice_args: 'Any') \
+            -> 'ExerciseCommand':
+        return ExerciseCommand(contract=contract_id, choice=choice_name, arguments=choice_args)
 
     def serialize_exercise_by_key_command(
-            self, template_ref: TypeReference, key_arguments: Any,
-            choice_info: TemplateChoice, choice_arguments: Any) -> ExerciseByKeyCommand:
+            self, template_name: 'TypeConName', key_arguments: Any,
+            choice_name: str, choice_arguments: 'Any') -> 'ExerciseByKeyCommand':
         return ExerciseByKeyCommand(
-            template=template_ref.con, contract_key=key_arguments,
-            choice=choice_info.name, choice_argument=choice_arguments)
+            template=template_name, contract_key=key_arguments,
+            choice=choice_name, choice_argument=choice_arguments)
 
     def serialize_create_and_exercise_command(
-            self, template_type: RecordType, create_arguments: Any,
-            choice_info: TemplateChoice, choice_arguments: Any) -> CreateAndExerciseCommand:
+            self, template_name: 'TypeConName', create_arguments: Any,
+            choice_name: str, choice_arguments: 'Any') -> 'CreateAndExerciseCommand':
         return CreateAndExerciseCommand(
-            template=template_type.name.con, arguments=create_arguments,
-            choice=choice_info.name, choice_argument=choice_arguments)
-
-    def serialize_unit(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return obj
-
-    def serialize_bool(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        from ..protocols.v1.pb_parse_event import to_bool
-        return to_bool(obj)
-
-    def serialize_text(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_str(obj)
-
-    def serialize_int(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_int(obj)
-
-    def serialize_decimal(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_decimal(obj)
-
-    def serialize_party(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_str(obj)
-
-    def serialize_date(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_date(obj)
-
-    def serialize_datetime(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return to_datetime(obj)
-
-    def serialize_timedelta(self, context: TypeEvaluationContext, obj: Any) -> Any:
-        return obj
-
-    def serialize_contract_id(self, context: TypeEvaluationContext, tt: ContractIdType, obj: Any) \
-            -> Any:
-        return obj
-
-    def serialize_optional(self, context: TypeEvaluationContext, tt: OptionalType, obj: Any) -> Any:
-        # a `None` object is, of course, a valid Optional
-        if obj is None:
-            return None
-
-        # any other object is considered in the context of its inner type
-        return self._serialize_dispatch(context.append_path('?'), tt.type_parameter, obj)
-
-    def serialize_list(self, context: TypeEvaluationContext, tt: ListType, obj: Any) -> Any:
-        # a `None` object is trivially interpreted as an empty list
-        if obj is None:
-            return []
-
-        if isinstance(obj, str):
-            # Strings are a bit special because they're enumerable, but we don't really want to
-            # treat them that way here. Additionally, if this is a bare string with commas in it,
-            # use those commas to split the string. Additionally, if it's the empty string, treat
-            # that as a null list instead of a single list with an empty string inside of it.
-            obj = obj.split(',') if obj else []
-
-        from collections import Collection
-        if not isinstance(obj, Collection):
-            obj = [obj]
-
-        return [self._serialize_dispatch(context.append_path(f'[{i}]'), tt.type_parameter, item)
-                for i, item in enumerate(obj)]
-
-    def serialize_map(self, context: TypeEvaluationContext, tt: TextMapType, obj: Any) -> Any:
-        if obj is None:
-            return {}
-
-        from collections import Mapping
-        if isinstance(obj, Mapping):
-            reformatted = {}
-            for key, value in obj.items():
-                new_value = self._serialize_dispatch(
-                    context.append_path(f'[{key}]'), tt.value_type, value)
-                reformatted[key] = new_value
-            return reformatted
-        else:
-            raise ValueError(f'expected a dict here (got {type(obj)}: {obj!r} instead)')
-
-    def serialize_record(self, context: TypeEvaluationContext, tt: RecordType, obj: Any) -> Any:
-        from collections.abc import Mapping
-        if isinstance(obj, Mapping):
-            # pull out any specialized dotted-field mappings
-            reformatted = dict(to_record(obj))
-            missing_keys = set()
-            for name, field_type in tt.named_args:
-                if name in reformatted:
-                    new_value = self._serialize_dispatch(
-                        context.append_path(name), field_type, reformatted[name])
-                    reformatted[name] = new_value
-                else:
-                    missing_keys.add(name)
-            if missing_keys:
-                raise ValueError(f'missing entries in a record: {sorted(missing_keys)}')
-            return reformatted
-        else:
-            raise ValueError(f'expected a dict at {".".join(context.path)}')
-
-    def serialize_variant(self, context: TypeEvaluationContext, tt: VariantType, obj: Any) -> Any:
-        from collections import Mapping
-        if isinstance(obj, Mapping):
-            proposed_variants = {}
-            error_variants = {}
-            reformatted = to_record(obj)
-            for name, field_type in tt.named_args:
-                if name in reformatted:
-                    try:
-                        new_value = self._serialize_dispatch(
-                            context.append_path(name), field_type, reformatted[name])
-                        proposed_variants[name] = new_value
-                    except:
-                        error_variants[name] = reformatted[name]
-
-            if not proposed_variants:
-                raise ValueError('got an empty dict where a single-key dict was expected')
-            if len(proposed_variants) == 1:
-                return proposed_variants
-            else:
-                non_optional_ctors = dict()
-                optional_ctors = set()
-                for name, field_type in tt.named_args:
-                    if name in proposed_variants:
-                        value = proposed_variants[name]
-                        if can_be_optional(field_type, value):
-                            optional_ctors.add(name)
-                        else:
-                            non_optional_ctors[name] = value
-                if len(non_optional_ctors) == 1:
-                    return non_optional_ctors
-                else:
-                    raise ValueError(f'too many entries in a variant dict: could not choose among '
-                                     f'{sorted(non_optional_ctors)}')
-        else:
-            error = 'variants must be encoded as dictionaries with a single key and a value'
-            raise ValueError(f'{error} (got {obj!r} instead)', obj)
-
-    def serialize_enum(self, context: TypeEvaluationContext, tt: EnumType, obj: Any) -> Any:
-        if obj in tt.constructors:
-            return obj
-        else:
-            error = f'expected one of {tt.constructors}'
-            raise ValueError(f'{error} (got {obj!r} instead')
-
-    def serialize_unsupported(self, context: TypeEvaluationContext, tt: UnsupportedType, obj: Any) \
-            -> Any:
-        return obj
-
-
-def can_be_optional(tt: Type, obj: Any):
-    from collections import Mapping
-    if not obj and obj != 0:
-        return True
-    if isinstance(obj, Mapping):
-        # TODO: For now we're not using type information; might be useful to introduce it at some
-        #  point though
-        cbo = all(can_be_optional(None, value) for value in obj.values())
-        return cbo
-    else:
-        return False
-
+            template=template_name, arguments=create_arguments,
+            choice=choice_name, choice_argument=choice_arguments)

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -31,6 +31,7 @@ from .bots import Bot, BotCollection
 from .config import AnonymousNetworkConfig, NetworkConfig, PartyConfig
 from ._base_model import IfMissingPartyBehavior, CREATE_IF_MISSING
 from ..damlast import get_dar_package_ids
+from ..damlast.protocols import SymbolLookup
 from ..metrics import MetricEvents
 from ..model.core import ContractsState, ContractMatch, \
     ContractContextualData, ContractContextualDataCollection, Dar
@@ -155,6 +156,14 @@ class Network:
             admin_url: 'Optional[str]' = None,
             **kwargs):
         self._impl.set_config(*config, url=url, admin_url=admin_url, **kwargs)
+
+    @property
+    def lookup(self) -> 'SymbolLookup':
+        """
+        Return a :class:`SymbolLookup` that provides type and package information for known
+        packages.
+        """
+        return self._impl.lookup
 
     def resolved_config(self) -> 'NetworkConfig':
         """

--- a/python/dazl/damlast/daml_types.py
+++ b/python/dazl/damlast/daml_types.py
@@ -54,6 +54,9 @@ def con(tycon: 'TypeConName', *args: 'Type') -> 'Type':
     :param tycon: The fully-qualified name of the type constructor.
     :param args: Type arguments (only applicable if the type is a generic type).
     """
+    if tycon is None:
+        raise ValueError('tycon is required')
+
     return Type(con=Type.Con(tycon=tycon, args=tuple(args)))
 
 

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -63,8 +63,8 @@ from .core import ContractId, ContractData, ContractContextualData, Party
 from .lookup import template_reverse_globs, validate_template
 from .types import TypeReference
 from .types_store import PackageStore
+from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.protocols import SymbolLookup
-
 
 T = TypeVar('T')
 
@@ -256,7 +256,7 @@ def create_dispatch(
 
 @dataclass(frozen=True)
 class ContractFilter:
-    templates: 'Optional[Collection[TypeReference]]' = None
+    templates: 'Optional[Collection[TypeConName]]' = None
     party_groups: 'Optional[Collection[Party]]' = None
 
 

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence, Union
 from ._render_base import PrettyPrintBase
 from .util import maybe_parentheses
 from ..damlast.daml_lf_1 import DefDataType, DefTemplate, Expr, ModuleRef, PrimType, \
-    Type as NewType, Scenario, Pure, Block, Update
+    Type as NewType, Scenario, Pure, Block, Update, TypeConName
 from ..damlast.util import package_local_name, module_name
 from ..model.types import Type as OldType, ScalarType, ContractIdType, ListType, OptionalType, \
     TextMapType, RecordType, TypeApp, TypeVariable, TypeReference, UpdateType, VariantType, \
@@ -57,8 +57,8 @@ class DamlPrettyPrinter(PrettyPrintBase):
         local_name = '.'.join(def_data_type.name.segments)
 
         from ..damlast.expand import ExpandVisitor, SimplifyVisitor
-        ex = ExpandVisitor(self.store)
-        sp = SimplifyVisitor(self.store)
+        ex = ExpandVisitor(self.lookup)
+        sp = SimplifyVisitor(self.lookup)
 
         def render(expr: Expr) -> str:
             #return self.visit_expr(expr)
@@ -285,7 +285,7 @@ class DamlPrettyPrinter(PrettyPrintBase):
 
     # region visit_type_* methods
 
-    def visit_type(self, type: 'Union[str, NewType, OldType]', parenthesize: bool = False) -> str:
+    def visit_type(self, type: 'Union[str, NewType, OldType, TypeConName]', parenthesize: bool = False) -> str:
         from ..model.types import TypeReference
         from ..damlast.daml_lf_1 import TypeConName
         if isinstance(type, str):

--- a/python/dazl/protocols/v0/json_ser_command.py
+++ b/python/dazl/protocols/v0/json_ser_command.py
@@ -9,15 +9,13 @@ types over the wire on the REST interface using JSON.
 import warnings
 from datetime import datetime, date
 from decimal import Decimal
-from typing import Union, Dict, Any, List
+from typing import Any
 
-from ...model.types import ListType, RecordType, VariantType, \
-    ContractIdType, UnsupportedType, as_contract_id, TemplateChoice, TextMapType
-from ...model.writing import CommandPayload, AbstractSerializer, TypeEvaluationContext
-from ...prim import ContractId, JSONEncoder, to_bool, to_date, to_datetime, to_decimal, \
-    to_int, to_str, to_timedelta, to_variant
-
-R = Union[bool, str, date, datetime, int, float, Decimal, List['R'], Dict[str, 'R']]
+from ... import LOG
+from ...damlast.daml_lf_1 import TypeConName
+from ...prim import ContractId
+from ...model.types import ScalarType
+from ...model.writing import CommandPayload, AbstractSerializer
 
 
 class LedgerJSONEncoder(JSONEncoder):
@@ -50,7 +48,11 @@ def to_api_datetime(obj):
     return datetime_to_str(obj) if isinstance(obj, datetime) else obj
 
 
-class JsonSerializer(AbstractSerializer[dict, R]):
+class JsonSerializer(AbstractSerializer):
+
+    def mapper(self):
+        from ...values.json import ENCODER
+        return ENCODER
 
     ################################################################################################
     # COMMAND serializers
@@ -63,76 +65,16 @@ class JsonSerializer(AbstractSerializer[dict, R]):
             commands=commands,
             application=command_payload.application_id)
 
-    def serialize_create_command(self, template_type: RecordType, template_args: R) -> dict:
+    def serialize_create_command(self, template_name: 'TypeConName', template_args: 'Any') -> 'Any':
         # the package_id in ModuleRef is a convenient place to
         # stash legacy template IDs in the REST endpoint
         return {'create': {
-            'template': str(template_type.name.con),
+            'template': str(template_name),
             'arguments': template_args}}
 
     def serialize_exercise_command(
-            self, contract_id: 'ContractId', choice_info: TemplateChoice, choice_args: R) -> dict:
+            self, contract_id: ContractId, choice_name: str, choice_args: 'Any') -> 'Any':
         return {'exercise': {
-            'contract': str(contract_id.value_type),
-            'choice': choice_info.name,
+            'contract': contract_id.value,
+            'choice': choice_name,
             'arguments': choice_args}}
-
-    ################################################################################################
-    # VALUE serializers
-    ################################################################################################
-
-    def serialize_unit(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return dict()
-
-    def serialize_bool(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_bool(obj)
-
-    def serialize_text(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_str(obj)
-
-    def serialize_int(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_int(obj)
-
-    def serialize_decimal(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_decimal(obj)
-
-    def serialize_party(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_str(obj)
-
-    def serialize_date(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_date(obj)
-
-    def serialize_datetime(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_datetime(obj)
-
-    def serialize_timedelta(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return to_timedelta(obj)
-
-    def serialize_contract_id(
-            self, context: TypeEvaluationContext, tt: ContractIdType, obj: Any) -> R:
-        return as_contract_id(obj, template_id=tt.type_parameter).contract_id
-
-    def serialize_list(self, context: TypeEvaluationContext, tt: ListType, obj: Any) -> R:
-        return [self._serialize_dispatch(context.append_path(f'[{i}]'), tt.type_parameter, item)
-                for i, item in enumerate(obj)]
-
-    def serialize_map(self, context: TypeEvaluationContext, tt: TextMapType, obj: Any) -> R:
-        return {self._serialize_dispatch(context.append_path(f'[key {i}]'), tt.key_type, key):
-                self._serialize_dispatch(context.append_path(f'[value {i}]'), tt.value_type, value)
-                for i, (key, value) in enumerate(obj.items())}
-
-    def serialize_record(self, context: TypeEvaluationContext, tt: RecordType, obj: Any) -> R:
-        return {arg: self._serialize_dispatch(context.append_path(arg), arg_type, obj.get(arg))
-                for arg, arg_type in tt.named_args}
-
-    def serialize_variant(self, context: TypeEvaluationContext, tt: VariantType, obj: Any) -> R:
-        obj_ctor, obj_value = to_variant(obj)
-        value_ctor = tt.field_type(obj_ctor)
-
-        new_value = self._serialize_dispatch(context.append_path(obj_ctor), value_ctor, obj_value)
-        return {obj_ctor: new_value}
-
-    def serialize_unsupported(
-            self, context: TypeEvaluationContext, tt: UnsupportedType, obj: Any) -> R:
-        return obj
-

--- a/python/dazl/protocols/v1/pb_ser_command.py
+++ b/python/dazl/protocols/v1/pb_ser_command.py
@@ -4,25 +4,16 @@
 """
 Conversion methods to Ledger API Protobuf-generated types from dazl/Pythonic types.
 """
-from typing import Any, Tuple, Union
-
-# noinspection PyPackageRequirements
-from google.protobuf.empty_pb2 import Empty
+from typing import Any, Union
 
 # noinspection PyPep8Naming
 from . import model as G
-from ... import LOG
 from ...damlast.daml_lf_1 import TypeConName
 from ...model.core import ContractId
-from ...model.types import VariantType, RecordType, ListType, ContractIdType, \
-    UnsupportedType, TemplateChoice, TypeReference, TypeEvaluationContext, SCALAR_TYPE_UNIT, \
-    TextMapType, OptionalType, EnumType
+from ...model.types import TypeReference
 from ...model.writing import AbstractSerializer, CommandPayload
-from ...prim import date_to_int, datetime_to_epoch_microseconds, decimal_to_str, \
-    timedelta_to_duration, to_bool, to_date, to_datetime, to_decimal, to_int, to_str, to_variant
-from ...values.protobuf import set_value
-
-R = Tuple[str, Any]
+from ...prim import timedelta_to_duration
+from ...values.protobuf import ProtobufEncoder, set_value
 
 
 def as_identifier(tref: 'Union[TypeReference, TypeConName]') -> 'G.Identifier':
@@ -38,7 +29,9 @@ def as_identifier(tref: 'Union[TypeReference, TypeConName]') -> 'G.Identifier':
         raise TypeError('as_identifier requires a TypeConName or a TypeReference')
 
 
-class ProtobufSerializer(AbstractSerializer[G.Command, R]):
+class ProtobufSerializer(AbstractSerializer):
+
+    mapper = ProtobufEncoder()
 
     ################################################################################################
     # COMMAND serializers
@@ -56,18 +49,18 @@ class ProtobufSerializer(AbstractSerializer[G.Command, R]):
             deduplication_time=(timedelta_to_duration(command_payload.deduplication_time)
                                 if command_payload.deduplication_time is not None else None)))
 
-    def serialize_create_command(self, template_type: RecordType, template_args: R) -> G.Command:
+    def serialize_create_command(self, name: 'TypeConName', template_args: 'Any') -> G.Command:
         create_ctor, create_value = template_args
         if create_ctor != 'record':
             raise ValueError('Template values must resemble records')
 
         cmd = G.CreateCommand()
-        _set_template(cmd.template_id, template_type.name.con)
+        _set_template(cmd.template_id, name)
         set_value(cmd.create_arguments, None, create_value)
         return G.Command(create=cmd)
 
     def serialize_exercise_command(
-            self, contract_id: ContractId, choice_info: TemplateChoice, choice_args: R) \
+            self, contract_id: 'ContractId', choice_name: str, choice_args: 'Any') \
             -> G.Command:
         type_ref = contract_id.value_type
         ctor, value = choice_args
@@ -75,162 +68,37 @@ class ProtobufSerializer(AbstractSerializer[G.Command, R]):
         cmd = G.ExerciseCommand()
         _set_template(cmd.template_id, type_ref)
         cmd.contract_id = contract_id.value
-        cmd.choice = choice_info.name
+        cmd.choice = choice_name
         set_value(cmd.choice_argument, ctor, value)
         return G.Command(exercise=cmd)
 
     def serialize_exercise_by_key_command(
-            self, template_ref: TypeReference, key_arguments: Any,
-            choice_info: TemplateChoice, choice_arguments: Any) -> G.Command:
+            self, template_name: 'TypeConName', key_arguments: Any,
+            choice_name: str, choice_arguments: Any) -> G.Command:
         key_ctor, key_value = key_arguments
         choice_ctor, choice_value = choice_arguments
 
         cmd = G.ExerciseByKeyCommand()
-        _set_template(cmd.template_id, template_ref.con)
+        _set_template(cmd.template_id, template_name)
         set_value(cmd.contract_key, key_ctor, key_value)
-        cmd.choice = choice_info.name
+        cmd.choice = choice_name
         set_value(cmd.choice_argument, choice_ctor, choice_value)
         return G.Command(exerciseByKey=cmd)
 
     def serialize_create_and_exercise_command(
-            self, template_type: RecordType, create_arguments: Any,
-            choice_info: TemplateChoice, choice_arguments: Any) -> G.Command:
+            self, template_name: 'TypeConName', create_arguments: 'Any',
+            choice_name: str, choice_arguments: Any) -> G.Command:
         create_ctor, create_value = create_arguments
         if create_ctor != 'record':
             raise ValueError('Template values must resemble records')
         choice_ctor, choice_value = choice_arguments
 
         cmd = G.CreateAndExerciseCommand()
-        _set_template(cmd.template_id, template_type.name.con)
+        _set_template(cmd.template_id, template_name)
         set_value(cmd.create_arguments, None, create_value)
-        cmd.choice = choice_info.name
+        cmd.choice = choice_name
         set_value(cmd.choice_argument, choice_ctor, choice_value)
         return G.Command(createAndExercise=cmd)
-
-    ################################################################################################
-    # VALUE serializers
-    ################################################################################################
-
-    def serialize_unit(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'unit', Empty()
-
-    def serialize_bool(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'bool', to_bool(obj)
-
-    def serialize_text(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'text', to_str(obj)
-
-    def serialize_int(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'int64', to_int(obj)
-
-    def serialize_decimal(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'numeric', decimal_to_str(to_decimal(obj))
-
-    def serialize_party(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'party', to_str(obj)
-
-    def serialize_date(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'date', date_to_int(to_date(obj))
-
-    def serialize_datetime(self, context: TypeEvaluationContext, obj: Any) -> R:
-        return 'timestamp', datetime_to_epoch_microseconds(to_datetime(obj))
-
-    def serialize_timedelta(self, context: TypeEvaluationContext, obj: Any) -> R:
-        raise ValueError('RelTime types are not supported by the gRPC API')
-
-    def serialize_contract_id(
-            self, context: TypeEvaluationContext, tt: ContractIdType, obj: Any) -> R:
-        return 'contract_id', to_str(obj)
-
-    def serialize_optional(self, context: TypeEvaluationContext, tt: OptionalType, obj: Any):
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import Optional
-        ut = tt.type_parameter
-
-        optional_message = Optional()
-        if obj is not None:
-            ctor, val = self._serialize_dispatch(context.append_path('?'), ut, obj)
-            set_value(optional_message.value, ctor, val)
-        return 'optional', optional_message
-
-    def serialize_list(self, context: TypeEvaluationContext, tt: ListType, obj: Any) -> R:
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import List
-        ut = tt.type_parameter
-
-        list_message = List()
-        for i, item in enumerate(obj):
-            value = list_message.elements.add()
-            ctor, val = self._serialize_dispatch(context.append_path(f'[{i}]'), ut, item)
-            set_value(value, ctor, val)
-        return 'list', list_message
-
-    def serialize_map(self, context: TypeEvaluationContext, tt: TextMapType, obj: Any) -> R:
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import Map
-        vt = tt.value_type
-
-        map_message = Map()
-        for key, value in obj.items():
-            entry = map_message.entries.add()
-            entry.key = key
-            ctor, val = self._serialize_dispatch(context.append_path(f'[{key}]'), vt, value)
-            set_value(entry.value, ctor, val)
-        return 'map', map_message
-
-    def serialize_record(self, context: TypeEvaluationContext, tt: RecordType, obj: Any) -> R:
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import Record
-
-        did_fail = False
-        record_message = Record()
-        for key, vt in tt.named_args:
-            if key not in obj:
-                LOG.error('The field %s is missing on %s', key, tt)
-                did_fail = True
-                continue
-
-            ctor, value = self._serialize_dispatch(context.append_path(key), vt, obj.get(key))
-            field = record_message.fields.add()
-            field.label = key
-            set_value(field.value, ctor, value)
-        if did_fail:
-            raise ValueError('Failed to parse a record; check the logs for more information.')
-        return 'record', record_message
-
-    def serialize_variant(self, context: TypeEvaluationContext, tt: VariantType, obj: Any) -> R:
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import Variant
-        try:
-            obj_ctor, obj_value = to_variant(obj)
-        except ValueError:
-            if len(tt.named_args) == 1:
-                # there is only one variation on this variant; under very specific circumstances
-                # we'll allow for some convenience representations of this case
-                obj_ctor, vt = tt.named_args[0]
-                if (isinstance(vt, (RecordType, VariantType)) and len(vt.named_args) == 0) or \
-                        vt == SCALAR_TYPE_UNIT:
-                    obj_value = {}
-                else:
-                    LOG.error('Could not find a helpful representation of the single-variant case '
-                              'with value type %s', vt)
-                    raise
-            else:
-                raise
-
-        vt = tt._find_ctor(obj_ctor)
-
-        ctor, value = self._serialize_dispatch(context.append_path(obj_ctor), vt, obj_value)
-
-        variant_message = Variant()
-        variant_message.constructor = obj_ctor
-        set_value(variant_message.value, ctor, value)
-        return 'variant', variant_message
-
-    def serialize_enum(self, context: TypeEvaluationContext, tt: EnumType, obj: Any) -> R:
-        from ..._gen.com.daml.ledger.api.v1.value_pb2 import Enum
-        enum_message = Enum()
-        enum_message.constructor = obj
-        return 'enum', enum_message
-
-    def serialize_unsupported(
-            self, context: TypeEvaluationContext, tt: UnsupportedType, obj: Any) -> R:
-        raise Exception(f'UnsupportedType {tt} is not serializable in gRPC')
 
 
 def _set_template(message: G.Identifier, name: 'TypeConName') -> None:

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -69,7 +69,7 @@ class DarFile(_DarFile):
         """
         warnings.warn(
             'get_archives is deprecated; there is no replacement.',
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
         return {a.hash: a.payload for a in self._pb_archives()}
 
     def get_dalf_names(self) -> 'Sequence[str]':

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -183,7 +183,7 @@ class Context:
                 # still the canonical form of a ContractId until the deprecated version is dropped
                 return DeprecatedContractId(contract_id.value, element_type.con.tycon)
             else:
-                return ContractId(element_type.con.tycon, contract_id)
+                return DeprecatedContractId(contract_id, element_type.con.tycon)
 
     def resolve_data_type(self, con: 'Type.Con') -> 'DefDataType':
         """

--- a/python/tests/unit/test_dar_upload.py
+++ b/python/tests/unit/test_dar_upload.py
@@ -18,7 +18,7 @@ async def test_dar_uploads_near_startup(sandbox):
     async def upload_dars_and_verify():
         await upload_test_dars(network)
         metadata = await network.aio_global().metadata()
-        package_ids.extend(metadata.store.package_ids())
+        package_ids.extend(network.lookup.package_ids())
 
     await network.aio_run(upload_dars_and_verify(), keep_open=False)
 
@@ -49,6 +49,7 @@ async def test_package_events(sandbox):
         # client is running and # operational
         await client.ready()
         await upload_test_dars(network)
+        await (await network.aio_global().metadata()).package_loader.load_all()
 
         # give the client some time to pick up the new packages; unfortunately there isn't
         # much more to do here except wait

--- a/python/tests/unit/test_event_order.py
+++ b/python/tests/unit/test_event_order.py
@@ -58,8 +58,6 @@ class Stage1LedgerInit:
 
     async def on_ready(self, event):
         await self.network.aio_global().ensure_dar(SimpleDar)
-        while not event.package_store.resolve_template(Simple.OperatorRole):
-            await sleep(1)
 
         return create(Simple.OperatorRole, {'operator': event.party})
 

--- a/python/tests/unit/test_flask.py
+++ b/python/tests/unit/test_flask.py
@@ -50,9 +50,6 @@ def create_initial_state(event: 'ReadyEvent'):
     try:
         LOG.info('Uploading our DAR...')
         event.client.ensure_dar(PostOffice)
-        while not event.package_store.resolve_template('Main:PostmanRole'):
-            logging.info("Waiting for our DAR to be uploaded...")
-            sleep(1)
 
         LOG.info('DAR uploaded. Creating the initial postman role contract...')
         return create('Main:PostmanRole', dict(postman=event.party))

--- a/python/tests/unit/test_pretty_daml.py
+++ b/python/tests/unit/test_pretty_daml.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 from dazl.damlast.daml_lf_1 import DottedName, ModuleRef, PackageRef, TypeConName
-from dazl.damlast import daml_types as daml
+from dazl.damlast import daml_types as daml, DarFile
+from dazl.damlast.lookup import MultiPackageLookup
 from dazl.pretty import DamlPrettyPrinter, PrettyOptions
-from dazl.util.dar import DarFile
 from .dars import Pending
 
 
@@ -77,5 +78,5 @@ def test_render_update_of_contract_type_con_new():
 
 def test_render_metadata():
     with DarFile(Pending) as dar:
-        pp = DamlPrettyPrinter(store=dar.read_metadata(), context=PrettyOptions(show_hidden_types=True))
+        pp = DamlPrettyPrinter(lookup=MultiPackageLookup(dar.archives()), context=PrettyOptions(show_hidden_types=True))
         pp.render_store()


### PR DESCRIPTION
Fix a race condition that could cause failures when trying to use packages around the same time they are uploaded to the ledger.

This is the one that switches the primary encode/decoder to the new `ValueMapper` introduced in #144, and uses the `SymbolLookup`/`PackageLoader` combination from #142.

A few long-standing TODOs in the guts of dazl have also now been dropped, particularly around ordering of when packages get loaded, and inopportune polling as it relates to trying to make sure the appropriate packages are available at the appropriate time (which turns out to be impossible to do).