### PR TITLE
python: Move error definitions out of a consolidated package to avoid circular imports

### DIFF
--- a/python/dazl/cli/__init__.py
+++ b/python/dazl/cli/__init__.py
@@ -9,7 +9,7 @@ import logging
 from typing import List, Sequence
 
 from .._logging import configure as configure_logger
-from ..model.core import ConfigurationError
+from ..client.errors import ConfigurationError
 from ._base import CliCommand
 from .ls import ListAllCommand
 from .metadata import PrintMetadataCommand

--- a/python/dazl/cli/metadata.py
+++ b/python/dazl/cli/metadata.py
@@ -13,8 +13,8 @@ from ..damlast.daml_lf_1 import Archive
 from ..damlast.lookup import MultiPackageLookup
 from ..damlast.pkgfile import DarFile
 from ..damlast.protocols import SymbolLookup
-from ..model.core import ConnectionTimeoutError, UserTerminateRequest
 from ..pretty import PrettyOptions, get_pretty_printer
+from ..protocols.errors import ConnectionTimeoutError, UserTerminateRequest
 from ._base import CliCommand
 
 

--- a/python/dazl/client/_network_client_impl.py
+++ b/python/dazl/client/_network_client_impl.py
@@ -30,7 +30,6 @@ from .. import LOG
 from ..damlast.lookup import MultiPackageLookup
 from ..damlast.pkgfile import get_dar_package_ids
 from ..metrics import MetricEvents
-from ..model.core import DazlPartyMissingError
 from ..model.ledger import LedgerMetadata
 from ..model.network import connection_settings
 from ..model.reading import BaseEvent, InitEvent, ReadyEvent
@@ -47,6 +46,7 @@ from ._base_model import (
 from ._party_client_impl import _PartyClientImpl
 from .bots import Bot, BotCollection
 from .config import AnonymousNetworkConfig, NetworkConfig, URLConfig
+from .errors import DazlPartyMissingError
 
 T = TypeVar("T")
 

--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Collection, List, Mapping, Optional, Sequ
 import warnings
 
 from .. import LOG
-from ..model.core import ConfigurationError
 from ..prim import Party
 from ..util.config_meta import (
     BOOLEAN_TYPE,
@@ -29,6 +28,7 @@ from ..util.config_meta import (
     config_field,
     config_fields,
 )
+from .errors import ConfigurationError
 
 # If this environment variable is set, is used in place of a configuration file if none is supplied
 # on the command-line.

--- a/python/dazl/client/errors.py
+++ b/python/dazl/client/errors.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Collection, Union
+
+from ..prim import DazlError, DazlWarning, Party
+
+__all__ = ["ConfigurationError", "DazlPartyMissingError", "UnknownTemplateWarning"]
+
+
+class ConfigurationError(DazlError):
+    """
+    Raised when a configuration error prevents a client from being started.
+
+    .. attribute:: ConfigurationError.reasons
+
+        A collection of reasons for a failure.
+    """
+
+    def __init__(self, reasons: "Union[str, Collection[str]]"):
+        if reasons is None:
+            self.reasons = []  # type: Collection[str]
+        elif isinstance(reasons, str):
+            self.reasons = [reasons]
+        else:
+            self.reasons = reasons  # type: Collection[str]
+
+
+class DazlPartyMissingError(DazlError):
+    """
+    Error raised when a party or some information about a party is requested, and that party is not
+    found.
+    """
+
+    def __init__(self, party: "Party"):
+        super().__init__(f"party {party!r} does not have a defined client")
+        self.party = party
+
+
+class UnknownTemplateWarning(DazlWarning):
+    """
+    Raised when trying to do something with a template name that is unknown.
+    """

--- a/python/dazl/client/state.py
+++ b/python/dazl/client/state.py
@@ -6,20 +6,20 @@ from collections import defaultdict
 from typing import Awaitable, Collection, Dict, List, Optional, Union, cast
 import warnings
 
-from ..client._reader_match import is_match
 from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.protocols import SymbolLookup
 from ..model.core import (
     ContractContextualData,
     ContractContextualDataCollection,
-    ContractId,
     ContractMatch,
     ContractsState,
-    UnknownTemplateWarning,
 )
 from ..model.reading import ContractArchiveEvent, ContractCreateEvent
+from ..prim import ContractId
 from ..scheduler import Invoker
 from ..util.asyncio_util import await_then
+from ._reader_match import is_match
+from .errors import UnknownTemplateWarning
 
 
 class ActiveContractSet:

--- a/python/dazl/damlast/errors.py
+++ b/python/dazl/damlast/errors.py
@@ -11,7 +11,7 @@ Error types
 
 from typing import TYPE_CHECKING, Any
 
-from ..model.core import DazlError
+from ..prim import DazlError
 
 if TYPE_CHECKING:
     from . import daml_lf_1

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -11,11 +11,23 @@ the Ledger API.
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Collection, Dict, Optional, Tuple, TypeVar, Union
+from typing import BinaryIO, Callable, Dict, Optional, Tuple, TypeVar, Union
+import warnings
 
-from ..prim import ContractData, ContractId, Party
+from ..prim import ContractData, ContractId, DazlError, DazlWarning, Party
 
 T = TypeVar("T")
+
+
+__all__ = [
+    "ContractMatch",
+    "ContractsState",
+    "ContractsHistoricalState",
+    "ContractContextualDataCollection",
+    "ContractContextualData",
+    "DazlError",
+    "DazlWarning",
+]
 
 
 ContractMatch = Union[None, Callable[[ContractData], bool], ContractData]
@@ -56,73 +68,22 @@ class ContractContextualData:
 Dar = Union[bytes, str, Path, BinaryIO]
 
 
-class DazlError(Exception):
-    """
-    Superclass of errors raised by dazl.
-    """
+# TODO: Import dazl.client.errors types here when the circular references between the broader
+#  dazl.client and dazl.model packages are resolved:
+#       * ConfigurationError
+#       * DazlPartyMissingError
+#       * UnknownTemplateWarning
 
 
-class DazlWarning(Warning):
-    """
-    Superclass of warnings raised by dazl.
-    """
+# TODO: Import dazl.protocol.errors types here when the circular references between the broader
+#  dazl.protocol and dazl.model packages are resolved:
+#       * ConnectionTimeoutError
+#       * UserTerminateRequest
 
 
-class DazlPartyMissingError(DazlError):
-    """
-    Error raised when a party or some information about a party is requested, and that party is not
-    found.
-    """
-
-    def __init__(self, party: Party):
-        super().__init__(f"party {party!r} does not have a defined client")
-        self.party = party
-
-
-class DazlImportError(ImportError, DazlError):
-    """
-    Import error raised when an optional dependency could not be found.
-    """
-
-    def __init__(self, missing_module, message):
-        super().__init__(message)
-        self.missing_module = missing_module
-
-
-class UserTerminateRequest(DazlError):
-    """
-    Raised when the user has initiated a request to terminate the application.
-    """
-
-
-class ConnectionTimeoutError(DazlError):
-    """
-    Raised when a connection failed to be established before the connection timeout elapsed.
-    """
-
-
-class CommandTimeoutError(DazlError):
-    """
-    Raised when a corresponding event for a command was not seen in the appropriate time window.
-    """
-
-
-class ConfigurationError(DazlError):
-    """
-    Raised when a configuration error prevents a client from being started.
-
-    .. attribute:: ConfigurationError.reasons
-
-        A collection of reasons for a failure.
-    """
-
-    def __init__(self, reasons: "Union[str, Collection[str]]"):
-        if reasons is None:
-            self.reasons = []  # type: Collection[str]
-        elif isinstance(reasons, str):
-            self.reasons = [reasons]
-        else:
-            self.reasons = reasons  # type: Collection[str]
+# TODO: Import dazl.util.proc_util error types here when the circular references between the broader
+#  dazl.util and dazl.model packages are resolved:
+#       * ProcessDiedException
 
 
 class ConnectionClosedError(DazlError):
@@ -131,12 +92,9 @@ class ConnectionClosedError(DazlError):
     closed.
     """
 
-
-class UnknownTemplateWarning(DazlWarning):
-    """
-    Raised when trying to do something with a template name that is unknown.
-    """
-
-
-class ProcessDiedException(DazlError):
-    pass
+    def __init__(self):
+        warnings.warn(
+            "This error is never raised; this symbol will be removed in dazl v9",
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/python/dazl/prim/__init__.py
+++ b/python/dazl/prim/__init__.py
@@ -22,6 +22,7 @@ from .datetime import (
     to_datetime,
     to_timedelta,
 )
+from .errors import DazlError, DazlWarning
 from .json import JSONEncoder
 from .map import FrozenDict
 from .numbers import decimal_to_str, to_decimal, to_int

--- a/python/dazl/prim/errors.py
+++ b/python/dazl/prim/errors.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+__all__ = ["DazlError", "DazlWarning", "DazlImportError"]
+
+import warnings
+
+
+class DazlError(Exception):
+    """
+    Superclass of errors raised by dazl.
+    """
+
+
+class DazlWarning(Warning):
+    """
+    Superclass of warnings raised by dazl.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "DazlWarning is deprecated; it and UnknownTemplateWarning wil be removed in dazl v9",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+
+class DazlImportError(ImportError, DazlError):
+    """
+    Import error raised when an optional dependency could not be found.
+    """
+
+    def __init__(self, missing_module, message):
+        super().__init__(message)
+        warnings.warn(
+            "DazlImportError will be removed in dazl v9; prefer to catch ImportError instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.missing_module = missing_module

--- a/python/dazl/protocols/autodetect.py
+++ b/python/dazl/protocols/autodetect.py
@@ -6,12 +6,12 @@ from threading import Event, RLock, Thread
 from typing import Awaitable, Dict, Iterable, Optional, Union
 
 from .. import LOG
-from ..model.core import ConnectionTimeoutError, UserTerminateRequest
 from ..model.ledger import LedgerMetadata
 from ..model.network import HTTPConnectionSettings
 from ..prim import Party
 from ..scheduler import Invoker
 from ._base import LedgerClient, LedgerConnectionOptions, LedgerNetwork
+from .errors import ConnectionTimeoutError, UserTerminateRequest
 from .oauth import oauth_flow
 from .v1.grpc import GRPCv1Connection
 

--- a/python/dazl/protocols/errors.py
+++ b/python/dazl/protocols/errors.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from ..prim import DazlError
+
+__all__ = ["ConnectionTimeoutError", "UserTerminateRequest"]
+
+
+class ConnectionTimeoutError(DazlError):
+    """
+    Raised when a connection failed to be established before the connection timeout elapsed.
+    """
+
+
+class UserTerminateRequest(DazlError):
+    """
+    Raised when the user has initiated a request to terminate the application.
+    """

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -13,7 +13,6 @@ from grpc import Channel, RpcError, insecure_channel, secure_channel, ssl_channe
 
 from ... import LOG
 from ...damlast.daml_lf_1 import PackageRef
-from ...model.core import ConnectionTimeoutError, UserTerminateRequest
 from ...model.ledger import LedgerMetadata
 from ...model.network import HTTPConnectionSettings
 from ...model.reading import BaseEvent, ContractFilter, TransactionFilter
@@ -23,6 +22,7 @@ from ...scheduler import Invoker, RunLevel
 from ...util.io import read_file_bytes
 from ...util.typing import safe_cast
 from .._base import LedgerClient, LedgerConnectionOptions, _LedgerConnection
+from ..errors import ConnectionTimeoutError, UserTerminateRequest
 from .pb_parse_event import (
     BaseEventDeserializationContext,
     serialize_acs_request,

--- a/python/dazl/server/management.py
+++ b/python/dazl/server/management.py
@@ -7,11 +7,12 @@ Endpoints for managing parties/bots connected via a dazl client.
 
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Collection, Sequence
+import warnings
 
 from ..client import Bot, _NetworkImpl
 from ..client.bots import SourceLocation
-from ..model.core import DazlImportError
 from ..prim import Party
+from ..prim.errors import DazlImportError
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -41,9 +42,11 @@ def build_routes(network_impl: "_NetworkImpl") -> "Collection[web.AbstractRouteD
     try:
         from aiohttp import web
     except ImportError:
-        raise DazlImportError(
-            "aiohttp", "server routes could not be built because aiohttp is not installed"
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            raise DazlImportError(
+                "aiohttp", "server routes could not be built because aiohttp is not installed"
+            )
 
     routes = web.RouteTableDef()
 

--- a/python/dazl/util/proc_util.py
+++ b/python/dazl/util/proc_util.py
@@ -8,7 +8,7 @@ import sys
 from threading import Event, Thread
 import time
 
-from ..prim.datetime import TimeDeltaLike, to_timedelta
+from ..prim import DazlError, TimeDeltaLike, to_timedelta
 
 
 def kill_process_tree(process: "Popen"):
@@ -47,7 +47,6 @@ def kill_process_tree(process: "Popen"):
 
 
 def wait_for_process_port(process: "Popen", port: int, timeout: "TimeDeltaLike") -> None:
-    from ..model.core import ProcessDiedException
     from .io import is_port_alive
 
     alive = False
@@ -114,3 +113,7 @@ class ProcessLogger:
                 self.logger.info(line.rstrip("\n"))
         except:  # noqa
             pass
+
+
+class ProcessDiedException(DazlError):
+    pass


### PR DESCRIPTION
Move `dazl.model.errors` classes closer to the places where they are actually used.

The central `dazl.model` package triggers circular imports too easily, particularly as I try to move/deprecate symbols in preparation for v8.