### PR TITLE
python: Move the ACS types in dazl.model.core closer to their actual usage

### DIFF
--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -23,7 +23,6 @@ import uuid
 
 from .. import LOG
 from ..damlast.daml_lf_1 import TypeConName
-from ..model.core import ContractContextualData, ContractContextualDataCollection, ContractsState
 from ..model.network import OAuthSettings, connection_settings
 from ..model.reading import (
     ActiveContractSetEvent,
@@ -50,7 +49,12 @@ from ._writer_verify import ValidateSerializer
 from .bots import Bot, BotCallback, BotCollection, BotFilter
 from .config import NetworkConfig, PartyConfig
 from .ledger import LedgerMetadata
-from .state import ActiveContractSet
+from .state import (
+    ActiveContractSet,
+    ContractContextualData,
+    ContractContextualDataCollection,
+    ContractsState,
+)
 
 if TYPE_CHECKING:
     from ._network_client_impl import _NetworkImpl
@@ -203,20 +207,20 @@ class _PartyClientImpl:
         return self._acs.get(cid)
 
     def find(
-        self, template: Any, match: ContractMatch = None, include_archived: bool = False
-    ) -> ContractContextualDataCollection:
+        self, template: Any, match: "ContractMatch" = None, include_archived: bool = False
+    ) -> "ContractContextualDataCollection":
         return self._acs.read_full(template, match, include_archived=include_archived)
 
-    def find_active(self, template: Any, match: ContractMatch = None) -> ContractsState:
+    def find_active(self, template: Any, match: "ContractMatch" = None) -> "ContractsState":
         return self._acs.read_active(template, match)
 
     def find_historical(
-        self, template: Any, match: ContractMatch = None
-    ) -> ContractContextualDataCollection:
+        self, template: Any, match: "ContractMatch" = None
+    ) -> "ContractContextualDataCollection":
         return self._acs.read_full(template, match, include_archived=True)
 
     def find_nonempty(
-        self, template: Any, match: ContractMatch, min_count: int = 1, timeout: float = 30
+        self, template: Any, match: "ContractMatch", min_count: int = 1, timeout: float = 30
     ):
         return self._acs.read_async(template, match, min_count=min_count)
 

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -42,12 +42,7 @@ from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.pkgfile import Dar
 from ..damlast.protocols import SymbolLookup
 from ..metrics import MetricEvents
-from ..model.core import (
-    ContractContextualData,
-    ContractContextualDataCollection,
-    ContractMatch,
-    ContractsState,
-)
+from ..model.core import ContractMatch
 from ..model.reading import (
     ContractArchiveEvent,
     ContractCreateEvent,
@@ -78,6 +73,7 @@ from .bots import Bot, BotCollection
 from .config import AnonymousNetworkConfig, NetworkConfig, PartyConfig
 from .events import EventKey
 from .ledger import LedgerMetadata
+from .state import ContractContextualData, ContractContextualDataCollection, ContractsState
 
 DEFAULT_TIMEOUT_SECONDS = 30
 
@@ -107,7 +103,9 @@ def simple_client(
     if log_level is not None:
         from .. import setup_default_logger
 
-        setup_default_logger(log_level)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            setup_default_logger(log_level)
 
     import os
 
@@ -964,7 +962,7 @@ class AIOPartyClient(PartyClient):
 
     def find(
         self, template: Any, match: "ContractMatch" = None, include_archived: bool = False
-    ) -> ContractContextualDataCollection:
+    ) -> "ContractContextualDataCollection":
         return self._impl.find(template, match, include_archived=include_archived)
 
     def find_active(self, template: Any, match: "ContractMatch" = None) -> "ContractsState":
@@ -1576,12 +1574,12 @@ class SimplePartyClient(PartyClient):
 
     def find(
         self, template: Any, match: ContractMatch = None, include_archived: bool = False
-    ) -> ContractContextualDataCollection:
+    ) -> "ContractContextualDataCollection":
         return self._impl.invoker.run_in_loop(
             lambda: self._impl.find(template, match, include_archived=include_archived)
         )
 
-    def find_active(self, template: Any, match: ContractMatch = None) -> ContractsState:
+    def find_active(self, template: Any, match: ContractMatch = None) -> "ContractsState":
         """
         Immediately return data from the current active contract set.
 

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -8,10 +8,8 @@ Core types
 The :mod:`dazl.model.core` module contains classes used on both the read-side and the write-side of
 the Ledger API.
 """
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Dict, Optional, Tuple, TypeVar, Union
+from typing import BinaryIO, TypeVar, Union
 import warnings
 
 from ..prim import ContractData, ContractId, DazlError, DazlWarning, Party
@@ -24,47 +22,18 @@ __all__ = [
     "ContractId",
     "ContractData",
     "ContractMatch",
-    "ContractsState",
-    "ContractsHistoricalState",
-    "ContractContextualDataCollection",
-    "ContractContextualData",
     "DazlError",
     "DazlWarning",
     "Party",
 ]
 
 
-ContractsState = Dict[ContractId, ContractData]
-ContractsHistoricalState = Dict[ContractId, Tuple[ContractData, bool]]
-
-
-class ContractContextualDataCollection(tuple):
-    def __getitem__(self, index: Union[int, str, ContractId]):
-        if index is None:
-            raise ValueError("the index cannot be None")
-        elif isinstance(index, int):
-            return tuple.__getitem__(self, index)
-        elif isinstance(index, str):
-            for cxd in self:
-                if cxd.cid.contract_id == index:
-                    return cxd
-            raise KeyError(index)
-        elif isinstance(index, ContractId):
-            for cxd in self:
-                if cxd.cid == index:
-                    return cxd
-            raise KeyError(index)
-        else:
-            raise TypeError("cannot index into a ContractContextualDataCollection with {index!r}")
-
-
-@dataclass(frozen=True)
-class ContractContextualData:
-    cid: "ContractId"
-    cdata: "Optional[ContractData]"
-    effective_at: datetime
-    archived_at: "Optional[datetime]"
-    active: bool
+# TODO: Import dazl.client.state types here when the circular references between the broader
+#  dazl.client and dazl.model packages are resolved:
+#       * ContractsState
+#       * ContractsHistoricalState
+#       * ContractContextualData
+#       * ContractContextualDataCollection
 
 
 # Wherever the API expects a DAR, we can take a file path, `bytes`, or a byte buffer.

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -57,11 +57,14 @@ This module contains models used on the read-side of the Ledger API.
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Collection, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Collection, Optional, Sequence, Union
 
 from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.protocols import SymbolLookup
-from .core import ContractContextualData, ContractData, ContractId, Party
+from ..prim import ContractData, ContractId, Party
+
+if TYPE_CHECKING:
+    from ..client.state import ContractContextualData
 
 __all__ = [
     "BaseEvent",


### PR DESCRIPTION
Continuing to move more code out of `dazl.models`.

These types are actually only used for the ACS, and support for querying the ACS as an in-memory database will not be part of the v8 API.