### PR TITLE
python: Introduce ValueMapper

### DIFF
--- a/python/dazl/damlast/lookup.py
+++ b/python/dazl/damlast/lookup.py
@@ -23,7 +23,9 @@ from .errors import NameNotFoundError, PackageNotFoundError
 from .protocols import SymbolLookup
 from ..model.lookup import validate_template
 
-__all__ = ['parse_type_con_name', 'EmptyLookup', 'PackageLookup', 'MultiPackageLookup']
+__all__ = [
+    'find_choice', 'parse_type_con_name', 'EmptyLookup', 'PackageLookup', 'MultiPackageLookup'
+]
 
 
 def parse_type_con_name(val: str) -> 'TypeConName':

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from typing import Mapping, Optional, Sequence, Union, TYPE_CHECKING
-from .daml_lf_1 import DefValue, Expr, ModuleRef, Type, PrimType, Kind, UNIT, TypeVarWithKind, _Name, PackageRef, \
-    DottedName
+from .daml_lf_1 import DefValue, Expr, ModuleRef, Type, PrimType, Kind, UNIT, TypeVarWithKind, \
+    _Name, PackageRef, DottedName, DefDataType
 
 if TYPE_CHECKING:
     from ..model.types import Type as OldType, TypeReference
@@ -187,3 +188,10 @@ def module_local_name(obj: 'Union[_Name, TypeReference]') -> str:
     else:
         raise ValueError(f"Could not extract a module_local_name from {obj!r}")
 
+
+def find_variant_type(dt: 'DefDataType', variant: 'DefDataType.Fields', constructor: str) -> 'Type':
+    for fld_metadata in variant.fields:
+        if fld_metadata.field == constructor:
+            return fld_metadata.type
+
+    raise ValueError(f'{constructor} is not a field of {dt.name}')

--- a/python/dazl/protocols/v1/pb_parse_event.py
+++ b/python/dazl/protocols/v1/pb_parse_event.py
@@ -15,7 +15,6 @@ from google.protobuf.empty_pb2 import Empty
 
 from ... import LOG
 from ...damlast.daml_lf_1 import ModuleRef, PackageRef, DottedName, TypeConName
-from ...damlast.daml_types import con
 from ...damlast.protocols import SymbolLookup
 from ...model.core import ContractId
 from ...model.reading import BaseEvent, TransactionFilter, ContractCreateEvent, \
@@ -351,7 +350,7 @@ def to_created_event(
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
         cid = ContractId(cr.contract_id, name)
-    cdata = cdata = to_record(tt_context, tt, cr.create_arguments)
+    cdata = to_record(tt_context, tt, cr.create_arguments)
     event_id = cr.event_id
     witness_parties = tuple(cr.witness_parties)
 

--- a/python/dazl/values/__init__.py
+++ b/python/dazl/values/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+:mod:`dazl.values` package
+==========================
+
+The :mod:`dazl.values` module contains utilities for converting between different representations
+of DAML-LF types.
+"""
+
+from .context import Context
+from .canonical import CanonicalMapper
+from .mapper import ValueMapper
+from .json import JsonDecoder, JsonEncoder
+from .protobuf import ProtobufDecoder, ProtobufEncoder

--- a/python/dazl/values/canonical.py
+++ b/python/dazl/values/canonical.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Mapping, Tuple
+
+from .context import Context
+from .mapper import ValueMapper
+from ..damlast.daml_lf_1 import DefDataType, Type
+from ..prim import to_bool, to_date, to_record, to_variant, to_int, to_party, to_datetime, to_str, \
+    to_decimal
+
+
+class CanonicalMapper(ValueMapper):
+    """
+    A mapper that canonicalizes values. If values are already in canonical form, this is essentially
+    the identity mapper.
+
+    For container primitives (Optional, List, Map, etc), records, and variants, values are recursed
+    and walked through, so subclasses that override :class:`CanonicalMapper` can typically just
+    override the primitive methods in order to get slightly different behavior.
+
+    The canonical format of DAML-LF values in dazl was designed specifically to conform as closely
+    as possible to simple JSON representations, so the :class:`CanonicalMapper` can also be used to
+    decode DAML-LF JSON.
+    """
+
+    def data_record(
+            self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') \
+            -> 'Any':
+        orig_mapping = self._record_to_dict(context, dt, record, obj)
+
+        expected_keys = frozenset(fld.field for fld in record.fields)
+        actual_keys = frozenset(orig_mapping)
+        if actual_keys.issuperset(expected_keys):
+            if actual_keys != expected_keys:
+                # Earlier versions of dazl were more tolerant of extra fields. To keep backwards
+                # compatibility, we'll emit a warning, though this may become an exception
+                # eventually.
+                context.value_warn(
+                    obj, f'extra fields: {", ".join(sorted(actual_keys - expected_keys))}')
+        else:
+            context.value_error(
+                obj, f'missing fields: {", ".join(sorted(expected_keys - actual_keys))}')
+
+        new_mapping = {
+            fld.field: context.append_path(fld.field).convert(fld.type, orig_mapping[fld.field])
+            for fld in record.fields}
+        return self._dict_to_record(context, dt, record, new_mapping)
+
+    def data_variant(
+            self,
+            context: 'Context',
+            dt: 'DefDataType',
+            variant: 'DefDataType.Fields',
+            obj: 'Any') -> 'Any':
+        ctor, orig_val = self._variant_to_ctor_value(context, dt, variant, obj)
+        for fld in variant.fields:
+            if fld.field == ctor:
+                new_val = context.append_path(fld.field).convert(fld.type, orig_val)
+                return self._ctor_value_to_variant(context, dt, variant, ctor, new_val)
+
+        # searched through all fields, and did not find the constructor
+        raise ValueError(f'could not find a variant constructor for {ctor}')
+
+    def data_enum(
+            self,
+            context: 'Context',
+            dt: 'DefDataType',
+            enum: 'DefDataType.EnumConstructors',
+            obj: 'Any') -> 'Any':
+        return context.value_validate_enum(obj, enum)
+
+    def prim_unit(self, context: 'Context', obj: 'Any') -> 'Any':
+        return {}
+
+    def prim_bool(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_bool(obj)
+
+    def prim_int64(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_int(obj)
+
+    def prim_text(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_str(obj)
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_datetime(obj)
+
+    def prim_party(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_party(obj)
+
+    def prim_list(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        return context.convert_list(item_type, obj)
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_date(obj)
+
+    def prim_contract_id(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        return context.convert_contract_id(item_type, obj)
+
+    def prim_optional(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        return context.convert_optional(item_type, obj)
+
+    def prim_text_map(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        return context.convert_text_map(item_type, obj)
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        return to_decimal(obj)
+
+    def prim_gen_map(
+            self, context: 'Context', key_type: 'Type', value_type: 'Type', obj: 'Any') -> 'Any':
+        return obj
+
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def _record_to_dict(
+            self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') \
+            -> 'Mapping[str, Any]':
+        """
+        Convert a record object to a Python dict. Should be overridden by subclasses to convert a
+        record to a dict whose keys are field names and values are associated field values if record
+        objects are not always understood to be dicts.
+
+        The default implementation assumes that ``obj`` is already a ``dict`` that matches this
+        contract and simply returns it (though this is verified first).
+        """
+        return to_record(obj)
+
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def _dict_to_record(
+            self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any'):
+        return obj
+
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def _variant_to_ctor_value(
+            self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') \
+            -> 'Tuple[str, Any]':
+        """
+        Convert a variant object to a constructor and a value. Should be overridden by subclasses to
+        convert a variant that is not formatted in a recognized way.
+        """
+        return to_variant(obj)
+
+    # noinspection PyMethodMayBeStatic,PyUnusedLocal
+    def _ctor_value_to_variant(
+            self, context: 'Context', dt: 'DefDataType', variant: 'DefDataType.Fields', ctor: str,
+            value: 'Any') -> 'Any':
+        return {ctor: value}

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+from typing import Any, List, Dict, Mapping, NoReturn, Optional, Sequence, TYPE_CHECKING
+
+from .mapper import ValueMapper
+from ..damlast import IdentityTypeVisitor
+from ..damlast.daml_lf_1 import DefDataType, FieldWithType, PrimType, Type
+from ..damlast.lookup import EmptyLookup
+from ..damlast.protocols import SymbolLookup
+from ..model.core import DazlError
+from ..prim import ContractId, to_variant, to_str
+
+if TYPE_CHECKING:
+    from .mapper import ValueMapper
+
+
+__all__ = ['Context', 'UnboundVarError']
+
+
+# Context is designed to be subclassable, so avoid making methods that could be static, static.
+# noinspection PyMethodMayBeStatic
+class Context:
+    """
+    A context under which object translation can occur.
+
+    Usage:
+
+    > context = Context(mapper)
+    > context.convert(obj_type, obj)
+    """
+
+    def __init__(
+            self,
+            mapper: 'ValueMapper',
+            lookup: 'Optional[SymbolLookup]' = None,
+            path: 'Sequence[str]' = ()):
+        """
+        Initialize a Context.
+
+        Note that ``None`` as a :class:`SymbolLookup` means that mappers that use the created
+         :class:`Context` can only understand and map primitive types; this may be suitable for
+        some limited use cases, so it is allowed.
+
+        :param lookup:
+            :class:`SymbolLookup` implementation that can provide references to types and templates.
+            If ``None``, mappers that use this context cannot resolve any complex types.
+        """
+        self.mapper = mapper
+        self.lookup = lookup if lookup is not None else EmptyLookup()
+        self.path = tuple(path)
+
+    def convert(self, item_type: 'Type', obj: 'Any'):
+        """
+        Convert a value from one representation to another.
+
+        :param item_type:
+            The assumed DAML-LF :class:`Type` of ``obj``.
+        :param obj:
+            The object to convert.
+        """
+        try:
+            if item_type.var is not None:
+                # We support type variables, but only when they are bound; if we receive a type
+                # variable here (outside of a Type.Con context where type arguments can be
+                # immediately applied and substituted) we can't meaningfully process them.
+                raise UnboundVarError(item_type.var.var)
+            elif item_type.con is not None:
+                dt = self.resolve_data_type(item_type.con)
+                if dt.record is not None:
+                    return self.mapper.data_record(self, dt, dt.record, obj)
+                elif dt.variant is not None:
+                    return self.mapper.data_variant(self, dt, dt.variant, obj)
+                elif dt.enum is not None:
+                    return self.mapper.data_enum(self, dt, dt.enum, obj)
+            elif item_type.prim is not None:
+                if item_type.prim.prim == PrimType.UNIT:
+                    return self.mapper.prim_unit(self, obj)
+                elif item_type.prim.prim == PrimType.BOOL:
+                    return self.mapper.prim_bool(self, obj)
+                elif item_type.prim.prim == PrimType.INT64:
+                    return self.mapper.prim_int64(self, obj)
+                elif item_type.prim.prim == PrimType.DECIMAL:
+                    return self.mapper.prim_numeric(self, 10, obj)
+                elif item_type.prim.prim == PrimType.TEXT or item_type.prim.prim == PrimType.CHAR:
+                    return self.mapper.prim_text(self, obj)
+                elif item_type.prim.prim == PrimType.TIMESTAMP:
+                    return self.mapper.prim_timestamp(self, obj)
+                elif item_type.prim.prim == PrimType.PARTY:
+                    return self.mapper.prim_party(self, obj)
+                elif item_type.prim.prim == PrimType.LIST:
+                    return self.mapper.prim_list(self, item_type.prim.args[0], obj)
+                elif item_type.prim.prim == PrimType.DATE:
+                    return self.mapper.prim_date(self, obj)
+                elif item_type.prim.prim == PrimType.CONTRACT_ID:
+                    return self.mapper.prim_contract_id(self, item_type.prim.args[0], obj)
+                elif item_type.prim.prim == PrimType.OPTIONAL:
+                    return self.mapper.prim_optional(self, item_type.prim.args[0], obj)
+                elif item_type.prim.prim == PrimType.TEXTMAP:
+                    return self.mapper.prim_text_map(self, item_type.prim.args[0], obj)
+                elif item_type.prim.prim == PrimType.NUMERIC:
+                    return self.mapper.prim_numeric(self, item_type.prim.args[0].nat, obj)
+                elif item_type.prim.prim == PrimType.GENMAP:
+                    return self.mapper.prim_gen_map(
+                        self, item_type.prim.args[0], item_type.prim.args[1], obj)
+
+            raise ValueError(f'could not process type: {item_type}')
+
+        except ValueError as ex:
+            # re-raise ValueErrors with a more descriptive string that includes the current context
+            # path
+            raise ValueError(f'value at {".".join(self.path)} has an invalid value: {obj}') from ex
+
+    def convert_list(self, element_type: 'Type', elements: 'Sequence[Any]') -> 'List[Any]':
+        """
+        Convert a _list_ of elements, each of an assumed type.
+
+        This is a convenience method for :class:`ValueMapper` implementations where lists are
+        implemented as Python lists. Note that a :class:`ValueMapper` may choose to implement list
+        type conversion in a completely different way instead of calling this function, which may be
+        necessary if a list of DAML-LF values is encoded in a way other than a Python list
+        (i.e., Protobuf).
+
+        :param element_type:
+            The :class:`Type` of the element.
+        :param elements:
+            An iterable collection of objects to convert.
+        """
+        return [self.append_path(f'[{i}').convert(element_type, elem)
+                for i, elem in enumerate(elements)]
+
+    def convert_optional(self, element_type: 'Type', element: 'Optional[Any]') -> 'List[Any]':
+        """
+        Convert a _list_ of elements, each of an assumed type.
+
+        This is a convenience method for :class:`ValueMapper` implementations where DAML-LF
+        Optionals are implemented as normal Python values or ``None``. A :class:`ValueMapper` may
+        choose to implement optional type conversion in a completely different way, which may be
+        necessary if an Optional of a DAML-LF value is encoded in a way other than its natural
+        representation or ``None`` (i.e., Protobuf).
+
+        :param element_type:
+            The :class:`Type` of the element.
+        :param element:
+            An object to convert.
+        :return:
+            The converted object, or ``None`` if the value of the object is ``None``.
+        """
+        return self.append_path('?').convert(element_type, element) if element is not None else None
+
+    def convert_text_map(self, element_type: 'Type', elements: 'Mapping[str, Any]') \
+            -> 'Dict[str, Any]':
+        """
+        Convert a _map_ of elements, each of an assumed type.
+
+        This is a convenience method for :class:`ValueMapper` implementations where DAML-LF TextMaps
+        are represented as Python dictionaries. Note that a :class:`ValueMapper` may choose to
+        implement TextMap type conversion in a completely different way instead of calling this
+        function, which may be necessary if a TextMap of DAML-LF values is encoded in a way other
+        than a Python dict (i.e., Protobuf).
+
+        :param element_type:
+            The :class:`Type` of the element.
+        :param elements:
+            A mapping of keys to values.
+        """
+        return {key: self.append_path(key).convert(element_type, value)
+                for key, value in elements.items()}
+
+    def convert_contract_id(self, element_type: 'Type', contract_id: 'Any') -> 'ContractId':
+        """
+        Convert a contract ID string to a :class:`ContractId`.
+        """
+        with warnings.catch_warnings():
+            # TODO: Drop this and switch to new-style ContractIds
+            warnings.simplefilter('ignore', DeprecationWarning)
+            from ..model.core import ContractId as DeprecatedContractId
+            if isinstance(contract_id, DeprecatedContractId):
+                return contract_id
+            elif isinstance(contract_id, ContractId):
+                # convert new-style ContractId instances to deprecated subclasses; for now, this is
+                # still the canonical form of a ContractId until the deprecated version is dropped
+                return DeprecatedContractId(contract_id.value, element_type.con.tycon)
+            else:
+                return ContractId(element_type.con.tycon, contract_id)
+
+    def resolve_data_type(self, con: 'Type.Con') -> 'DefDataType':
+        """
+        Resolve a :class:`DefDataType`, including applying any type parameters.
+
+        In order to support recursive types and type variables, only the variables that are fields
+        of the resolved :class:`DefDataType` are replaced.
+        """
+        dt = self.lookup.data_type(con.tycon)
+        if len(dt.params) != len(con.args):
+            # every time we encounter DefDataType, we expect to be given its type arguments in the
+            # same place; there are no other constructs in DAML-LF that express type application,
+            # so failure to supply type arguments here is an error
+            raise ValueError('partially-applied types are not allowed')
+
+        # without type arguments, simply return the original DefDataType; it does not need to be
+        # modified
+        if not con.args:
+            return dt
+
+        # from this point on, we discard all type arguments and the original name of the DefDataType
+        # since the fully-applied type is NOT the same type as the original, nor is it correct to
+        # say it takes any type arguments
+
+        type_vars = {tvwk.var: arg for (tvwk, arg) in zip(dt.params, con.args)}
+
+        if dt.record is not None:
+            return DefDataType(
+                record=self._replace_all_type_vars(type_vars, dt.record),
+                serializable=dt.serializable,
+                location=dt.location)
+
+        elif dt.variant is not None:
+            return DefDataType(
+                variant=self._replace_all_type_vars(type_vars, dt.variant),
+                serializable=dt.serializable,
+                location=dt.location)
+
+        elif dt.enum is not None:
+            return DefDataType(enum=dt.enum, serializable=dt.serializable, location=dt.location)
+
+        elif dt.synonym is not None:
+            return DefDataType(
+                synonym=dt.synonym, serializable=dt.serializable, location=dt.location)
+
+        else:
+            raise ValueError('unknown DefDataType cannot have variables applied to them')
+
+    def append_path(self, path: str) -> 'Context':
+        """
+        Return a new :class:`Context` marked at a deeper path within an object hierarchy.
+
+        :param path: The path to append to the current :class:`Context`'s path.
+        :return: A new :class:`Context` with a modified path.
+        """
+        return Context(self.mapper, self.lookup, self.path + (path,))
+
+    def value_validate_enum(self, value: 'Any', enum: 'DefDataType.EnumConstructors') -> str:
+        """
+        Return either a confirmed valid value from the list of possible enums, or throw an error.
+
+        :param value:
+            The "natural" Python type for an enum (either a string or a variant object).
+        :param enum:
+            The enum constructors to validate against.
+        :return:
+            The string that is the valid constructor from the list of constructors to choose from.
+        :raise ValueError:
+            if the value could not be understood as one of the enum constructors.
+        """
+        from collections.abc import Mapping
+        if isinstance(value, Mapping):
+            ctor, _ = to_variant(value)
+        else:
+            ctor = to_str(value)
+
+        if ctor in enum.constructors:
+            return ctor
+
+        self.value_error(value, f'expected one of {enum.constructors}')
+
+    def value_warn(self, value: 'Any', message: str) -> 'None':
+        """
+        Raise a :class:`ValueWarning`, enriched with information in the current context.
+        """
+        warnings.warn(
+            f'value at {".".join(self.path)} has a possibly invalid value: {value} ({message})',
+            ValueWarning, stacklevel=2)
+
+    def value_error(self, value: 'Any', message: str) -> 'NoReturn':
+        """
+        Raise a :class:`ValueError`, enriched with information in the current context.
+        """
+        raise ValueError(f'value at {".".join(self.path)} has an invalid value: {value} ({message})')
+
+    def _replace_all_type_vars(
+            self, type_vars: 'Mapping[str, Type]', fields: 'DefDataType.Fields') \
+            -> 'DefDataType.Fields':
+        """
+        Substitute type variables from the given mapping into each of the provided fields.
+        """
+        tv = ReplacingTypeVisitor(type_vars)
+        return DefDataType.Fields(
+            [FieldWithType(f.field, tv.visit_type(f.type)) for f in fields.fields])
+
+
+class ReplacingTypeVisitor(IdentityTypeVisitor):
+    def __init__(self, type_vars: 'Mapping[str, Type]'):
+        self.type_vars = type_vars
+
+    def resolve_type(self, var: 'str') -> 'Optional[Type]':
+        replacement = self.type_vars.get(var)
+        if replacement is None:
+            raise UnboundVarError(var)
+
+        return replacement
+
+
+class UnboundVarError(DazlError):
+    def __init__(self, var):
+        self.var = var
+
+
+class ValueWarning(Warning):
+    pass

--- a/python/dazl/values/json.py
+++ b/python/dazl/values/json.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Mappers for translating to and from native Python types.
+
+Documentation for this encoding format can be found at:
+https://docs.daml.com/json-api/lf-value-specification.html
+"""
+
+from typing import Any
+
+from .canonical import CanonicalMapper
+from .context import Context
+from ..damlast.daml_lf_1 import Type as DamlType, DefDataType
+from ..prim import date_to_str, datetime_to_str, decimal_to_str, to_date, to_datetime, \
+    to_decimal
+
+__all__ = ['JsonDecoder', 'JsonEncoder']
+
+
+class JsonDecoder(CanonicalMapper):
+    """
+    Convert DAML-LF JSON encoded types into native Python types.
+
+    Note that currently, objects that come back from the HTTP JSON API, so canonicalization is
+    completely sufficient.
+    """
+
+
+class JsonEncoder(CanonicalMapper):
+    """
+    Convert native Python types to DAML-LF JSON encoded types.
+    """
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        return datetime_to_str(to_datetime(obj))
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        return date_to_str(to_date(obj))
+
+    def prim_contract_id(self, context: 'Context', item_type: 'DamlType', obj: 'Any') -> 'Any':
+        return obj.contract_id
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        return decimal_to_str(to_decimal(obj))
+
+    def _ctor_value_to_variant(
+            self, context: 'Context', dt: 'DefDataType', variant: 'DefDataType.Fields', ctor: str,
+            value: 'Any') -> 'Any':
+        """
+        Format a variant according to the DAML-LF JSON spec (an object with a "tag" and "value"
+        field).
+        """
+        return {"tag": ctor, "value": value}

--- a/python/dazl/values/mapper.py
+++ b/python/dazl/values/mapper.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from typing import Any, TYPE_CHECKING
+
+from ..damlast.daml_lf_1 import DefDataType, Type
+
+if TYPE_CHECKING:
+    from .context import Context
+
+if sys.version_info >= (3, 7):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
+__all__ = ['ValueMapper']
+
+
+class ValueMapper(Protocol):
+    """
+    Protocol for an object that can map one representation of DAML-LF values to another
+    representation. This is the protocol that wire encoders/decoders adhere to, as well as certain
+    types of validators.
+
+    To use an instance of a :class:`ValueMapper` to transform an object, create a :class:`Context`
+    with an instance of a :class:`ValueMapper`; then call :meth:`Context.convert`.
+    """
+
+    def data_record(
+            self,
+            context: 'Context',
+            dt: 'DefDataType',
+            record: 'DefDataType.Fields',
+            obj: 'Any') \
+            -> 'Any':
+        raise NotImplementedError('data_record requires an implementation')
+
+    def data_variant(
+            self,
+            context: 'Context',
+            dt: 'DefDataType',
+            variant: 'DefDataType.Fields',
+            obj: 'Any') \
+            -> 'Any':
+        raise NotImplementedError('data_variant requires an implementation')
+
+    def data_enum(self, context: 'Context', dt: 'DefDataType', enum: 'DefDataType.EnumConstructors',
+                  obj: 'Any') -> 'Any':
+        raise NotImplementedError('data_variant requires an implementation')
+
+    def prim_unit(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_unit requires an implementation')
+
+    def prim_bool(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_bool requires an implementation')
+
+    def prim_int64(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_int64 requires an implementation')
+
+    def prim_text(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_text requires an implementation')
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_timestamp requires an implementation')
+
+    def prim_party(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_party requires an implementation')
+
+    def prim_list(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_list requires an implementation')
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_date requires an implementation')
+
+    def prim_contract_id(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_contract_id requires an implementation')
+
+    def prim_optional(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_optional requires an implementation')
+
+    def prim_text_map(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_text_map requires an implementation')
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_numeric requires an implementation')
+
+    def prim_gen_map(
+            self, context: 'Context', key_type: 'Type', value_type: 'Type', obj: 'Any') -> 'Any':
+        raise NotImplementedError('prim_gen_map requires an implementation')

--- a/python/dazl/values/protobuf.py
+++ b/python/dazl/values/protobuf.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Optional, Type, TypeVar
+
+# noinspection PyPackageRequirements
+from google.protobuf.empty_pb2 import Empty
+# noinspection PyPackageRequirements
+from google.protobuf import timestamp_pb2
+
+from .context import Context
+from .mapper import ValueMapper
+from .._gen.com.daml.ledger.api.v1 import value_pb2
+from ..damlast.daml_lf_1 import Type, DefDataType
+from ..damlast.util import find_variant_type
+from ..prim import decimal_to_str, to_bool, to_date, to_datetime, to_decimal, to_int, to_str, \
+    to_variant, date_to_int, datetime_to_epoch_microseconds, to_party
+
+__all__ = ['ProtobufDecoder', 'ProtobufEncoder', 'get_value', 'set_value']
+
+T = TypeVar('T')
+
+
+class ProtobufDecoder(ValueMapper):
+    """
+    Convert value_pb2.Value (or any of its cases) to a native Python type.
+
+    This mapper also handles:
+     * re-typing ContractIds (they come over the Ledger API without their type parameter)
+     * non-verbose Ledger API record values (field names are omitted for message brevity, meaning
+       they can only be understood in a generic way by knowing the metadata associated with the
+       object ahead of time)
+    """
+
+    def data_record(self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'record', value_pb2.Record)
+
+        d = dict()
+        for fld_metadata, fld_data in zip(record.fields, msg.fields):
+            name = fld_metadata.field
+            value = context.append_path(name).convert(fld_metadata.type, fld_data.value)
+            d[name] = value
+
+        return d
+
+    def data_variant(self, context: 'Context', dt: 'DefDataType', variant: 'DefDataType.Fields', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'variant', value_pb2.Variant)
+        obj_ctor = msg.constructor
+        obj_value = msg.value
+        obj_type = find_variant_type(dt, variant, obj_ctor)
+
+        d_value = context.append_path(obj_ctor).convert(obj_type, obj_value)
+
+        return {obj_ctor: d_value}
+
+    def data_enum(self, context: 'Context', dt: 'DefDataType', enum: 'DefDataType.EnumConstructors',
+                  obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'enum', value_pb2.Enum)
+        return context.value_validate_enum(msg.constructor, enum)
+
+    def prim_unit(self, context: 'Context', obj: 'Any') -> 'Any':
+        return {}
+
+    def prim_bool(self, context: 'Context', obj: 'Any') -> 'Any':
+        return get_value(obj, 'bool', bool)
+
+    def prim_int64(self, context: 'Context', obj: 'Any') -> 'Any':
+        return get_value(obj, 'int64', int)
+
+    def prim_text(self, context: 'Context', obj: 'Any') -> 'Any':
+        return get_value(obj, 'text', str)
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_datetime(get_value(obj, 'timestamp', timestamp_pb2.Timestamp))
+
+    def prim_party(self, context: 'Context', obj: 'Any') -> 'Any':
+        return to_party(get_value(obj, 'party', str))
+
+    def prim_list(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'list', value_pb2.List)
+        return context.convert_list(item_type, msg.elements)
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'date', str)
+        return to_date(msg)
+
+    def prim_contract_id(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'contract_id', str)
+        return context.convert_contract_id(item_type, msg)
+
+    def prim_optional(self, context: 'Context', t: 'Type', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'optional', value_pb2.Optional)
+        maybe_val = msg.value if msg.HasField('value') else None
+        return context.convert_optional(t, maybe_val)
+
+    def prim_text_map(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'map', value_pb2.Map)
+        mapping = {entry_pb.key: entry_pb.value for entry_pb in msg.entries}
+        return context.convert_text_map(item_type, mapping)
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'numeric', str)
+        return to_decimal(msg)
+
+    def prim_gen_map(self, context: 'Context', key_type: 'Type', value_type: 'Type', obj: 'Any') -> 'Any':
+        msg = get_value(obj, 'gen_map', value_pb2.GenMap)
+
+        obj = {}
+        for i, entry in enumerate(msg.entries):
+            key = context.append_path(f'[key: {i}]').convert(key_type, entry.key)
+            value = context.append_path(f'[{key}]').convert(value_type, entry.value)
+            obj[key] = value
+
+        return obj
+
+
+class ProtobufEncoder(ValueMapper):
+    def data_record(
+            self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') -> 'Any':
+        msg = value_pb2.Record()
+
+        for fld in record.fields:
+            entry = msg.fields.add()
+            entry.label = fld.field
+            ctor, val = context.append_path(fld.field).convert(fld.type, obj[fld.field])
+            set_value(entry.value, ctor, val)
+
+        return 'record', msg
+
+    def data_variant(
+            self,
+            context: 'Context',
+            dt: 'DefDataType',
+            variant: 'DefDataType.Fields',
+            obj: 'Any') -> 'Any':
+        obj_ctor, obj_value = to_variant(obj)
+        obj_type = find_variant_type(dt, variant, obj_ctor)
+
+        msg_case, msg_value = context.append_path(obj_ctor).convert(obj_type, obj_value)
+
+        msg = value_pb2.Variant()
+        msg.constructor = obj_ctor
+        set_value(msg.value, msg_case, msg_value)
+
+        return 'variant', msg
+
+    def data_enum(self, context: 'Context', dt: 'DefDataType', enum: 'DefDataType.EnumConstructors',
+                  obj: 'Any') -> 'Any':
+        msg = value_pb2.Enum()
+        msg.constructor = context.value_validate_enum(obj, enum)
+        return 'enum', msg
+
+    def prim_unit(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'unit', Empty()
+
+    def prim_bool(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'bool', to_bool(obj)
+
+    def prim_int64(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'int64', to_int(obj)
+
+    def prim_text(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'text', to_str(obj)
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'timestamp', datetime_to_epoch_microseconds(to_datetime(obj))
+
+    def prim_party(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'party', to_str(obj)
+
+    def prim_list(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = value_pb2.List()
+        for i, item in enumerate(obj):
+            value = msg.elements.add()
+            ctor, val = context.append_path(f'[{i}').convert(item_type, item)
+            set_value(value, ctor, val)
+        return 'list', msg
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'date', date_to_int(to_date(obj))
+
+    def prim_contract_id(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        return 'contract_id', to_str(obj)
+
+    def prim_optional(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = value_pb2.Optional()
+        if obj is not None:
+            ctor, val = context.append_path('?').convert(item_type, obj)
+            set_value(msg.value, ctor, val)
+        return 'optional', msg
+
+    def prim_text_map(self, context: 'Context', item_type: 'Type', obj: 'Any') -> 'Any':
+        msg = value_pb2.Map()
+        for key, value in obj.items():
+            entry = msg.entries.add()
+            entry.key = key
+            ctor, val = context.append_path(f'[{key}]').convert(item_type, value)
+            set_value(entry.value, ctor, val)
+        return 'map', msg
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        return 'numeric', decimal_to_str(to_decimal(obj))
+
+    def prim_gen_map(
+            self, context: 'Context', key_type: 'Type', value_type: 'Type', obj: 'Any') -> 'Any':
+        msg = value_pb2.GenMap()
+        for i, (key, value) in enumerate(obj.items()):
+            entry = msg.entries.add()
+            key_ctor, key_val = context.append_path(f'[key: {i}]').convert(key_type, key)
+            val_ctor, val_val = context.append_path(f'[{key}]').convert(value_type, value)
+            set_value(entry.key, key_ctor, key_val)
+            set_value(entry.value, val_ctor, val_val)
+        return 'gen_map', msg
+
+
+def get_value(obj: 'Any', field: str, pb_type: 'Type[T]') -> 'T':
+    return obj if isinstance(obj, pb_type) else getattr(obj, field)
+
+
+def set_value(message: 'value_pb2.Value', ctor: 'Optional[str]', value: 'Any') -> None:
+    """
+    Work around the somewhat crazy API of Python's gRPC library to apply a known value to a
+    :class:`Value`.
+
+    :param message:
+        The :class:`Value` object to modify.
+    :param ctor:
+        The actual field to apply to, or ``None`` to interpret the entire message as a ``Record``
+        instead.
+    :param value:
+        The actual value to set. Must be compatible with the appropriate field.
+    """
+    try:
+        if ctor is None:
+            message.MergeFrom(value)
+        elif ctor == 'unit':
+            message.unit.SetInParent()
+        elif ctor in ('record', 'variant', 'list', 'optional', 'enum', 'map', 'gen_map'):
+            getattr(message, ctor).MergeFrom(value)
+        else:
+            setattr(message, ctor, value)
+    except:  # noqa
+        from .. import LOG
+        LOG.error('Failed to set a value %s, %s', ctor, value)
+        raise

--- a/python/dazl/values/pysample_encoder.py
+++ b/python/dazl/values/pysample_encoder.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from ..damlast.daml_lf_1 import Type as DamlType, DefDataType
+from .mapper import ValueMapper, Context, convert
+
+
+class PythonSampleEncoder(ValueMapper):
+    def __init__(self, max_depth: int = 6):
+        self.max_depth = max_depth
+
+    def _recurse(self, context: 'Context', key, item_type):
+        if context.depth <= self.max_depth:
+            return '...'
+        else:
+            return convert(self, context.append_path(key), item_type, None)
+
+    def data_record(self, context: 'Context', dt: 'DefDataType', record: 'DefDataType.Fields', obj: 'Any') -> 'Any':
+        return {fld.field: self._recurse(context, fld.field, fld.type) for fld in record.fields}
+        pass
+
+    def data_variant(self, context: 'Context', dt: 'DefDataType', variant: 'DefDataType.Fields', obj: 'Any') -> 'Any':
+        return {fld.field: self._recurse(context, fld.field, fld.type) for fld in variant.fields}
+
+    def data_enum(self, context: 'Context', dt: 'DefDataType', enum: 'DefDataType.EnumConstructors', obj: 'Any') -> 'Any':
+        return ' | '.join(enum.constructors)
+
+    def prim_unit(self, context: 'Context', obj: 'Any') -> 'Any':
+        return '{}'
+
+    def prim_bool(self, context: 'Context', obj: 'Any') -> 'Any':
+        return 'true | false'
+
+    def prim_int64(self, context: 'Context', obj: 'Any') -> 'Any':
+        return "int-value"
+
+    def prim_text(self, context: 'Context', obj: 'Any') -> 'Any':
+        return "text-value"
+
+    def prim_timestamp(self, context: 'Context', obj: 'Any') -> 'Any':
+        return "timestamp-value"
+
+    def prim_party(self, context: 'Context', obj: 'Any') -> 'Any':
+        return "party-value"
+
+    def prim_list(self, context: 'Context', item_type: 'DamlType', obj: 'Any') -> 'Any':
+        return [self._recurse(context, '[]', item_type)]
+
+    def prim_date(self, context: 'Context', obj: 'Any') -> 'Any':
+        return "date-value"
+
+    def prim_contract_id(self, context: 'Context', item_type: 'DamlType', obj: 'Any') -> 'Any':
+        return "contract-id"
+
+    def prim_optional(self, context: 'Context', item_type: 'DamlType', obj: 'Any') -> 'Any':
+        return ""
+
+    def prim_text_map(self, context: 'Context', item_type: 'DamlType', obj: 'Any') -> 'Any':
+        return [self._recurse(context, '[]', item_type)]
+
+    def prim_numeric(self, context: 'Context', nat: int, obj: 'Any') -> 'Any':
+        pass
+
+    def prim_gen_map(self, context: 'Context', key_type: 'DamlType', value_type: 'DamlType', obj: 'Any') -> 'Any':
+        return {self._recurse(context, '[]', key_type): self._recurse(context, '[]', value_type)}

--- a/python/tests/unit/test_values_canonical.py
+++ b/python/tests/unit/test_values_canonical.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import date
+from dazl.damlast import daml_types as daml
+from dazl.prim import Party
+from dazl.values import Context, CanonicalMapper
+
+
+def test_values_canonical_bool():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Bool, False)
+    assert not actual
+
+
+def test_values_canonical_bool_false_string():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Bool, "false")
+    assert not actual
+
+
+def test_values_canonical_bool_random_string():
+    ctx = Context(CanonicalMapper())
+    try:
+        ctx.convert(daml.Bool, "blahblahblah")
+        assert False, "we were supposed to fail!"
+    except ValueError:
+        pass
+
+
+def test_values_canonical_date():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Date, date(2020, 1, 1))
+    assert date(2020, 1, 1) == actual
+
+
+def test_values_canonical_date_str():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Date, "2020-01-01")
+    assert date(2020, 1, 1) == actual
+
+
+def test_values_canonical_str_that_looks_like_a_date():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Text, "2020-01-01")
+    assert "2020-01-01" == actual
+
+
+def test_values_optional_some_empty_string():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Optional(daml.Text), "")
+    assert "" == actual
+
+
+def test_values_optional_none():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Optional(daml.Text), None)
+    assert None is actual
+
+
+def test_values_party():
+    ctx = Context(CanonicalMapper())
+    actual = ctx.convert(daml.Party, "some-party")
+    assert actual == Party("some-party")

--- a/python/tests/unit/test_values_json_decoder.py
+++ b/python/tests/unit/test_values_json_decoder.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import date, datetime
+
+from dazl.damlast import daml_types as daml
+from dazl.damlast.daml_types import con
+from dazl.damlast.lookup import MultiPackageLookup
+from dazl.damlast.pkgfile import CachedDarFile
+from dazl.values import JsonDecoder, JsonEncoder, Context
+from tests.unit import dars
+
+
+def test_basic_json_text():
+    ctx = Context(JsonDecoder())
+    actual = ctx.convert(daml.Text, "some-text")
+    assert actual == "some-text"
+
+
+def test_json_all_kinds_of():
+    """
+    Serialize a JSON payload of all kinds of fields.
+    """
+    lookup = MultiPackageLookup(CachedDarFile(dars.AllKindsOf).archives())
+    tt = con(lookup.data_type_name('AllKindsOf:OneOfEverything'))
+    ctx = Context(JsonEncoder(), lookup)
+
+    expected = {
+        'operator': 'Operator',
+        'someBoolean': True,
+        'someInteger': 10,
+        'someDecimal': '10',
+        'someMaybe': 10,
+        'someMaybeNot': None,
+        'someText': 'text',
+        'someDate': '2000-01-01',
+        'someDatetime': '2000-01-01T00:00:00Z',
+        'someSimpleList': [1],
+        'someSimplePair': {'left': 4, 'right': 5},
+        'someNestedPair': {'left': {'left': 4, 'right': 5}, 'right': {'left': 10, 'right': 4}},
+        'someUglyNesting': {
+            'tag': 'Both',
+            'value': {'tag': 'Right', 'value': {'left': {'left': 10, 'right': 20}, 'right': {'left': 30, 'right': 40}}}
+        },
+        'someMeasurement': '5',
+        'someEnum': 'Green',
+        'theUnit': {}
+    }
+
+    actual = ctx.convert(tt, {
+        "operator": "Operator",
+        "someBoolean": True,
+        "someInteger": 10,
+        "someDecimal": 10,
+        "someMaybe": 10,
+        "someMaybeNot": None,
+        "someText": "text",
+        "someDate": date(2000, 1, 1),
+        "someDatetime": datetime(2000, 1, 1),
+        "someSimpleList": [1],
+        "someSimplePair": {"left": 4, "right": 5},
+        "someNestedPair": {"left": {"left": 4, "right": 5}, "right": {"left": 10, "right": 4}},
+        "someUglyNesting": {"Both": {"Right": {"left": {"left": 10, "right": 20}, "right": {"left": 30, "right": 40}}}},
+        "someMeasurement": 5,
+        "someEnum": "Green",
+        "theUnit": {}
+    })
+
+    assert expected == actual

--- a/python/tests/unit/test_values_protobuf.py
+++ b/python/tests/unit/test_values_protobuf.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2017-2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import date, datetime, timedelta, timezone
+
+# noinspection PyPackageRequirements
+import pytest
+
+from dazl._gen.com.daml.ledger.api.v1 import value_pb2
+from dazl.damlast import daml_types as daml, CachedDarFile
+from dazl.damlast.lookup import MultiPackageLookup
+from dazl.values import ProtobufEncoder, Context, ProtobufDecoder
+from tests.unit import dars
+
+
+ARBITRARY_DATETIME = datetime(1989, 7, 5, 21, 30, tzinfo=timezone(-timedelta(hours=4)))
+ARBITRARY_DATETIME_TIMESTAMP = 615691800000000
+
+
+@pytest.fixture(scope='package')
+def lookup():
+    return MultiPackageLookup(CachedDarFile(dars.AllKindsOf).archives())
+
+
+@pytest.fixture(scope='package')
+def encode_context(lookup):
+    return Context(ProtobufEncoder(), lookup)
+
+
+@pytest.fixture(scope='package')
+def decode_context(lookup):
+    return Context(ProtobufDecoder(), lookup)
+
+
+def test_values_protobuf_encode_bool_true(encode_context):
+    actual = encode_context.convert(daml.Bool, True)
+    assert actual == ('bool', True)
+
+
+def test_values_protobuf_encode_bool_false(encode_context):
+    actual = encode_context.convert(daml.Bool, False)
+    assert actual == ('bool', False)
+
+
+def test_values_protobuf_encode_enum(encode_context, lookup):
+    color_enum_type = daml.con(lookup.data_type_name('*:AllKindsOf:Color'))
+    actual = encode_context.convert(color_enum_type, "Red")
+    assert actual == ('enum', value_pb2.Enum(constructor='Red'))
+
+
+def test_values_protobuf_encode_enum_invalid(encode_context, lookup):
+    color_enum_type = daml.con(lookup.data_type_name('*:AllKindsOf:Color'))
+    try:
+        encode_context.convert(color_enum_type, "imagination")
+        assert False, 'we were supported to fail!'
+    except ValueError:
+        pass
+
+
+def test_values_protobuf_encode_numeric(encode_context):
+    actual = encode_context.convert(daml.Decimal, '1E+20')
+    assert actual == ('numeric', '100000000000000000000')
+
+
+def test_values_protobuf_encode_numeric_zero(encode_context):
+    actual = encode_context.convert(daml.Numeric(0), '1E+20')
+    assert actual == ('numeric', '100000000000000000000')
+
+
+def test_values_protobuf_encode_date(encode_context):
+    actual = encode_context.convert(daml.Date, '2020-01-01')
+    assert actual == ('date', 18262)
+
+
+def test_values_protobuf_encode_date_far_in_the_past(encode_context):
+    actual = encode_context.convert(daml.Date, '1969-12-31')
+    assert actual == ('date', -1)
+
+
+def test_values_protobuf_encode_datetime(encode_context):
+    actual = encode_context.convert(daml.Time, ARBITRARY_DATETIME)
+    assert actual == ('timestamp', ARBITRARY_DATETIME_TIMESTAMP)
+
+
+def test_values_protobuf_decode_date(decode_context):
+    value = value_pb2.Value()
+    value.date = 18262
+
+    actual = decode_context.convert(daml.Date, value)
+    assert actual == date(2020, 1, 1)
+
+
+def test_values_protobuf_decode_date_far_in_the_past(decode_context):
+    value = value_pb2.Value()
+    value.date = -1
+
+    actual = decode_context.convert(daml.Date, value)
+    assert actual == date(1969, 12, 31)
+
+
+def test_values_protobuf_decode_datetime(decode_context):
+    value = value_pb2.Value()
+    value.timestamp = ARBITRARY_DATETIME_TIMESTAMP
+
+    actual = decode_context.convert(daml.Time, value)
+    assert actual == ARBITRARY_DATETIME


### PR DESCRIPTION
Introduce ValueMapper, a replacement for Serializer on the write side and a replacement for pb_parse_event (which was gRPC only) on the read side.

Unlike `Serializer`, `ValueMapper` uses DAML-LF `dazl.damlast.daml_lf_1.Type` objects instead of `dazl`'s original `dazl.model.types.Type` object, which means extending dazl to handle new types introduced in DAML-LF in the future will be much easier. Additionally the new mappers have no implicit dependency on `PackageStore` fully-resolved types behavior as the mappers are built on `SymbolLookup`, which has well-defined behavior for how it handles a missing package lookup.

This PR was split out of #143 simply because #143 was too large. This PR's focus is on introducing the new implementation into the codebase (along with its tests); #143 will be the actual cutover to using this code.