### PR TITLE
python: Remove a few last usages of the model package.

### DIFF
--- a/python/dazl/__init__.py
+++ b/python/dazl/__init__.py
@@ -6,9 +6,8 @@ This module contains the Python API for interacting with the Ledger API.
 """
 from ._logging import LOG
 from .client import AIOPartyClient, Network, SimplePartyClient, async_network, run, simple_client
-from .model.core import ContractData, ContractId, DazlError, Party
 from .pretty.table import write_acs
-from .prim import FrozenDict as frozendict
+from .prim import ContractData, ContractId, DazlError, FrozenDict as frozendict, Party
 from .protocols.commands import (
     Command,
     CreateAndExerciseCommand,

--- a/python/dazl/client/_run_level.py
+++ b/python/dazl/client/_run_level.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from threading import Event
 
-from ..model.core import RunLevel
+from ..scheduler import RunLevel
 
 
 class RunState:

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -8,8 +8,7 @@ from ..damlast import IdentityTypeVisitor
 from ..damlast.daml_lf_1 import DefDataType, FieldWithType, PrimType, Type
 from ..damlast.lookup import EmptyLookup
 from ..damlast.protocols import SymbolLookup
-from ..model.core import DazlError
-from ..prim import ContractId, to_str, to_variant
+from ..prim import ContractId, DazlError, to_str, to_variant
 from .mapper import ValueMapper
 
 if TYPE_CHECKING:

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -37,14 +37,13 @@ Connect to the ledger as a single party, print all contracts, and close::
 
 Connect to the ledger using asynchronous callbacks::
 
-    from dazl.model.reading import ReadyEvent
     network = dazl.Network()
     network.set_config(url='http://localhost:6865')
 
     alice = network.aio_party('Alice')
 
     @alice.ledger_ready()
-    async def onReady(event: ReadyEvent):
+    async def onReady(event):
       contracts = await event.acs_find_one('Main.Asset')
       print(contracts)
 

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -7,8 +7,7 @@ import logging
 from aiohttp import ClientSession
 import pytest
 
-from dazl import Network, async_network, create, exercise_by_key
-from dazl.model.core import Party
+from dazl import Network, Party, async_network, create, exercise_by_key
 
 from .dars import TestServer as TestServerDar
 


### PR DESCRIPTION
Just a few last rewrites before remaking the `dazl.model` package as deprecated links back to the places where types have actually been moved to.