### PR TITLE
python: Move dazl.model.core.ContractMatch to dazl.query.

### DIFF
--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -23,12 +23,7 @@ import uuid
 
 from .. import LOG
 from ..damlast.daml_lf_1 import TypeConName
-from ..model.core import (
-    ContractContextualData,
-    ContractContextualDataCollection,
-    ContractMatch,
-    ContractsState,
-)
+from ..model.core import ContractContextualData, ContractContextualDataCollection, ContractsState
 from ..model.network import OAuthSettings, connection_settings
 from ..model.reading import (
     ActiveContractSetEvent,
@@ -47,6 +42,7 @@ from ..model.reading import (
 from ..model.writing import CommandBuilder, CommandDefaults, CommandPayload, EventHandlerResponse
 from ..prim import ContractId, Party, TimeDeltaLike, to_timedelta
 from ..protocols import LedgerClient, LedgerNetwork
+from ..query import ContractMatch
 from ..util.asyncio_util import ServiceQueue, completed, named_gather
 from ..util.prim_natural import n_things
 from ..util.typing import safe_cast

--- a/python/dazl/client/state.py
+++ b/python/dazl/client/state.py
@@ -8,17 +8,12 @@ import warnings
 
 from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.protocols import SymbolLookup
-from ..model.core import (
-    ContractContextualData,
-    ContractContextualDataCollection,
-    ContractMatch,
-    ContractsState,
-)
+from ..model.core import ContractContextualData, ContractContextualDataCollection, ContractsState
 from ..model.reading import ContractArchiveEvent, ContractCreateEvent
 from ..prim import ContractId
+from ..query import ContractMatch, is_match
 from ..scheduler import Invoker
 from ..util.asyncio_util import await_then
-from ._reader_match import is_match
 from .errors import UnknownTemplateWarning
 
 

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -11,10 +11,11 @@ the Ledger API.
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import BinaryIO, Dict, Optional, Tuple, TypeVar, Union
 import warnings
 
 from ..prim import ContractData, ContractId, DazlError, DazlWarning, Party
+from ..query import ContractMatch
 
 T = TypeVar("T")
 
@@ -33,7 +34,6 @@ __all__ = [
 ]
 
 
-ContractMatch = Union[None, Callable[[ContractData], bool], ContractData]
 ContractsState = Dict[ContractId, ContractData]
 ContractsHistoricalState = Dict[ContractId, Tuple[ContractData, bool]]
 

--- a/python/dazl/query/__init__.py
+++ b/python/dazl/query/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+__all__ = ["ContractMatch", "is_match"]
+
+from .query import ContractMatch, is_match

--- a/python/dazl/query/query.py
+++ b/python/dazl/query/query.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-This module contains functions for testing contract data against a match object.
-"""
+from typing import Callable, Union
 
-from ..model.core import ContractMatch
 from ..prim import ContractData
+
+__all__ = ["ContractMatch", "is_match"]
+
+ContractMatch = Union[None, Callable[[ContractData], bool], ContractData]
 
 
 def is_match(predicate: "ContractMatch", cdata: "ContractData") -> bool:

--- a/python/tests/unit/test_matches.py
+++ b/python/tests/unit/test_matches.py
@@ -5,7 +5,7 @@
 This module contains tests for testing contract data against a match object.
 """
 
-from dazl.client._reader_match import is_match
+from dazl.query import is_match
 
 
 def test_match_of_partial_keys():


### PR DESCRIPTION
Continuing to move more code out of `dazl.models`.

This code will actually remain (and possibly be expanded) in v8; query filtering is one area where the HTTP JSON API provides a richer API than the gRPC Ledger API, and in general some primitive client-side filtering has proved useful in the past.