### PR TITLE
python: Move the nascent v8 api into dazl.ledger

### DIFF
--- a/python/dazl/__init__.py
+++ b/python/dazl/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
     "write_acs",
 ]
 
-
 from ._logging import LOG
 from .client import AIOPartyClient, Network, SimplePartyClient, async_network, run, simple_client
 from .client.commands import (
@@ -50,9 +49,9 @@ from .client.commands import (
     exercise,
     exercise_by_key,
 )
+from .ledger import Command
 from .pretty.table import write_acs
 from .prim import ContractData, ContractId, DazlError, FrozenDict as frozendict, Party
-from .protocols.commands import Command
 from .util.logging import setup_default_logger
 
 try:

--- a/python/dazl/client/_writer_verify.py
+++ b/python/dazl/client/_writer_verify.py
@@ -6,7 +6,7 @@ import warnings
 
 from ..damlast.daml_lf_1 import TypeConName
 from ..prim import ContractId
-from ..protocols.commands import AbstractSerializer
+from ..protocols.serializers import AbstractSerializer
 from ..values import CanonicalMapper
 from .commands import CreateAndExerciseCommand, CreateCommand, ExerciseByKeyCommand, ExerciseCommand
 

--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -29,8 +29,8 @@ from typing import (
 from uuid import uuid4
 
 from .. import LOG
+from ..ledger import Command
 from ..prim import Party
-from ..protocols.commands import Command
 from ..protocols.events import BaseEvent
 from ..util.asyncio_util import LongRunningAwaitable, Signal, completed, failed, propagate
 from .commands import CommandBuilder

--- a/python/dazl/client/commands.py
+++ b/python/dazl/client/commands.py
@@ -12,8 +12,8 @@ import uuid
 import warnings
 
 from ..damlast.daml_lf_1 import TypeConName
+from ..ledger import api_types
 from ..prim import ContractData, ContractId, Party
-from ..protocols import commands as pcmd
 
 __all__ = [
     "CommandBuilder",
@@ -33,7 +33,7 @@ __all__ = [
 ]
 
 
-class CreateCommand(pcmd.CreateCommand):
+class CreateCommand(api_types.CreateCommand):
     """
     A command that creates a contract without any predecessors.
     """
@@ -43,9 +43,9 @@ class CreateCommand(pcmd.CreateCommand):
     ):
         warnings.warn(
             "dazl.client.commands.CreateCommand is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.create or "
+            "prefer calling dazl.ledger.Connection.create or "
             "dazl.client.PartyClient.submit_create, "
-            "or use dazl.protocols.commands.CreateCommand instead.",
+            "or use dazl.ledger.CreateCommand instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -76,7 +76,7 @@ class CreateCommand(pcmd.CreateCommand):
         return self.payload
 
 
-class CreateAndExerciseCommand(pcmd.CreateAndExerciseCommand):
+class CreateAndExerciseCommand(api_types.CreateAndExerciseCommand):
     """
     A command that exercises a choice on a newly-created contract, in a single transaction.
     """
@@ -90,9 +90,9 @@ class CreateAndExerciseCommand(pcmd.CreateAndExerciseCommand):
     ):
         warnings.warn(
             "dazl.client.commands.CreateAndExerciseCommand is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.create_and_exercise or "
+            "prefer calling dazl.ledger.Connection.create_and_exercise or "
             "dazl.client.PartyClient.submit_create_and_exercise, "
-            "or use dazl.protocols.commands.CreateAndExerciseCommand instead.",
+            "or use dazl.ledger.CreateAndExerciseCommand instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -138,7 +138,7 @@ class CreateAndExerciseCommand(pcmd.CreateAndExerciseCommand):
         return self.argument
 
 
-class ExerciseCommand(pcmd.ExerciseCommand):
+class ExerciseCommand(api_types.ExerciseCommand):
     """
     A command that exercises a choice on a contract identified by its contract ID.
     """
@@ -146,9 +146,9 @@ class ExerciseCommand(pcmd.ExerciseCommand):
     def __init__(self, contract: "ContractId", choice: str, arguments: "Optional[Any]" = None):
         warnings.warn(
             "dazl.client.commands.ExerciseCommand is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.exercise or "
+            "prefer calling dazl.ledger.Connection.exercise or "
             "dazl.client.PartyClient.submit_exercise, "
-            "or use dazl.protocols.commands.ExerciseCommand instead.",
+            "or use dazl.ledger.ExerciseCommand instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -178,7 +178,7 @@ class ExerciseCommand(pcmd.ExerciseCommand):
         return self.argument
 
 
-class ExerciseByKeyCommand(pcmd.ExerciseByKeyCommand):
+class ExerciseByKeyCommand(api_types.ExerciseByKeyCommand):
     def __init__(
         self,
         template: "Union[str, TypeConName]",
@@ -188,9 +188,9 @@ class ExerciseByKeyCommand(pcmd.ExerciseByKeyCommand):
     ):
         warnings.warn(
             "dazl.client.commands.ExerciseByKeyCommand is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.exercise_by_key or "
+            "prefer calling dazl.ledger.Connection.exercise_by_key or "
             "dazl.client.PartyClient.submit_exercise_by_key, "
-            "or use dazl.protocols.commands.ExerciseByKeyCommand instead.",
+            "or use dazl.ledger.ExerciseByKeyCommand instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -237,7 +237,7 @@ class ExerciseByKeyCommand(pcmd.ExerciseByKeyCommand):
         return self.argument
 
 
-CommandsOrCommandSequence = Union[None, pcmd.Command, Sequence[Optional[pcmd.Command]]]
+CommandsOrCommandSequence = Union[None, api_types.Command, Sequence[Optional[api_types.Command]]]
 
 
 # noinspection PyDeprecation
@@ -258,7 +258,7 @@ class CommandBuilder:
         """
         warnings.warn(
             "CommandBuilder is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.commands, "
+            "prefer calling dazl.ledger.Connection.commands, "
             "dazl.client.PartyClient.submit, or construct commands explicitly instead.",
             DeprecationWarning,
             stacklevel=2,
@@ -276,13 +276,13 @@ class CommandBuilder:
     def __init__(self, atomic_default: bool = False):
         warnings.warn(
             "CommandBuilder is deprecated; "
-            "prefer calling dazl.protocols.ledgerapi.Connection.commands, "
+            "prefer calling dazl.ledger.Connection.commands, "
             "dazl.client.PartyClient.submit, or construct commands explicitly instead.",
             DeprecationWarning,
             stacklevel=2,
         )
         self._atomic_default = atomic_default
-        self._commands = [[]]  # type: List[List[pcmd.Command]]
+        self._commands = [[]]  # type: List[List[api_types.Command]]
         self._defaults = CommandDefaults()
 
     def defaults(
@@ -345,13 +345,13 @@ class CommandBuilder:
             return self.append_nonatomically(*commands)
 
     def append_atomically(
-        self, *commands: "Union[pcmd.Command, Sequence[pcmd.Command]]"
+        self, *commands: "Union[api_types.Command, Sequence[api_types.Command]]"
     ) -> "CommandBuilder":
         self._commands.extend([flatten_command_sequence(commands)])
         return self
 
     def append_nonatomically(
-        self, *commands: "Union[pcmd.Command, Sequence[pcmd.Command]]"
+        self, *commands: "Union[api_types.Command, Sequence[api_types.Command]]"
     ) -> "CommandBuilder":
         self._commands.extend([[cmd] for cmd in flatten_command_sequence(commands)])
         return self
@@ -395,17 +395,17 @@ class CommandBuilder:
 
 def flatten_command_sequence(
     commands: "Sequence[CommandsOrCommandSequence]",
-) -> "List[pcmd.Command]":
+) -> "List[api_types.Command]":
     """
     Convert a list of mixed commands, ``None``, and list of commands into an ordered sequence of
     non-``None`` commands.
     """
-    ret = []  # type: List[pcmd.Command]
+    ret = []  # type: List[api_types.Command]
     errors = []
 
     for i, obj in enumerate(commands):
         if obj is not None:
-            if isinstance(obj, pcmd.Command):
+            if isinstance(obj, api_types.Command):
                 ret.append(obj)
             else:
                 try:
@@ -414,7 +414,7 @@ def flatten_command_sequence(
                     errors.append(((i,), obj))
                     continue
                 for j, cmd in enumerate(cmd_iter):
-                    if isinstance(cmd, pcmd.Command):
+                    if isinstance(cmd, api_types.Command):
                         ret.append(cmd)
                     else:
                         errors.append(((i, j), cmd))
@@ -468,7 +468,7 @@ class CommandPayload:
     workflow_id: str
     application_id: str
     command_id: str
-    commands: "Sequence[pcmd.Command]"
+    commands: "Sequence[api_types.Command]"
     deduplication_time: "Optional[timedelta]" = None
 
     def __post_init__(self):
@@ -487,9 +487,9 @@ class CommandPayload:
 def create(template, arguments=None):
     warnings.warn(
         "dazl.client.commands.create is deprecated; "
-        "prefer calling dazl.protocols.ledgerapi.Connection.create or "
+        "prefer calling dazl.ledger.Connection.create or "
         "dazl.client.PartyClient.submit_create, "
-        "or use dazl.protocols.commands.CreateCommand instead.",
+        "or use dazl.ledger.CreateCommand instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -507,9 +507,9 @@ def create(template, arguments=None):
 def create_and_exercise(template, create_arguments, choice_name, choice_argument):
     warnings.warn(
         "dazl.client.commands.CreateAndExerciseCommand is deprecated; "
-        "prefer calling dazl.protocols.ledgerapi.Connection.create_and_exercise or "
+        "prefer calling dazl.ledger.Connection.create_and_exercise or "
         "dazl.client.PartyClient.submit_create_and_exercise, "
-        "or use dazl.protocols.commands.CreateAndExerciseCommand instead.",
+        "or use dazl.ledger.CreateAndExerciseCommand instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -523,9 +523,9 @@ def create_and_exercise(template, create_arguments, choice_name, choice_argument
 def exercise(contract, choice, arguments=None):
     warnings.warn(
         "dazl.client.commands.exercise is deprecated; "
-        "prefer calling dazl.protocols.ledgerapi.Connection.exercise or "
+        "prefer calling dazl.ledger.Connection.exercise or "
         "dazl.client.PartyClient.submit_exercise, "
-        "or use dazl.protocols.commands.ExerciseCommand instead.",
+        "or use dazl.ledger.ExerciseCommand instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -544,9 +544,9 @@ def exercise(contract, choice, arguments=None):
 def exercise_by_key(template, contract_key, choice_name, choice_argument):
     warnings.warn(
         "dazl.client.commands.ExerciseByKeyCommand is deprecated; "
-        "prefer calling dazl.protocols.ledgerapi.Connection.exercise_by_key or "
+        "prefer calling dazl.ledger.Connection.exercise_by_key or "
         "dazl.client.PartyClient.submit_exercise_by_key, "
-        "or use dazl.protocols.commands.ExerciseByKeyCommand instead.",
+        "or use dazl.ledger.ExerciseByKeyCommand instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/python/dazl/client/ledger.py
+++ b/python/dazl/client/ledger.py
@@ -6,8 +6,9 @@ Types that describe the behavior of the ledger itself.
 """
 from dataclasses import dataclass
 
-from ..protocols.commands import Serializer
-from ..protocols.pkgloader_aio import PackageLoader
+from dazl.ledger.pkgloader_aio import PackageLoader
+
+from ..protocols.serializers import Serializer
 
 
 @dataclass(init=False, frozen=True)

--- a/python/dazl/client/pkg_loader.py
+++ b/python/dazl/client/pkg_loader.py
@@ -3,7 +3,7 @@
 
 import warnings
 
-from ..protocols.pkgloader_aio_compat import PackageLoader, SyncPackageService
+from dazl.ledger.pkgloader_aio_compat import PackageLoader, SyncPackageService
 
 warnings.warn("dazl.client.pkg_loader is deprecated; use dazl.protocols.pkgloader_aio instead.")
 

--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .api_types import (
+    ArchiveEvent,
+    Command,
+    CreateAndExerciseCommand,
+    CreateCommand,
+    CreateEvent,
+    ExerciseByKeyCommand,
+    ExerciseCommand,
+)
+
+__all__ = [
+    "Command",
+    "CreateCommand",
+    "CreateAndExerciseCommand",
+    "CreateEvent",
+    "ArchiveEvent",
+    "ExerciseCommand",
+    "ExerciseByKeyCommand",
+]

--- a/python/dazl/ledger/pkgloader_aio.py
+++ b/python/dazl/ledger/pkgloader_aio.py
@@ -4,8 +4,7 @@
 from asyncio import ensure_future, gather, get_event_loop, sleep, wait_for
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
-import sys
-from typing import AbstractSet, Awaitable, Callable, Dict, Optional, Set, TypeVar
+from typing import AbstractSet, Awaitable, Callable, Dict, Optional, Protocol, Set, TypeVar
 
 from .. import LOG
 from ..damlast.daml_lf_1 import Archive, Package, PackageRef
@@ -13,11 +12,6 @@ from ..damlast.errors import NameNotFoundError, PackageNotFoundError
 from ..damlast.lookup import MultiPackageLookup, validate_template
 from ..damlast.pkgfile import Dar
 from ..prim import DazlError
-
-if sys.version_info >= (3, 7):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 __all__ = ["PackageService", "PackageLoader"]
 

--- a/python/dazl/ledger/pkgloader_aio_compat.py
+++ b/python/dazl/ledger/pkgloader_aio_compat.py
@@ -13,8 +13,9 @@ import sys
 from typing import AbstractSet
 import warnings
 
-from ..damlast.daml_lf_1 import PackageRef
-from ..damlast.lookup import MultiPackageLookup
+from dazl.damlast.daml_lf_1 import PackageRef
+from dazl.damlast.lookup import MultiPackageLookup
+
 from .pkgloader_aio import DEFAULT_TIMEOUT, PackageLoader as NewPackageLoader
 
 if sys.version_info >= (3, 7):

--- a/python/dazl/model/writing.py
+++ b/python/dazl/model/writing.py
@@ -3,7 +3,7 @@
 
 """
 This module has been relocated to ``dazl.client.commands``, though if possible you should move to
-``dazl.protocol.commands``.
+the command types defined in ``dazl.ledger`` instead.
 """
 
 from ..client.commands import (
@@ -18,15 +18,14 @@ from ..client.commands import (
     exercise_by_key,
     flatten_command_sequence,
 )
-from ..protocols.commands import (
-    AbstractSerializer,
+from ..ledger import (
     Command,
     CreateAndExerciseCommand,
     CreateCommand,
     ExerciseByKeyCommand,
     ExerciseCommand,
-    Serializer,
 )
+from ..protocols.serializers import AbstractSerializer, Serializer
 
 __all__ = [
     "AbstractSerializer",

--- a/python/dazl/protocols/serializers.py
+++ b/python/dazl/protocols/serializers.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This module will likely be deprecated in v8.
+
+from typing import Any, Sequence
+
+from ..damlast.daml_lf_1 import Type, TypeConName
+from ..damlast.daml_types import con
+from ..damlast.lookup import find_choice
+from ..damlast.protocols import SymbolLookup
+from ..ledger import (
+    Command,
+    CreateAndExerciseCommand,
+    CreateCommand,
+    ExerciseByKeyCommand,
+    ExerciseCommand,
+)
+from ..prim import ContractId
+from ..values import ValueMapper
+
+__all__ = [
+    "Serializer",
+    "AbstractSerializer",
+]
+
+
+class Serializer:
+    """
+    Serializer interface for objects on the write-side of the API.
+    """
+
+    def serialize_value(self, tt: "Type", obj: "Any") -> "Any":
+        raise NotImplementedError("serialize_value requires an implementation")
+
+    def serialize_command(self, command: "Any") -> "Any":
+        raise NotImplementedError("serialize_command requires an implementation")
+
+
+class AbstractSerializer(Serializer):
+    """
+    Implementation of :class:`Serializer` that helps enforce that all possible cases of type
+    serialization have been implemented.
+    """
+
+    def __init__(self, lookup: "SymbolLookup"):
+        self.lookup = lookup
+
+    @property
+    def mapper(self) -> "ValueMapper":
+        raise NotImplementedError(f"{type(self)}.mapper() must be defined")
+
+    def serialize_value(self, tt: "Type", obj: Any) -> "Any":
+        from ..values import Context
+
+        return Context(self.mapper, self.lookup).convert(tt, obj)
+
+    def serialize_commands(self, commands: "Sequence[Command]") -> "Sequence[Any]":
+        return [self.serialize_command(cmd) for cmd in commands]
+
+    def serialize_command(self, command: "Command") -> "Any":
+        if isinstance(command, CreateCommand):
+            name = self.lookup.template_name(command.template_id)
+            value = self.serialize_value(con(name), command.payload)
+            return self.serialize_create_command(name, value)
+
+        elif isinstance(command, ExerciseCommand):
+            template = self.lookup.template(command.contract_id.value_type)
+            choice = find_choice(template, command.choice)
+            args = self.serialize_value(choice.arg_binder.type, command.argument)
+            return self.serialize_exercise_command(command.contract_id, choice.name, args)
+
+        elif isinstance(command, CreateAndExerciseCommand):
+            name = self.lookup.template_name(command.template_id)
+            template = self.lookup.template(name)
+            create_value = self.serialize_value(con(name), command.payload)
+            choice = find_choice(template, command.choice)
+            choice_args = self.serialize_value(choice.arg_binder.type, command.argument)
+            return self.serialize_create_and_exercise_command(
+                name, create_value, choice.name, choice_args
+            )
+
+        elif isinstance(command, ExerciseByKeyCommand):
+            name = self.lookup.template_name(command.template_id)
+            template = self.lookup.template(name)
+            key_value = self.serialize_value(template.key.type, command.key)
+            choice = find_choice(template, command.choice)
+            choice_args = self.serialize_value(choice.arg_binder.type, command.argument)
+            return self.serialize_exercise_by_key_command(name, key_value, choice.name, choice_args)
+
+        else:
+            raise ValueError(f"unknown Command type: {command!r}")
+
+    def serialize_create_command(self, name: "TypeConName", template_args: "Any") -> "Any":
+        raise NotImplementedError("serialize_create_command requires an implementation")
+
+    def serialize_exercise_command(
+        self, contract_id: "ContractId", choice_name: str, choice_args: "Any"
+    ) -> "Any":
+        raise NotImplementedError("serialize_exercise_command requires an implementation")
+
+    def serialize_exercise_by_key_command(
+        self, name: "TypeConName", key_arguments: "Any", choice_name: str, choice_arguments: "Any"
+    ) -> "Any":
+        raise NotImplementedError("serialize_exercise_by_key_command requires an implementation")
+
+    def serialize_create_and_exercise_command(
+        self, name: "TypeConName", create_args: "Any", choice_name: str, choice_arguments: "Any"
+    ) -> "Any":
+        raise NotImplementedError(
+            "serialize_create_and_exercise_command requires an implementation"
+        )

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -209,8 +209,9 @@ def grpc_detect_ledger_id(connection: "GRPCv1Connection") -> str:
 
 
 def grpc_main_thread(connection: "GRPCv1Connection", ledger_id: str) -> "Iterable[LedgerMetadata]":
+    from dazl.ledger.pkgloader_aio_compat import PackageLoader
+
     from ...client.ledger import LedgerMetadata
-    from ..pkgloader_aio_compat import PackageLoader
     from .pb_ser_command import ProtobufSerializer
 
     LOG.info("grpc_main_thread...")

--- a/python/dazl/protocols/v1/pb_ser_command.py
+++ b/python/dazl/protocols/v1/pb_ser_command.py
@@ -11,7 +11,7 @@ from . import model as G
 from ...damlast.daml_lf_1 import TypeConName
 from ...prim import ContractId, timedelta_to_duration
 from ...values.protobuf import ProtobufEncoder, set_value
-from ..commands import AbstractSerializer
+from ..serializers import AbstractSerializer
 
 if TYPE_CHECKING:
     from ...client.commands import CommandPayload

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -6,8 +6,8 @@ from unittest import TestCase
 
 from dazl.client.commands import CommandBuilder, CommandDefaults, CommandPayload, create
 from dazl.damlast.lookup import parse_type_con_name
+from dazl.ledger import CreateCommand, ExerciseCommand
 from dazl.prim import ContractId, Party
-from dazl.protocols.commands import CreateCommand, ExerciseCommand
 
 SOME_TEMPLATE_NAME = parse_type_con_name("Sample:Untyped")
 SOME_PARTY = Party("SomeParty")

--- a/python/tests/unit/test_pkg_loader.py
+++ b/python/tests/unit/test_pkg_loader.py
@@ -9,7 +9,7 @@ import pytest
 from dazl.damlast import DarFile
 from dazl.damlast.daml_lf_1 import PackageRef
 from dazl.damlast.lookup import MultiPackageLookup
-from dazl.protocols.pkgloader_aio import PackageLoader
+from dazl.ledger.pkgloader_aio import PackageLoader
 
 from .dars import AllKindsOf
 

--- a/python/tests/unit/test_pkg_loader_do_with_retry.py
+++ b/python/tests/unit/test_pkg_loader_do_with_retry.py
@@ -9,7 +9,7 @@ from dazl.damlast.daml_lf_1 import PackageRef, TypeConName
 from dazl.damlast.errors import NameNotFoundError
 from dazl.damlast.lookup import MultiPackageLookup
 from dazl.damlast.util import package_ref
-from dazl.protocols.pkgloader_aio import PackageLoader
+from dazl.ledger.pkgloader_aio import PackageLoader
 
 from .dars import AllKindsOf
 


### PR DESCRIPTION
This originally was just going to be about adding read-side objects, but in looking more closely at some names (and also the Daml TypeScript library) it became clear that we could do better here.

So this PR:
* Moves the nascent v8 api into `dazl.ledger` and out of `dazl.protocols`.
  * The v5 API was split between `dazl.protocols` and `dazl.client`, but the v8 API is thin enough that it doesn't need two layers.
  * The v8 API won't actually share any common code with `dazl.protocols`; earlier iterations used more of `dazl.protocols`' existing code, but incorporating the gRPC asyncio changes turned out to be more invasive, requiring parallel implementations.
* Add new definitions for `CreateEvent` and `ArchiveEvent`. They will be _purely_ data classes; I'm not sure it will be possible to maintain a compatibility layer between the old events and the new ones, nor am I even convinced that such a compatibility layer would add much value (as the v5 and v8 APIs would still continue to emit only their respective events).
* Move `Serializer`/`AbstractSerializer` out of the file where `Command` classes are defined; they will probably be deprecated soon.