### PR TITLE
python: Reintroduce the dazl.model package, but with deprecation warnings

### DIFF
--- a/python/dazl/model/__init__.py
+++ b/python/dazl/model/__init__.py
@@ -5,32 +5,25 @@
 :mod:`dazl.model` package
 =========================
 
-The :mod:`dazl.model` module is the low-level domain model for the Ledger. Most of the time, these
-classes will not be instantiated directly, but will frequently be passed to your code to work with.
-
-The most important classes:
-
-:mod:`dazl.model.core`:
-    :class:`~dazl.model.core.ContractId`
-
-:mod:`dazl.model.writing`:
-    Subclasses of :class:`~dazl.model.writing.Command` for the Write API:
-    :class:`~dazl.model.writing.CreateCommand` and
-    :class:`~dazl.model.writing.ExerciseCommand`
-
-:mod:`dazl.model.types`:
-    Type description classes:
-    Subclasses of :class:`~dazl.model.types.Type`:
-    :class:`~dazl.model.types.ScalarType`,
-    :class:`~dazl.model.types.ListType`,
-    :class:`~dazl.model.types.RecordType`,
-    :class:`~dazl.model.types.VariantType`
+This module is deprecated. These types have generally moved to :mod:`dazl.client` (for the API
+introduced in dazl v5) or :mod:`dazl.protocols` (for the API introduced in dazl v8).
 
 .. automodule:: dazl.model.core
 .. automodule:: dazl.model.ledger
+.. automodule:: dazl.model.lookup
+.. automodule:: dazl.model.network
 .. automodule:: dazl.model.reading
 .. automodule:: dazl.model.writing
 
 """
 
-from . import core, ledger
+import warnings
+
+from . import core, ledger, lookup, network, reading, writing
+
+__all__ = ["core", "ledger", "lookup", "network", "reading", "writing"]
+
+warnings.warn(
+    "dazl.model is deprecated; these types have moved to either dazl.protocols or dazl.client.",
+    DeprecationWarning,
+)

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -2,60 +2,62 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Core types
-----------
-
-The :mod:`dazl.model.core` module contains classes used on both the read-side and the write-side of
-the Ledger API.
+This module has been relocated to ``dazl.client``, ``dazl.damlast``, ``dazl.protocols``, or
+``dazl.query``.
 """
-from pathlib import Path
-from typing import BinaryIO, TypeVar, Union
+from typing import TypeVar
 import warnings
 
+from ..client.errors import ConfigurationError, DazlPartyMissingError, UnknownTemplateWarning
+from ..client.state import (
+    ContractContextualData,
+    ContractContextualDataCollection,
+    ContractsHistoricalState,
+    ContractsState,
+)
+from ..damlast.pkgfile import Dar
 from ..prim import ContractData, ContractId, DazlError, DazlWarning, Party
+from ..prim.errors import DazlImportError
+from ..protocols.errors import ConnectionTimeoutError, UserTerminateRequest
 from ..query import ContractMatch
+from ..util.proc_util import ProcessDiedException
 
 T = TypeVar("T")
 
 
 __all__ = [
-    "ContractId",
+    "ConfigurationError",
+    "ConnectionTimeoutError",
+    "ContractContextualData",
+    "ContractContextualDataCollection",
     "ContractData",
+    "ContractId",
     "ContractMatch",
+    "ContractsHistoricalState",
+    "ContractsState",
+    "Dar",
     "DazlError",
+    "DazlImportError",
+    "DazlPartyMissingError",
     "DazlWarning",
     "Party",
+    "ProcessDiedException",
+    "UnknownTemplateWarning",
+    "UserTerminateRequest",
 ]
 
 
-# TODO: Import dazl.client.state types here when the circular references between the broader
-#  dazl.client and dazl.model packages are resolved:
-#       * ContractsState
-#       * ContractsHistoricalState
-#       * ContractContextualData
-#       * ContractContextualDataCollection
+class CommandTimeoutError(DazlError):
+    """
+    Raised when a corresponding event for a command was not seen in the appropriate time window.
+    """
 
-
-# Wherever the API expects a DAR, we can take a file path, `bytes`, or a byte buffer.
-Dar = Union[bytes, str, Path, BinaryIO]
-
-
-# TODO: Import dazl.client.errors types here when the circular references between the broader
-#  dazl.client and dazl.model packages are resolved:
-#       * ConfigurationError
-#       * DazlPartyMissingError
-#       * UnknownTemplateWarning
-
-
-# TODO: Import dazl.protocol.errors types here when the circular references between the broader
-#  dazl.protocol and dazl.model packages are resolved:
-#       * ConnectionTimeoutError
-#       * UserTerminateRequest
-
-
-# TODO: Import dazl.util.proc_util error types here when the circular references between the broader
-#  dazl.util and dazl.model packages are resolved:
-#       * ProcessDiedException
+    def __init__(self):
+        warnings.warn(
+            "This error is never raised; this symbol will be removed in dazl v9",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 class ConnectionClosedError(DazlError):

--- a/python/dazl/model/ledger.py
+++ b/python/dazl/model/ledger.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO: Import dazl.client.ledger types here when the circular references between the broader
-#  dazl.client and dazl.model packages are resolved:
-#    LedgerMetadata
+"""
+This module has been relocated to ``dazl.client.ledger``.
+"""
+from ..client.ledger import LedgerMetadata
+
+__all__ = ["LedgerMetadata"]

--- a/python/dazl/model/lookup.py
+++ b/python/dazl/model/lookup.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module has been relocated to ``dazl.client.events`` or ``dazl.damlast.lookup``.
+"""
+
+__all__ = ["validate_template", "template_reverse_globs"]
+
+from ..client.events import template_reverse_globs
+from ..damlast.lookup import validate_template

--- a/python/dazl/model/network.py
+++ b/python/dazl/model/network.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module has been relocated to ``dazl.client._conn_settings``.
+"""
+
+__all__ = ["HTTPConnectionSettings", "SSLSettings", "OAuthSettings", "connection_settings"]
+
+from ..client._conn_settings import (
+    HTTPConnectionSettings,
+    OAuthSettings,
+    SSLSettings,
+    connection_settings,
+)

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module has been relocated to ``dazl.client.events``, though if possible you should move to
+``dazl.protocol.events``.
+"""
+
+from ..client._reader_sync import max_offset
+from ..client.events import EventKey, create_dispatch
+from ..protocols.events import (
+    ActiveContractSetEvent,
+    BaseEvent,
+    BaseTransactionEvent,
+    ContractArchiveEvent,
+    ContractCreateEvent,
+    ContractEvent,
+    ContractExercisedEvent,
+    ContractFilter,
+    InitEvent,
+    OffsetEvent,
+    PackagesAddedEvent,
+    ReadyEvent,
+    TransactionEndEvent,
+    TransactionFilter,
+    TransactionStartEvent,
+)
+
+__all__ = [
+    "ActiveContractSetEvent",
+    "BaseEvent",
+    "BaseTransactionEvent",
+    "ContractArchiveEvent",
+    "ContractCreateEvent",
+    "ContractEvent",
+    "ContractExercisedEvent",
+    "ContractFilter",
+    "EventKey",
+    "InitEvent",
+    "OffsetEvent",
+    "PackagesAddedEvent",
+    "ReadyEvent",
+    "TransactionEndEvent",
+    "TransactionFilter",
+    "TransactionStartEvent",
+    "create_dispatch",
+    "max_offset",
+]

--- a/python/dazl/model/writing.py
+++ b/python/dazl/model/writing.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module has been relocated to ``dazl.client.commands``, though if possible you should move to
+``dazl.protocol.commands``.
+"""
+
+from ..protocols.commands import (
+    AbstractSerializer,
+    Command,
+    CommandBuilder,
+    CommandDefaults,
+    CommandPayload,
+    CommandsOrCommandSequence,
+    CreateAndExerciseCommand,
+    CreateCommand,
+    EventHandlerResponse,
+    ExerciseByKeyCommand,
+    ExerciseCommand,
+    Serializer,
+    create,
+    create_and_exercise,
+    exercise,
+    exercise_by_key,
+    flatten_command_sequence,
+)
+
+__all__ = [
+    "AbstractSerializer",
+    "Command",
+    "CommandBuilder",
+    "CommandDefaults",
+    "CommandPayload",
+    "CommandsOrCommandSequence",
+    "CreateAndExerciseCommand",
+    "CreateCommand",
+    "EventHandlerResponse",
+    "ExerciseByKeyCommand",
+    "ExerciseCommand",
+    "Serializer",
+    "create",
+    "create_and_exercise",
+    "exercise",
+    "exercise_by_key",
+    "flatten_command_sequence",
+]


### PR DESCRIPTION
This is the final PR of the series that started to chip away at the `dazl.model` package:

* #159: drop `dazl.model.types` altogether (this was deprecated in dazl v7)
* #163: move `dazl.model.ledger` into `dazl.client`
* #166: move `dazl.model.network` into `dazl.client`
* #160, #165, #167: break apart `dazl.model.core` into more appropriate packages
* #168: move `dazl.model.writing` into `dazl.client`
* #169: move `dazl.model.reading` into `dazl.client`
* #170: final removal of any `dazl.model` imports

This PR _reintroduces_ the moved symbols, which is now safe to do as no package in `dazl` depends on `dazl.model` any more. These imports are present to avoid immediately breaking code, but they will emit deprecation warnings on import and be removed in dazl v9.