### PR TITLE
python: Drop low-level set_time support.

### DIFF
--- a/python/dazl/protocols/autodetect.py
+++ b/python/dazl/protocols/autodetect.py
@@ -79,19 +79,6 @@ class AutodetectLedgerNetwork(LedgerNetwork):
             lambda: grpc_upload_package(self._first_connection, dar_contents)
         )
 
-    async def set_time(self, new_time: datetime):
-        ledger = await self.ledger()
-        if ledger.protocol_version == "v1":
-            from .v1.grpc import grpc_set_time
-
-            return await self._invoker.run_in_executor(
-                lambda: grpc_set_time(self._first_connection, ledger.ledger_id, new_time)
-            )
-        elif ledger.protocol_version == "v0":
-            raise RuntimeError(f"Unsupported protocol version: {ledger.protocol_version}")
-        else:
-            raise RuntimeError(f"Unknown protocol version: {ledger.protocol_version}")
-
     async def close(self) -> None:
         with self._lock:
             connections = list(self._connections.values())

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -133,22 +133,6 @@ class GRPCv1LedgerClient(LedgerClient):
         )
 
 
-def grpc_set_time(connection: "GRPCv1Connection", ledger_id: str, new_datetime: datetime) -> None:
-    from . import model as G
-
-    request = G.GetTimeRequest(ledger_id=ledger_id)
-    response = connection.time_service.GetTime(request)
-    ts = next(iter(response))
-
-    request = G.SetTimeRequest(
-        ledger_id=ledger_id,
-        current_time=ts.current_time,
-        new_time=datetime_to_timestamp(new_datetime),
-    )
-    connection.time_service.SetTime(request)
-    LOG.info("Time on the server changed by the local client to %s.", new_datetime)
-
-
 def grpc_upload_package(connection: "GRPCv1Connection", dar_contents: bytes) -> None:
     from . import model as G
 


### PR DESCRIPTION
Somewhere along the line, `dazl` lost support for getting and setting static time, which isn't really that big of a deal considering that the old time model hasn't really been used since Daml 1.0.

These functions are also not exposed through `Network` or `PartyClient` in any way, so it's highly unlikely anyone was using these. There isn't a way to _get_ the current time either, so even more so does this code likely have limited utility.