### PR TITLE
python: Add the new v8 config objects, with docs.

### DIFF
--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
 """
 :mod:`dazl.ledger` — gRPC Ledger API / HTTP JSON API client
 ===========================================================
+.. autofunction:: connect
 
 This module contains the types needed to submit commands to and read events from a
 Daml `gRPC Ledger API <https://docs.daml.com/app-dev/ledger-api.html>`_ or
@@ -100,7 +100,11 @@ Other
     :members:
 
 """
+from logging import Logger
+from os import PathLike
+from typing import Collection, Optional, Union
 
+from ..prim import Party, TimeDeltaLike
 from .api_types import (
     ArchiveEvent,
     Boundary,
@@ -126,3 +130,209 @@ __all__ = [
     "ExerciseResponse",
     "PartyInfo",
 ]
+
+
+def connect(
+    url: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    scheme: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    application_name: Optional[str] = None,
+    oauth_token: Optional[str] = None,
+    oauth_token_file: Optional[str] = None,
+    ca: Optional[bytes] = None,
+    ca_file: Optional[PathLike] = None,
+    cert: Optional[bytes] = None,
+    cert_file: Optional[PathLike] = None,
+    cert_key: Optional[bytes] = None,
+    cert_key_file: Optional[PathLike] = None,
+    connect_timeout: Optional[TimeDeltaLike] = None,
+    use_http_proxy: bool = True,
+    logger: Optional[Logger] = None,
+    logger_name: Optional[str] = None,
+    log_level: Optional[str] = None,
+):
+    """
+    Create a connection from the supplied parameters.
+
+    The remote can be configured either by supplying a URL or by supplying a host (and optional
+    port and scheme). If none of ``url``, ``host``, ``port``, or ``scheme`` are supplied, then
+    environment variables are consulted; if no environment variables are specified either, then
+    default values are used.
+
+    The remote can be configured either by supplying a URL or by supplying a host (and optional
+    port and scheme). If none of ``url``, ``host``, ``port``, or ``scheme`` are supplied, then
+    environment variables are consulted; if no environment variables are specified either, then
+    default values are used.
+
+    When the URL scheme is ``http`` or ``https``, dazl will first attempt to connect assuming
+    the HTTP JSON API; if this fails, gRPC Ledger API is attempted.
+
+    If ``oauth_token`` is supplied and non-empty, then *token-based access* is used to connect
+    to the ledger. (Note that you cannot specify both ``oauth_token`` and ``oauth_token_file``.)
+
+    If other fields are specified, then *property-based access* is used. At least one of
+    ``read_as``, ``act_as``, or ``admin`` must be supplied. For the HTTP JSON API,
+    ``ledger_id`` MUST be supplied.
+
+    If _no_ fields are specified, this is an error unless environment variables supply an
+    alternate source of configuration.
+
+    +----------------------+----------------------+------------------------------------------------+
+    | function argument    | environment variable | default value                                  |
+    +======================+======================+================================================+
+    | **Connection config**                                                                        |
+    |                                                                                              |
+    | Specifying *any* of ``url``, ``host``, ``port``, or ``scheme`` causes *all* of these         |
+    | environment variables to be ignored                                                          |
+    +----------------------+----------------------+------------------------------------------------+
+    | ``url``              | DAML_LEDGER_URL      | localhost:6865                                 |
+    +----------------------+----------------------+------------------------------------------------+
+    | ``host``             | DAML_LEDGER_HOST     | localhost                                      |
+    +----------------------+----------------------+------------------------------------------------+
+    | ``port``             | DAML_LEDGER_PORT     | | 6865, unless ``scheme`` is specified:        |
+    |                      |                      | | • 80 for ``http``                            |
+    |                      |                      | | • 443 for ``https``                          |
+    |                      |                      | | • 6865 for ``grpc``                          |
+    +----------------------+----------------------+------------------------------------------------+
+    | ``scheme``           | DAML_LEDGER_SCHEME   | | ``https`` for port 443 or 8443               |
+    |                      |                      | | ``http`` for port 80, 7575 or 8080           |
+    |                      |                      | | ``grpc`` for port 6865                       |
+    |                      |                      | | ``https`` for all other ports                |
+    +----------------------+----------------------+------------------------------------------------+
+    | **Access config**                                                                            |
+    |                                                                                              |
+    | Specifying *any* of ``act_as``, ``read_as``, ``admin``, ``ledger_id``, ``application_name``, |
+    | ``oauth_token``, or ``oauth_token_file`` causes *all* of these environment variables to be   |
+    | ignored                                                                                      |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``act_as``           | ``DAML_LEDGER_ACT_AS``                                                |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``read_as``          | ``DAML_LEDGER_READ_AS``                                               |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``ledger_id``        | ``DAML_LEDGER_ID``                                                    |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``application_name`` | ``DAML_LEDGER_APPLICATION_NAME``                                      |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``oauth_token``      | ``DAML_LEDGER_OAUTH_TOKEN``                                           |
+    +----------------------+-----------------------------------------------------------------------+
+    | ``oauth_token_file`` | ``DAML_LEDGER_OAUTH_TOKEN_FILE``                                      |
+    +----------------------+-----------------------------------------------------------------------+
+
+    .. note::
+
+        When connecting to the gRPC Ledger API, note that
+        `gRPC environment variables
+        <https://grpc.github.io/grpc/cpp/md_doc_environment_variables.html>`_ are also respected.
+        You can configure the gRPC client in much more detail with these flags.
+
+    :param url:
+        The URL to connect to. Can be used as an alternative to supplying ``host``, ``port``,
+        and ``scheme`` as individual values. Can alternatively be supplied via the environment
+        variable ``DAML_LEDGER_URL``.
+    :param host:
+        The host to connect to. Can be used as an alternative to supplying ``url`` as a combined
+        value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_HOST``.
+    :param port:
+        The port to connect to. Can be used as an alternative to supplying ``url`` as a combined
+        value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_PORT``.
+    :param scheme:
+        The scheme to connect to. Can be used as an alternative to supplying ``url`` as a
+        combined value. Can alternatively be supplied via the environment variable
+        ``DAML_LEDGER_SCHEME``.
+    :param connect_timeout:
+        Length of time to wait before giving up connecting to the remote and declaring an error.
+        The default value is 30 seconds.
+    :param use_http_proxy:
+        ``True`` to use an HTTP(S) proxy server if configured; ``False`` to avoid using any
+        configured server. If unspecified and the host is ``localhost``, the proxy server is
+        avoided; otherwise the proxy server is used.
+    :param ca:
+        A certificate authority to use to validate the server's certificate. If not supplied,
+        the operating system's default trust store is used. Cannot be specified with
+        ``ca_file``.
+    :param ca_file:
+        A file containing the certificate authority to use to validate the server's certificate.
+        If not supplied, the operating system's default trust store is used. Cannot be specified
+        with ``ca``.
+    :param cert:
+        A client-side certificate to be used when connecting to a server that requires mutual
+        TLS. Cannot be specified with ``cert_file``.
+    :param cert_file:
+        A file containing the client-side certificate to be used when connecting to a server
+        that requires mutual TLS. Cannot be specified with ``cert``.
+    :param cert_key:
+        A client-side private key to be used when connecting to a server that requires mutual
+        TLS. Cannot be specified with ``cert_key_file``.
+    :param cert_key_file:
+        A client-side private key to be used when connecting to a server that requires mutual
+        TLS. Cannot be specified with ``cert_key``.
+    :param read_as:
+        A party or set of parties on whose behalf (in addition to all parties listed in
+        ``act_as``) contracts can be retrieved. Cannot be specified if ``oauth_token`` or
+        ``oauth_token_file`` is specified.
+    :param act_as:
+        A party or set of parties on whose behalf commands should be executed. Parties here are
+        also implicitly granted ``read_as`` access as well. Cannot be specified if
+        ``oauth_token`` or ``oauth_token_file`` is specified.
+    :param admin:
+        HTTP JSON API only: allow admin endpoints to be used. This flag is ignored when
+        connecting to gRPC Ledger API implementations. Cannot be specified if ``oauth_token`` or
+        ``oauth_token_file`` is specified.
+    :param ledger_id:
+        The ledger ID to connect to. For the HTTP JSON API, this value is required. For the gRPC
+        Ledger API, if this value is _not_ supplied, its value will be retrieved from the
+        server. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+    :param application_name:
+        A string that identifies this application. This is used for tracing purposes on the
+        server-side. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is
+        specified.
+    :param oauth_token:
+        The OAuth bearer token to be used on all requests. If specified, no other access
+        parameters can be specified.
+    :param oauth_token_file:
+        A file that contains the OAuth bearer token to be used on all requests. If specified, no
+        other access parameters can be specified.
+    :param logger:
+        The logger to use for connections created from this configuration. If not supplied, a
+        logger will be created.
+    :param logger_name:
+        The name of the logger. Only used if ``logger`` is not provided.
+    :param log_level:
+        The logging level for the logger. The default is ``warn``. Only used if ``logger`` is
+        not provided.
+    """
+    # TODO: Ideally we could _define_ the function as taking all of these parameters, but implement
+    #  it with kwargs passing; unfortunately Sphinx doesn't seem to allow this.
+    from .config import Config
+
+    _ = Config.create(
+        url=url,
+        host=host,
+        port=port,
+        scheme=scheme,
+        read_as=read_as,
+        act_as=act_as,
+        admin=admin,
+        ledger_id=ledger_id,
+        application_name=application_name,
+        oauth_token=oauth_token,
+        oauth_token_file=oauth_token_file,
+        ca=ca,
+        ca_file=ca_file,
+        cert=cert,
+        cert_file=cert_file,
+        cert_key=cert_key,
+        cert_key_file=cert_key_file,
+        connect_timeout=connect_timeout,
+        use_http_proxy=use_http_proxy,
+        logger=logger,
+        logger_name=logger_name,
+        log_level=log_level,
+    )
+    # TODO: Implement when the v8 connection code fully lands
+    raise NotImplementedError

--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -232,76 +232,141 @@ def connect(
 
     :param url:
         The URL to connect to. Can be used as an alternative to supplying ``host``, ``port``,
-        and ``scheme`` as individual values. Can alternatively be supplied via the environment
-        variable ``DAML_LEDGER_URL``.
+        and ``scheme`` as individual values.
+
+        If none of of ``url``, ``host``, ``port`` or ``scheme`` are specified, the value from the
+        environment variable ``DAML_LEDGER_URL`` is used instead.
+
     :param host:
         The host to connect to. Can be used as an alternative to supplying ``url`` as a combined
-        value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_HOST``.
+        value.
+
+        If none of of ``url``, ``host``, ``port`` or ``scheme`` are specified, the value from the
+        environment variable ``DAML_LEDGER_HOST`` is used instead.
+
     :param port:
         The port to connect to. Can be used as an alternative to supplying ``url`` as a combined
-        value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_PORT``.
+        value.
+
+        If none of of ``url``, ``host``, ``port`` or ``scheme`` are specified, the value from the
+        environment variable ``DAML_LEDGER_PORT`` is used instead.
+
     :param scheme:
         The scheme to connect to. Can be used as an alternative to supplying ``url`` as a
-        combined value. Can alternatively be supplied via the environment variable
-        ``DAML_LEDGER_SCHEME``.
+        combined value.
+
+        If none of of ``url``, ``host``, ``port`` or ``scheme`` are specified, the value from the
+        environment variable ``DAML_LEDGER_SCHEME`` is used instead.
+
     :param connect_timeout:
         Length of time to wait before giving up connecting to the remote and declaring an error.
         The default value is 30 seconds.
+
     :param use_http_proxy:
         ``True`` to use an HTTP(S) proxy server if configured; ``False`` to avoid using any
         configured server. If unspecified and the host is ``localhost``, the proxy server is
         avoided; otherwise the proxy server is used.
+
     :param ca:
         A certificate authority to use to validate the server's certificate. If not supplied,
         the operating system's default trust store is used. Cannot be specified with
         ``ca_file``.
+
     :param ca_file:
         A file containing the certificate authority to use to validate the server's certificate.
         If not supplied, the operating system's default trust store is used. Cannot be specified
         with ``ca``.
+
     :param cert:
         A client-side certificate to be used when connecting to a server that requires mutual
         TLS. Cannot be specified with ``cert_file``.
+
     :param cert_file:
         A file containing the client-side certificate to be used when connecting to a server
         that requires mutual TLS. Cannot be specified with ``cert``.
+
     :param cert_key:
         A client-side private key to be used when connecting to a server that requires mutual
         TLS. Cannot be specified with ``cert_key_file``.
+
     :param cert_key_file:
         A client-side private key to be used when connecting to a server that requires mutual
         TLS. Cannot be specified with ``cert_key``.
+
     :param read_as:
         A party or set of parties on whose behalf (in addition to all parties listed in
-        ``act_as``) contracts can be retrieved. Cannot be specified if ``oauth_token`` or
-        ``oauth_token_file`` is specified.
+        ``act_as``) contracts can be retrieved.
+
+        Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_ACT_AS`` is used instead.
+
     :param act_as:
         A party or set of parties on whose behalf commands should be executed. Parties here are
-        also implicitly granted ``read_as`` access as well. Cannot be specified if
-        ``oauth_token`` or ``oauth_token_file`` is specified.
+        also implicitly granted ``read_as`` access as well.
+
+        Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_ACT_AS`` is used instead.
+
     :param admin:
         HTTP JSON API only: allow admin endpoints to be used. This flag is ignored when
-        connecting to gRPC Ledger API implementations. Cannot be specified if ``oauth_token`` or
-        ``oauth_token_file`` is specified.
+        connecting to gRPC Ledger API implementations.
+
+        Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+
     :param ledger_id:
         The ledger ID to connect to. For the HTTP JSON API, this value is required. For the gRPC
         Ledger API, if this value is _not_ supplied, its value will be retrieved from the
-        server. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+        server.
+
+        Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_ID`` is used instead.
+
     :param application_name:
         A string that identifies this application. This is used for tracing purposes on the
-        server-side. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is
-        specified.
+        server-side.
+
+        Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_APPLICATION_NAME`` is used instead.
+
     :param oauth_token:
-        The OAuth bearer token to be used on all requests. If specified, no other access
-        parameters can be specified.
+        The OAuth bearer token to be used on all requests.
+
+        Cannot be specified if ``read_as``, ``act_as``, ``admin``, ``ledger_id``,
+        ``application_name``, or ``oauth_token_file`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_OAUTH_TOKEN`` is used instead.
+
     :param oauth_token_file:
-        A file that contains the OAuth bearer token to be used on all requests. If specified, no
-        other access parameters can be specified.
+        A file that contains the OAuth bearer token to be used on all requests.
+
+        Cannot be specified if ``read_as``, ``act_as``, ``admin``, ``ledger_id``,
+        ``application_name``, or ``oauth_token`` is specified.
+
+        If none of of ``read_as``, ``act_as``, ``admin``, ``ledger_id``, ``application_name``,
+        ``oauth_token``, or ``oauth_token_file`` are specified, the value from the environment
+        variable ``DAML_LEDGER_OAUTH_TOKEN_FILE`` is used instead.
+
     :param logger:
         The logger to use for connections created from this configuration. If not supplied, a
         logger will be created.
+
     :param logger_name:
         The name of the logger. Only used if ``logger`` is not provided.
+
     :param log_level:
         The logging level for the logger. The default is ``warn``. Only used if ``logger`` is
         not provided.

--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -210,9 +210,9 @@ def connect(
     | ``oauth_token``, or ``oauth_token_file`` causes *all* of these environment variables to be   |
     | ignored                                                                                      |
     +----------------------+-----------------------------------------------------------------------+
-    | ``act_as``           | ``DAML_LEDGER_ACT_AS``                                                |
+    | ``act_as``           | ``DAML_LEDGER_ACT_AS`` (as a comma-separated list of parties)         |
     +----------------------+-----------------------------------------------------------------------+
-    | ``read_as``          | ``DAML_LEDGER_READ_AS``                                               |
+    | ``read_as``          | ``DAML_LEDGER_READ_AS`` (as a comma-separated list of parties)        |
     +----------------------+-----------------------------------------------------------------------+
     | ``ledger_id``        | ``DAML_LEDGER_ID``                                                    |
     +----------------------+-----------------------------------------------------------------------+

--- a/python/dazl/ledger/config/__init__.py
+++ b/python/dazl/ledger/config/__init__.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+:mod:`dazl.ledger.config` — connection configuration
+====================================================
+
+This module contains configuration objects for a :class:`Connection`.
+
+Normally you don't need to construct these objects directly; instead, simply call
+:meth:`dazl.connect`, which contains the same options exposed by the :meth:`Config.create` function,
+which in turn includes the options exposed by the subobjects of :class:`Config`.
+
+Generally you should not modify a :class:`Config` object (or subobjects) that have already been
+passed to a :class:`Connection`. There are some exceptions to this rule, though; for example, when
+using tokens, you can simply assign ``Config.access.token`` to a new value.
+
+Configuration options are broken up into three subobjects:
+
+* :ref:`Access configuration <access-configuration>`: settings commonly found in Daml JWT tokens
+  (party settings, ledger ID, application name)
+* :ref:`SSL/TLS configuration <ssl-tls-configuration>`: settings for configuring TLS connections
+* :ref:`URL Configuration <url-configuration>`: settings that determine the location of gRPC Ledger
+  API or HTTP JSON API implementation
+
+.. autoclass:: Config
+    :members:
+
+.. _access-configuration:
+
+Access configuration
+--------------------
+
+The :class:`AccessConfig` protocol specifies how ``dazl`` identifies itself to a ledger. There are
+two built-in mechanisms for this: **property-based access**, which is traditionally used with
+ledgers that do NOT require authorization/authentication (typical in a local development scenario,
+for example coding against a local sandbox), and **token-based access**, which is required for
+ledgers that DO require authorization/authentication (typical in a production scenario and/or hosted
+ledgers).
+
+In **property-based access** (:class:`PropertyBasedAccessConfig`), the behavior differs depending on
+whether you are connecting over the gRPC Ledger API or the HTTP JSON API:
+
+* For the *gRPC Ledger API*, ``read_as`` and ``act_as`` are used as-is. ``ledger_id`` is
+  defaulted to the value requested from the ledger (but only if not initially specified).
+  The ``admin`` property is ignored and unused.
+* For the *HTTP JSON API*, ``read_as``, ``act_as``, ``admin``, ``ledger_id``, and
+  ``application_name`` are all used to generate an unsigned JWT locally. ``ledger_id`` MUST be
+  supplied.
+
+In **token-based access** (:class:`TokenBasedAccessConfig`), the value of the token completely
+determines the parties that can be used, the ledger ID to connect to, and the name of the
+application. ``AccessConfig.token`` can be overwritten at any time, and that value will be used for
+all subsequent calls to the ledger. If your ledger requires authorization/authentication using
+tokens, you _must_ use token-based access.
+
+Although ``dazl`` does not currently refresh tokens automatically, you can update the token yourself
+at any time:
+
+.. code-block:: python
+
+    async def main():
+        async with dazl.connect(token=MY_INITIAL_TOKEN) as conn:
+            task1 = asyncio.create_task(do_ledger_stuff(conn))
+            task2 = asyncio.create_task(refresh_token(conn))
+
+            await task1
+            task2.cancel()
+
+    async def do_ledger_stuff(conn):
+        # use the connection normally to make ledger calls
+        ...
+
+    async def refresh(conn):
+        while True:
+            # sleep for one hour
+            await asyncio.sleep(3600)
+            conn.config.access.token = NEW_REFRESHED_TOKEN
+
+Deeper support for token refreshing may be added in a future release.
+
+.. autoclass:: AccessConfig()
+    :members:
+
+.. autofunction:: create_access
+
+.. autoclass:: PropertyBasedAccessConfig()
+    :members:
+
+.. autoclass:: TokenBasedAccessConfig()
+    :members:
+
+.. _ssl-tls-configuration:
+
+SSL/TLS configuration
+---------------------
+
+.. autoclass:: SSLConfig
+    :members:
+
+.. _url-configuration:
+
+URL configuration
+-----------------
+
+The :class:`URLConfig` protocol specifies the ledger implementation that ``dazl`` connects to
+(either gRPC Ledger API or HTTP JSON API).
+
+.. autofunction:: create_url
+
+.. autoclass:: URLConfig()
+    :members:
+
+"""
+from __future__ import annotations
+
+import itertools
+import logging
+from logging import Logger
+from os import PathLike
+from typing import Collection, Optional, Union
+
+from ...prim import Party, TimeDeltaLike
+from .access import AccessConfig, PropertyBasedAccessConfig, TokenBasedAccessConfig, create_access
+from .argv import configure_parser
+from .ssl import SSLConfig
+from .url import URLConfig, create_url
+
+__all__ = [
+    "Config",
+    "AccessConfig",
+    "SSLConfig",
+    "URLConfig",
+    "TokenBasedAccessConfig",
+    "PropertyBasedAccessConfig",
+    "create_access",
+    "create_url",
+    "configure_parser",
+]
+
+# an incrementing counter that helps keep loggers for individual config connections unique
+# (see https://mail.python.org/pipermail//python-ideas/2016-August/041871.html); this is safe to
+# do even in multithreaded environments because ultimately we're reusing the GIL as our lock
+id_generator = itertools.count()
+
+
+# PyCharm thinks ``from .url import ...`` clashes with variables named ``url``
+# (same with ``ssl`` and ``access``).
+# noinspection PyShadowingNames
+class Config:
+    """
+    Stores configuration for a :class:`Connection`.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        url: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        scheme: Optional[str] = None,
+        read_as: Union[None, Party, Collection[Party]] = None,
+        act_as: Union[None, Party, Collection[Party]] = None,
+        admin: Optional[bool] = False,
+        ledger_id: Optional[str] = None,
+        application_name: Optional[str] = None,
+        oauth_token: Optional[str] = None,
+        oauth_token_file: Optional[str] = None,
+        ca: Optional[bytes] = None,
+        ca_file: Optional[PathLike] = None,
+        cert: Optional[bytes] = None,
+        cert_file: Optional[PathLike] = None,
+        cert_key: Optional[bytes] = None,
+        cert_key_file: Optional[PathLike] = None,
+        connect_timeout: Optional[TimeDeltaLike] = None,
+        use_http_proxy: bool = True,
+        logger: Optional[Logger] = None,
+        logger_name: Optional[str] = None,
+        log_level: Optional[str] = None,
+    ) -> "Config":
+        """
+        Create a :class:`Config` object from the supplied parameters.
+
+        The remote can be configured either by supplying a URL or by supplying a host (and optional
+        port and scheme). If none of ``url``, ``host``, ``port``, or ``scheme`` are supplied, then
+        environment variables are consulted; if no environment variables are specified either, then
+        default values are used.
+
+        The remote can be configured either by supplying a URL or by supplying a host (and optional
+        port and scheme). If none of ``url``, ``host``, ``port``, or ``scheme`` are supplied, then
+        environment variables are consulted; if no environment variables are specified either, then
+        default values are used.
+
+        When the URL scheme is ``http`` or ``https``, dazl will first attempt to connect assuming
+        the HTTP JSON API; if this fails, gRPC Ledger API is attempted.
+
+        If ``oauth_token`` is supplied and non-empty, then *token-based access* is used to connect
+        to the ledger.
+
+        If other fields are specified, then *property-based access* is used. At least one of
+        ``read_as``, ``act_as``, or ``admin`` must be supplied. For the HTTP JSON API,
+        ``ledger_id`` MUST be supplied.
+
+        If _no_ fields are specified, this is an error unless environment variables supply an
+        alternate source of configuration.
+
+        +-------------------+----------------------+-----------------------------------------------+
+        | function argument | environment variable | default value                                 |
+        +===================+======================+===============================================+
+        | ``url``           | DAML_LEDGER_URL      | localhost:6865                                |
+        +-------------------+----------------------+-----------------------------------------------+
+        | ``host``          | DAML_LEDGER_HOST     | localhost                                     |
+        +-------------------+----------------------+-----------------------------------------------+
+        | ``port``          | DAML_LEDGER_PORT     | 6865, unless ``scheme`` is specified:         |
+        |                   |                      | * 80 for ``http``                             |
+        |                   |                      | * 443 for ``https``                           |
+        |                   |                      | * 6865 for ``grpc``                           |
+        +-------------------+----------------------+-----------------------------------------------+
+        | ``scheme``        | DAML_LEDGER_SCHEME   | | ``https`` for port 443 or 8443              |
+        |                   |                      | | ``http`` for port 80, 7575 or 8080          |
+        |                   |                      | | ``grpc`` for port 6865                      |
+        |                   |                      | | ``https`` for all other ports               |
+        +-------------------+----------------------+-----------------------------------------------+
+
+        HTTP(s) proxies (gRPC Ledger API only)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        When connecting to the gRPC Ledger API, note that
+        `gRPC environment variables
+        <https://grpc.github.io/grpc/cpp/md_doc_environment_variables.html>`_
+        are always also respected; you can set ``https_proxy``/`http_proxy`` (note the lowercase
+        environment variable name). dazl, by default, will _also_ disable usage of a proxy server
+        for a ``localhost`` host or a ``127.0.0.1`` host; this can be overridden by passing a value
+        of ``use_http_proxy`` to ``True``.
+
+        :param url:
+            The URL to connect to. Can be used as an alternative to supplying ``host``, ``port``,
+            and ``scheme`` as individual values. Can alternatively be supplied via the environment
+            variable ``DAML_LEDGER_URL``.
+        :param host:
+            The host to connect to. Can be used as an alternative to supplying ``url`` as a combined
+            value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_HOST``.
+        :param port:
+            The port to connect to. Can be used as an alternative to supplying ``url`` as a combined
+            value. Can alternatively be supplied via the environment variable ``DAML_LEDGER_PORT``.
+        :param scheme:
+            The scheme to connect to. Can be used as an alternative to supplying ``url`` as a
+            combined value. Can alternatively be supplied via the environment variable
+            ``DAML_LEDGER_SCHEME``.
+        :param connect_timeout:
+            Length of time to wait before giving up connecting to the remote and declaring an error.
+            The default value is 30 seconds.
+        :param use_http_proxy:
+            ``True`` to use an HTTP(S) proxy server if configured; ``False`` to avoid using any
+            configured server. If unspecified and the host is ``localhost``, the proxy server is
+            avoided; otherwise the proxy server is used.
+        :param ca:
+            A certificate authority to use to validate the server's certificate. If not supplied,
+            the operating system's default trust store is used. Cannot be specified with
+            ``ca_file``.
+        :param ca_file:
+            A file containing the certificate authority to use to validate the server's certificate.
+            If not supplied, the operating system's default trust store is used. Cannot be specified
+            with ``ca``.
+        :param cert:
+            A client-side certificate to be used when connecting to a server that requires mutual
+            TLS. Cannot be specified with ``cert_file``.
+        :param cert_file:
+            A file containing the client-side certificate to be used when connecting to a server
+            that requires mutual TLS. Cannot be specified with ``cert``.
+        :param cert_key:
+            A client-side private key to be used when connecting to a server that requires mutual
+            TLS. Cannot be specified with ``cert_key_file``.
+        :param cert_key_file:
+            A client-side private key to be used when connecting to a server that requires mutual
+            TLS. Cannot be specified with ``cert_key``.
+        :param read_as:
+            A party or set of parties on whose behalf (in addition to all parties listed in
+            ``act_as``) contracts can be retrieved. Cannot be specified if ``oauth_token`` or
+            ``oauth_token_file`` is specified.
+        :param act_as:
+            A party or set of parties on whose behalf commands should be executed. Parties here are
+            also implicitly granted ``read_as`` access as well. Cannot be specified if
+            ``oauth_token`` or ``oauth_token_file`` is specified.
+        :param admin:
+            HTTP JSON API only: allow admin endpoints to be used. This flag is ignored when
+            connecting to gRPC Ledger API implementations. Cannot be specified if ``oauth_token`` or
+            ``oauth_token_file`` is specified.
+        :param ledger_id:
+            The ledger ID to connect to. For the HTTP JSON API, this value is required. For the gRPC
+            Ledger API, if this value is _not_ supplied, its value will be retrieved from the
+            server. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is specified.
+        :param application_name:
+            A string that identifies this application. This is used for tracing purposes on the
+            server-side. Cannot be specified if ``oauth_token`` or ``oauth_token_file`` is
+            specified.
+        :param oauth_token:
+            The OAuth bearer token to be used on all requests. If specified, no other access
+            parameters can be specified.
+        :param oauth_token_file:
+            A file that contains the OAuth bearer token to be used on all requests. If specified, no
+            other access parameters can be specified.
+        :param logger:
+            The logger to use for connections created from this configuration. If not supplied, a
+            logger will be created.
+        :param logger_name:
+            The name of the logger. Only used if ``logger`` is not provided.
+        :param log_level:
+            The logging level for the logger. The default is ``warn``. Only used if ``logger`` is
+            not provided.
+        """
+        if logger is None:
+            if not logger_name:
+                logger_name = f"dazl.conn.{next(id_generator)}"
+            logger = logging.getLogger(logger_name)
+            if log_level is not None:
+                logger.setLevel(log_level)
+
+        url_config = create_url(
+            url=url,
+            host=host,
+            port=port,
+            scheme=scheme,
+            connect_timeout=connect_timeout,
+            use_http_proxy=use_http_proxy,
+        )
+
+        access_config = create_access(
+            read_as=read_as,
+            act_as=act_as,
+            admin=admin,
+            ledger_id=ledger_id,
+            application_name=application_name,
+            oauth_token=oauth_token,
+            oauth_token_file=oauth_token_file,
+        )
+
+        ssl_config = SSLConfig(
+            ca=ca,
+            ca_file=ca_file,
+            cert=cert,
+            cert_file=cert_file,
+            cert_key=cert_key,
+            cert_key_file=cert_key_file,
+        )
+
+        return cls(access_config, ssl_config, url_config, logger)
+
+    def __init__(self, access: AccessConfig, ssl: SSLConfig, url: URLConfig, logger: Logger):
+        """
+        Initialize an instance of :class:`Config`.
+        """
+        self.access = access
+        self.ssl = ssl
+        self.url = url
+        self.logger = logger

--- a/python/dazl/ledger/config/__init__.py
+++ b/python/dazl/ledger/config/__init__.py
@@ -322,6 +322,7 @@ class Config:
             scheme=scheme,
             connect_timeout=connect_timeout,
             use_http_proxy=use_http_proxy,
+            logger=logger,
         )
 
         access_config = create_access(
@@ -332,6 +333,7 @@ class Config:
             application_name=application_name,
             oauth_token=oauth_token,
             oauth_token_file=oauth_token_file,
+            logger=logger,
         )
 
         ssl_config = SSLConfig(
@@ -341,6 +343,7 @@ class Config:
             cert_file=cert_file,
             cert_key=cert_key,
             cert_key_file=cert_key_file,
+            logger=logger,
         )
 
         return cls(access_config, ssl_config, url_config, logger)

--- a/python/dazl/ledger/config/access.py
+++ b/python/dazl/ledger/config/access.py
@@ -1,0 +1,491 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import base64
+from collections.abc import MutableSet as MutableSetBase, Set as SetBase
+import json
+import os
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Collection,
+    Iterator,
+    Mapping,
+    MutableSet,
+    Optional,
+    Protocol,
+    Union,
+    runtime_checkable,
+)
+
+from ...prim import Party
+from .exc import ConfigError
+
+__all__ = [
+    "AccessConfig",
+    "TokenBasedAccessConfig",
+    "PropertyBasedAccessConfig",
+    "PartyRights",
+    "PartyRightsSet",
+    "create_access",
+]
+
+if TYPE_CHECKING:
+    # We refer to the Config class in a docstring and
+    # without this import, Sphinx can't resolve the reference
+    # noinspection PyUnresolvedReferences
+    from . import Config
+
+
+def parties_from_env(*env_vars: str) -> AbstractSet[Party]:
+    """
+    Read the set of parties
+    """
+    return {Party(p) for env_var in env_vars for p in os.getenv(env_var, "").split(",") if p}
+
+
+# mypy note: typing.overload cannot properly express a more correct signature for this function,
+#  which is that if oauth_token is supplied, then a TokenBasedAccessConfig class is returned and
+#  otherwise, a PropertyBasedAccessConfig class is returned. Trying to type this properly with
+#  overloads results in:
+#     "Not all union combinations were tried because there are too many unions"
+#  It's also worth nothing that our only usage of this function also supplies all parameters since
+#  we're effectively just passing **kwargs around, so it's not clear a more accurate type helps much
+#  anyway.
+def create_access(
+    *,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = None,
+    ledger_id: Optional[str] = None,
+    application_name: Optional[str] = None,
+    oauth_token: Optional[str] = None,
+    oauth_token_file: Optional[str] = None,
+) -> AccessConfig:
+    """
+    Create an appropriate instance of :class:`AccessConfig`.
+
+    See :meth:`Config.create` for a more detailed description of these parameters.
+
+    """
+    # admin = None is effectively the same as admin = False in this context
+    is_property_based = read_as or act_as or admin or ledger_id or application_name
+    if not is_property_based and not oauth_token and not oauth_token_file:
+        # none of the access-related parameters were passed in, so try to read some from the
+        # environment
+        act_as = parties_from_env("DAML_LEDGER_ACT_AS", "DAML_LEDGER_PARTY")
+        read_as = parties_from_env("DAML_LEDGER_READ_AS", "DABL_PUBLIC_PARTY")
+        ledger_id = os.getenv("DAML_LEDGER_ID", "")
+        application_name = os.getenv("DAML_LEDGER_APPLICATION_NAME")
+        oauth_token = os.getenv("DAML_LEDGER_OAUTH_TOKEN")
+        oauth_token_file = os.getenv("DAML_LEDGER_OAUTH_TOKEN_FILE")
+
+    is_property_based = read_as or act_as or admin or ledger_id or application_name
+    if not is_property_based and not oauth_token and not oauth_token_file:
+        raise ConfigError("no oauth token access or read_as/act_as/admin was specified")
+
+    # how do they configure thee? let me count the ways...
+    if sum(map(int, (is_property_based, oauth_token, oauth_token_file))):
+        raise ConfigError(
+            "must specify ONE of read_as/act_as/admin, oauth_token, or oauth_token_file"
+        )
+
+    if oauth_token_file:
+        return TokenFileBasedAccessConfig(oauth_token_file)
+    elif oauth_token:
+        return TokenBasedAccessConfig(oauth_token)
+    else:
+        return PropertyBasedAccessConfig(
+            read_as=read_as,
+            act_as=act_as,
+            admin=admin,
+            ledger_id=ledger_id,
+            application_name=application_name,
+        )
+
+
+@runtime_checkable
+class AccessConfig(Protocol):
+    """
+    Configuration parameters for providing access to a ledger.
+
+    To create an instance of this protocol, call :func:`create_access` and provide *either*
+    ``oauth_token`` *or* the other fields you wish to set (such as ``act_as``). You cannot specify
+    both an access token and other fields.
+
+    You may implement this protocol using your own custom type if you have very specialized access
+    needs.
+    """
+
+    @property
+    def read_as(self) -> AbstractSet[Party]:
+        """
+        The set of parties that can be used to read data from the ledger. This also includes the
+        set of parties that can be used to write data to the ledger.
+
+        :type: AbstractSet[Party]
+        """
+        raise NotImplementedError
+
+    @property
+    def read_only_as(self) -> AbstractSet[Party]:
+        """
+        The set of parties that have read-only access to the underlying ledger.
+
+        :type: AbstractSet[Party]
+        """
+        raise NotImplementedError
+
+    @property
+    def act_as(self) -> AbstractSet[Party]:
+        """
+        The set of parties that can be used to write data to the ledger.
+
+        :type: AbstractSet[Party]
+        """
+        raise NotImplementedError
+
+    @property
+    def admin(self) -> bool:
+        """
+        ``True`` if the token grants "admin" access.
+
+        :type: bool
+        """
+        raise NotImplementedError
+
+    @property
+    def ledger_id(self) -> Optional[str]:
+        """
+        The ledger ID. For non-token based access methods, this can be queried from the ledger.
+
+        :type: Optional[str]
+        """
+        raise NotImplementedError
+
+    @property
+    def application_name(self) -> str:
+        """
+        The application name.
+
+        :type: str
+        """
+        raise NotImplementedError
+
+    @property
+    def token(self) -> str:
+        """
+        The bearer token that provides authorization and authentication to a ledger.
+
+        :type: str
+        """
+        raise NotImplementedError
+
+
+class TokenBasedAccessConfig(AccessConfig):
+    """
+    Access configuration that is inherently token-based. The token can be changed at any time, and
+    party rights, the application name, and ledger ID are all derived off of the token.
+    """
+
+    def __init__(self, oauth_token: str):
+        """
+        Initialize a token-based access configuration.
+
+        :param oauth_token: The initial value of the bearer token.
+        """
+        self.token = oauth_token
+
+    @property
+    def token(self) -> str:
+        """
+        The bearer token that provides authorization and authentication to a ledger. This value can
+        be replaced on a live connection in order to support use cases such as token refreshing.
+        """
+        return self._token
+
+    @token.setter
+    def token(self, value: str) -> None:
+        self._token = value
+        claims = decode_token(self._token)
+
+        read_as = frozenset(claims.get("readAs", ()))
+        act_as = frozenset(claims.get("actAs", ()))
+
+        self._act_as = act_as
+        self._read_only_as = read_as - act_as
+        self._read_as = read_as.union(act_as)
+        self._admin = bool(claims.get("admin", False))
+        self._ledger_id = claims.get("ledgerId", None)
+        self._application_name = claims.get("applicationId", None)
+
+    @property
+    def read_as(self) -> AbstractSet[Party]:
+        return self._read_as
+
+    @property
+    def read_only_as(self) -> AbstractSet[Party]:
+        return self._read_only_as
+
+    @property
+    def act_as(self) -> AbstractSet[Party]:
+        return self._act_as
+
+    @property
+    def admin(self) -> bool:
+        return self._admin
+
+    @property
+    def ledger_id(self) -> Optional[str]:
+        return self._ledger_id
+
+    @property
+    def application_name(self) -> str:
+        return self._application_name
+
+
+class TokenFileBasedAccessConfig(TokenBasedAccessConfig):
+    def __init__(self, oauth_token_file: str):
+        # TODO: Update the token when the contents of this file change.
+        super().__init__(Path(oauth_token_file).read_text())
+
+
+class PropertyBasedAccessConfig(AccessConfig):
+    """
+    Access configuration that is manually specified outside of an authentication/authorization
+    framework. Suitable for local testing or when no auth server is available, and the Ledger API
+    inherently trusts any caller to provide its own authentication and authorization.
+    """
+
+    def __init__(
+        self,
+        read_as: Union[None, Party, Collection[Party]] = None,
+        act_as: Union[None, Party, Collection[Party]] = None,
+        admin: Optional[bool] = False,
+        ledger_id: Optional[str] = None,
+        application_name: Optional[str] = None,
+    ):
+        """
+        Initialize a property-based access configuration.
+
+        :param read_as:
+            A party or set of parties on whose behalf (in addition to all parties listed in ``act_as``)
+            contracts can be retrieved.
+        :param act_as:
+            A party or set of parties on whose behalf commands should be executed. Parties here are also
+            implicitly granted ``read_as`` access as well.
+        :param admin:
+            HTTP JSON API only: allow admin endpoints to be used. This flag is ignored when connecting
+            to gRPC Ledger API implementations.
+        :param ledger_id:
+            The ledger ID to connect to. For the HTTP JSON API, this value is required. For the gRPC
+            Ledger API, if this value is _not_ supplied, its value will be retrieved from the server.
+        :param application_name:
+            A string that identifies this application. This is used for tracing purposes on the
+            server-side.
+        """
+        self._parties = PartyRights()
+        self._parties.maybe_add(read_as, False)
+        self._parties.maybe_add(act_as, True)
+        self._admin = bool(admin)
+        self._ledger_id = ledger_id
+        self._application_name = application_name or "dazl-client"
+
+    @property
+    def token(self):
+        """
+        Produces a token without signing, utilizing our parameters.
+        """
+        return encode_unsigned_token(
+            self.read_as, self.act_as, self.ledger_id, self.application_name, self.admin
+        )
+
+    @property
+    def ledger_id(self) -> "Optional[str]":
+        """
+        The ledger ID. When connecting to the gRPC Ledger API, this can be inferred and does not
+        need to be supplied. When connecting to the HTTP JSON API, it must be supplied.
+
+        :type: Optional[str]
+        """
+        return self._ledger_id
+
+    @ledger_id.setter
+    def ledger_id(self, value: "Optional[str]") -> None:
+        self._ledger_id = value
+
+    @property
+    def application_name(self) -> str:
+        return self._application_name
+
+    @property
+    def read_as(self) -> "AbstractSet[Party]":
+        """
+        The set of parties for which read rights are granted. This collection is read-only. If you
+        want to add a party with read-only access, add it to :meth:`read_only_as`; if you want to
+        add a party with act-as access as well as read-only access, add it to :meth:`act_as`.
+
+        This set always includes the act_as parties. For the set of parties that can be read as
+        but NOT acted as, use :meth:`read_only_as`.
+
+        :type: AbstractSet[Party]
+        """
+        return self._parties
+
+    @property
+    def read_only_as(self) -> "MutableSet[Party]":
+        """
+        The set of parties for which read-as rights are granted, but act-as rights are NOT granted.
+        This collection can be modified.
+
+        :type: MutableSet[Party]
+        """
+        return self._parties.read_as
+
+    @property
+    def act_as(self) -> "MutableSet[Party]":
+        """
+        The set of parties for which act-as rights are granted. This collection can be modified.
+        Adding a party to this set _removes_ it from :meth:`read_only_as`.
+
+        :type: MutableSet[Party]
+        """
+        return self._parties.act_as
+
+    @property
+    def admin(self) -> bool:
+        """
+        Whether or not the token sent to HTTP JSON API contains the ``admin: true`` flag that
+        signals a token bearer with admin access.
+        """
+        return self._admin
+
+    @admin.setter
+    def admin(self, value: bool) -> None:
+        self._admin = value
+
+
+def parties(p: Union[None, Party, Collection[Party]]) -> Collection[Party]:
+    if p is None:
+        return []
+    elif isinstance(p, str):
+        return [Party(p)]
+    else:
+        return p
+
+
+DamlLedgerApiNamespace = "https://daml.com/ledger-api"
+
+
+def decode_token(token: str) -> Mapping[str, Any]:
+    components = token.split(".", 3)
+    if len(components) != 3:
+        raise ValueError("not a JWT")
+    claim_str = base64.urlsafe_b64decode(components[1])
+    claims = json.loads(claim_str)
+    claims_dict = claims.get(DamlLedgerApiNamespace)
+    if claims_dict is None:
+        raise ValueError(f"JWT is missing claim namespace: {DamlLedgerApiNamespace!r}")
+    return claims_dict
+
+
+def encode_unsigned_token(
+    read_as: Collection[Party],
+    act_as: Collection[Party],
+    ledger_id: str,
+    application_id: str,
+    admin: bool = True,
+) -> bytes:
+    header = {
+        "alg": "none",
+        "typ": "JWT",
+    }
+    payload = {
+        DamlLedgerApiNamespace: {
+            "ledgerId": ledger_id,
+            "applicationId": application_id,
+            "actAs": sorted(act_as),
+            "readAs": sorted(read_as),
+            "admin": admin,
+        }
+    }
+
+    return (
+        base64.urlsafe_b64encode(json.dumps(header).encode("utf-8"))
+        + b"."
+        + base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        + b"."
+    )
+
+
+class PartyRights(SetBase):
+    __slots__ = ("_rights", "read_as", "act_as")
+
+    def __init__(self):
+        self._rights = dict()
+        self.read_as = PartyRightsSet(self, False)
+        self.act_as = PartyRightsSet(self, True)
+
+    def maybe_add(
+        self, value: "Union[None, Party, Collection[Party]]", has_act_rights: bool
+    ) -> None:
+        if value is None:
+            return
+
+        # Party is a fake Python newtype, so isinstance checks don't work on it
+        if isinstance(value, str):
+            self.add(Party(value), has_act_rights)
+        else:
+            for party in value:
+                self.add(party, has_act_rights)
+
+    def add(self, value: "Party", has_act_rights: bool) -> None:
+        """
+        Add/replace a ``Party`` and its rights.
+        """
+        self._rights[value] = has_act_rights
+
+    def discard(self, value: "Party") -> None:
+        self._rights.pop(value)
+
+    def get(self, value: "Party") -> "Optional[bool]":
+        return self._rights.get(value)
+
+    def count(self, act_as: bool) -> int:
+        return sum(1 for p, a in self._rights.items() if act_as == a)
+
+    def __contains__(self, party: object) -> bool:
+        return party in self._rights
+
+    def __len__(self) -> int:
+        return len(self._rights)
+
+    def __iter__(self) -> "Iterator[Party]":
+        return iter(sorted(self._rights))
+
+    def iter(self, act_as: bool) -> "Iterator[Party]":
+        return iter(p for p, a in sorted(self._rights.items()) if a == act_as)
+
+
+class PartyRightsSet(MutableSetBase):
+    def __init__(self, rights: "PartyRights", act_as: bool):
+        self._rights = rights
+        self._act_as = act_as
+
+    def add(self, value: "Party") -> None:
+        self._rights.add(value, self._act_as)
+
+    def discard(self, value: "Party") -> None:
+        self._rights.discard(value)
+
+    def __contains__(self, obj: "object") -> bool:
+        return isinstance(obj, str) and (self._rights.get(Party(obj)) == self._act_as)
+
+    def __len__(self) -> int:
+        return self._rights.count(self._act_as)
+
+    def __iter__(self) -> "Iterator[Party]":
+        return self._rights.iter(self._act_as)

--- a/python/dazl/ledger/config/argv.py
+++ b/python/dazl/ledger/config/argv.py
@@ -21,7 +21,19 @@ __all__ = ["configure_parser", "EXAMPLES"]
 # Implementation notes:
 #
 # A common trick employed throughout this file is to add an "argument" to a parser that is not
-# directly used. Calling ``add_arguments(...)`` with an argumen
+# directly used. Calling ``add_arguments(...)`` with a "name" of a completely arbitrary string that
+# is not practically possible to be called from the command line (for example,
+# ``add_arguments("--my-special-flag SOMETHING | -m BLAH")`` is entirely allowed. This also renders
+# as-is in the help strings. Additionally, passing nargs=SUPPRESS essentially prevents the flag from
+# being used during parsing, but does NOT remove it from help! The opposite (passing help=SUPPRESS)
+# can be used to hide the "real" arguments from the help string that would otherwise render in an
+# ugly way. This leads to this:
+#
+#   # argparse does not support different metavars for different arguments, so one arg for the
+#   # help string we want, and two more args for the two different cases
+#   parser.add_argument("--something STUFF | --something-file TOKEN", nargs=SUPPRESS)
+#   parser.add_argument("--something", help=SUPPRESS, ...)
+#   parser.add_argument("--something-file", help=SUPPRESS, ...)
 
 # An example string that can be used to help illustrate how to use common flags.
 EXAMPLES = """
@@ -111,7 +123,7 @@ def _configure_access(parser: ArgumentParser):
     group_p.add_argument(
         "--application-name",
         metavar="NAME",
-        help="application name",
+        help="application name; uniquely identifies this client to the server",
     )
 
     group_t = parser.add_argument_group("Access configuration (token-based)")

--- a/python/dazl/ledger/config/argv.py
+++ b/python/dazl/ledger/config/argv.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Support for exposing dazl's configuration parameters through :mod:`argparse`.
+"""
+import argparse
+from argparse import SUPPRESS, Action, ArgumentParser
+import os
+from typing import TYPE_CHECKING, Optional, Sequence
+import warnings
+
+from .exc import ConfigWarning
+from .url import DEFAULT_CONNECT_TIMEOUT, KNOWN_SCHEME_PORTS
+
+if TYPE_CHECKING:
+    from argparse import _ArgumentGroup
+
+__all__ = ["configure_parser", "EXAMPLES"]
+
+
+# Implementation notes:
+#
+# A common trick employed throughout this file is to add an "argument" to a parser that is not
+# directly used. Calling ``add_arguments(...)`` with an argumen
+
+# An example string that can be used to help illustrate how to use common flags.
+EXAMPLES = """
+  # connect to a local sandbox acting as Alice and Bob, with Carol read-only
+  # (localhost is the default if no url/host is specified)
+  %(prog)s -u Alice,Bob -r Carol
+
+  # connect to myledger.daml.app over SSL/TLS using the access token in "token.txt"
+  %(prog)s --url https://myledger.daml.app/ --oauth-token-file token.txt
+"""
+
+
+class WideHelpFormatter(argparse.HelpFormatter):
+    def __init__(self, prog: str, *args, **kwargs):
+        if "max_help_position" not in kwargs:
+            kwargs["max_help_position"] = 43
+        if "width" not in kwargs:
+            col = os.getenv("COLUMNS")
+            if col:
+                kwargs["width"] = int(col)
+
+        super().__init__(prog, *args, **kwargs)
+
+
+def configure_parser(parser: ArgumentParser, add_usage: bool = True) -> None:
+    """
+    Add dazl configuration options to an existing :class:`ArgumentParser`.
+
+    dazl exposes a variety of configuration options that could be tedious to duplicate in your own
+    application. To use this in your own application:
+
+    .. code-block:: python
+
+        parser = argparse.ArgumentParser(description='Something awesome with dazl.')
+        configure_parser(parser)
+        args = parser.parse_args()
+
+        conn = dazl.connect(**args)
+
+    :param parser:
+        The :class:`ArgumentParser` to add options to.
+    :param add_usage:
+        ``True`` to overwrite the usage string with something more compact; because there are a
+        lot of variables, the default usage string doesn't add much
+    """
+    if add_usage:
+        parser.usage = "%(prog)s [OPTIONS]\n\n" + EXAMPLES
+
+    _configure_url_basic_options(parser)
+    _configure_access(parser)
+    _configure_url_advanced_options(parser)
+    _configure_deprecated_options(parser)
+
+
+def _configure_access(parser: ArgumentParser):
+    group_p = parser.add_argument_group("Access configuration (property-based)")
+
+    group_p.add_argument("--act-as/-u PARTY [PARTY ...]", nargs=SUPPRESS, help="act-as parties")
+    group_p.add_argument(
+        "--act-as",
+        "-u",
+        "--party",
+        "--parties",
+        help=SUPPRESS,
+        action=AppendPartySetAction,
+    )
+    group_p.add_argument("--read-as/-r PARTY [PARTY ...]", nargs=SUPPRESS, help="read-as parties")
+    group_p.add_argument(
+        "--read-as",
+        "-r",
+        "--party-groups",
+        help=SUPPRESS,
+        action=AppendPartySetAction,
+    )
+
+    group_p.add_argument(
+        "--admin",
+        action="store_const",
+        const=True,
+        help="Add admin flag (HTTP JSON API only)",
+    )
+    group_p.add_argument(
+        "--ledger-id",
+        "-l",
+        help="ledger ID (required on HTTP JSON API)",
+    )
+    group_p.add_argument(
+        "--application-name",
+        metavar="NAME",
+        help="application name",
+    )
+
+    group_t = parser.add_argument_group("Access configuration (token-based)")
+    add_text_or_file_argument(
+        group_t,
+        "--oauth-token",
+        metavar="TOKEN",
+        help="OAuth2 bearer token",
+    )
+
+
+def _configure_url_basic_options(parser: ArgumentParser):
+    url = parser.add_argument_group("Basic options")
+    url.add_argument(
+        "--url",
+        help="URL of the gRPC Ledger API/HTTP JSON API (cannot be used with --host/--port)",
+    )
+    # kept around for backwards compatibility
+    url.add_argument("--participant-url", dest="url", help=argparse.SUPPRESS)
+
+    host_help = "ledger host (cannot be used with --url; default: localhost)"
+    url.add_argument("--host/-H HOST", help=host_help, nargs=SUPPRESS)
+    url.add_argument("--host", "-h", help=SUPPRESS)
+
+    # The --port field. Note that -p used to mean parties, but now it means port; this is a little
+    # hook to preserve backwards compatibility for one version (as it turns out, the value of the
+    # -p flag CAN disambiguate usage so we keep the CLI user-friendly, even it gets a little ugly
+    # under the hood for dazl v8
+    port_help = "ledger port (cannot be used with --url; default: based on scheme/host)"
+    url.add_argument("--port/-p PORT", help=port_help, nargs=SUPPRESS)
+    url.add_argument("--port", metavar="PORT", help=SUPPRESS, type=int)
+    url.add_argument("-p", action=DashPAction, help=SUPPRESS)
+
+    url.add_argument(
+        "--scheme",
+        help="scheme/protocol (cannot be used with --url)",
+        choices=KNOWN_SCHEME_PORTS,
+    )
+
+
+def _configure_url_advanced_options(parser: ArgumentParser):
+    group = parser.add_argument_group("Advanced options")
+    LOG_LEVELS = ["verbose", "debug", "info", "warn", "error"]
+    group.add_argument(
+        "--log-level",
+        metavar="LEVEL",
+        choices=LOG_LEVELS,
+        help=f"logging level (one of {{{','.join(LOG_LEVELS)}}}; default: warn)",
+    )
+    group.add_argument(
+        "--connect-timeout",
+        metavar="SECONDS",
+        type=float,
+        help="number of seconds before giving up on a connection "
+        f"(default: {DEFAULT_CONNECT_TIMEOUT.total_seconds()})",
+    )
+
+    group.add_argument(
+        "--plaintext",
+        help="force the connection to use plaintext instead of SSL/TLS",
+        dest="scheme",
+        action="store_const",
+        const="http",
+    )
+
+    add_text_or_file_argument(
+        group,
+        "--cert",
+        metavar="CERT",
+        help="client certificate (mutual TLS)",
+    )
+    add_text_or_file_argument(
+        group,
+        "--cert-key",
+        metavar="CERT",
+        help="client certificate private key (mutual TLS)",
+    )
+    add_text_or_file_argument(
+        group,
+        "--ca",
+        metavar="CA",
+        help="certificate authority",
+    )
+    add_bool_argument(
+        group,
+        "--use-http-proxy",
+        hidden_true_flags=["--enable-http-proxy"],
+        help="allow/disallow HTTP proxy server usage (default: use, except for localhost)",
+    )
+    group.add_argument(
+        "--package-fetch-poll-interval",
+        metavar="SECONDS",
+        type=int,
+        help="how frequently to fetch ALL packages (default: 0 [don't periodically fetch])",
+    )
+    # for backwards compatibility; remove in dazl v9
+    group.add_argument(
+        "--eager-package-fetch",
+        action="store_const",
+        dest="package_fetch_poll_interval",
+        const=1,
+        help=SUPPRESS,
+    )
+
+
+def _configure_deprecated_options(parser: ArgumentParser):
+    add_no_effect_deprecated_flag(parser, "--idle-timeout")
+    add_no_effect_deprecated_flag(parser, "--max-command-batch-timeout")
+    add_no_effect_deprecated_flag(parser, "--max-connection-batch-size")
+    add_no_effect_deprecated_flag(parser, "--max-connection-count")
+    add_no_effect_deprecated_flag(parser, "--max-consequence-depth")
+    add_no_effect_deprecated_flag(parser, "--max-event-block-size")
+    add_no_effect_deprecated_flag(parser, "--poll-interval")
+    add_no_effect_deprecated_flag(parser, "--quiet-count")
+    add_no_effect_deprecated_flag(parser, "--use-acs-service", nargs=0)
+
+
+def add_no_effect_deprecated_flag(parser, *name_or_flags: str, **kwargs):
+    """
+    Add a flag that can be passed in, but does
+    """
+    parser.add_argument(
+        *name_or_flags,
+        action=IgnoreAction,
+        warning=f"{'/'.join(name_or_flags)} is no longer used and has no effect; "
+        "this flag will be removed in dazl v9",
+        help=argparse.SUPPRESS,
+        **kwargs,
+    )
+
+
+# noinspection PyShadowingBuiltins
+def add_text_or_file_argument(
+    parser: "_ArgumentGroup",
+    *name_or_flags: str,
+    metavar: "Optional[str]" = None,
+    metavar_file: str = "FILE",
+    help: "Optional[str]" = None,
+) -> None:
+    """
+    Add a (user-facing) argument that can be passed in as a text value on the command-line or as a
+    file.
+
+    Note that this actually adds _two_ arguments, one for the base case where a string is passed in
+    and another to handle files. This is in line with what :meth:`Config.create` expects.
+    """
+    if help == SUPPRESS:
+        # we may enable this one day, but for now we're the only ones allowed to play weird games
+        # with argparse
+        raise ValueError("SUPPRESS is not supported here")
+
+    # The first "argument" that we add is actually just for purposes of displaying a nice help
+    # string; it is not directly usable
+    file_flags = [f"{flag}-file" for flag in name_or_flags if flag.startswith("--")]
+
+    if metavar is None:
+        metavar = "STRING"
+
+    parser.add_argument(
+        f"{'/'.join(name_or_flags)} {metavar} | {'/'.join(file_flags)} {metavar_file}",
+        action=IgnoreAction,
+        nargs=SUPPRESS,
+        help=help,
+    )
+    parser.add_argument(*name_or_flags, help=argparse.SUPPRESS)
+    parser.add_argument(*file_flags, help=argparse.SUPPRESS)
+
+
+# noinspection PyShadowingBuiltins
+def add_bool_argument(
+    parser: "_ArgumentGroup",
+    *name_or_flags: str,
+    hidden_true_flags: "Optional[Sequence[str]]" = None,
+    help: "Optional[str]" = None,
+):
+    """
+    This is partially an alternative to Python 3.9's argparse.BooleanOptionalAction, but this
+    function additionally renders help text in a more compact form, while also allowing for
+    deprecated identifiers.
+    """
+    if len(name_or_flags) != 1:
+        raise ValueError("can only supply one flag")
+    flag = name_or_flags[0]
+    if not flag.startswith("--"):
+        raise ValueError("flag must start with --")
+
+    base_flag = flag[2:]
+    dest = base_flag.replace("-", "_")
+
+    parser.add_argument(
+        f"--[no-]{base_flag}",
+        help=help,
+        nargs=argparse.SUPPRESS,
+        action=IgnoreAction,
+    )
+
+    parser.add_argument(
+        flag,
+        help=argparse.SUPPRESS,
+        action="store_const",
+        const=True,
+    )
+    parser.add_argument(
+        f"--no-{base_flag}",
+        help=argparse.SUPPRESS,
+        dest=dest,
+        action="store_const",
+        const=False,
+    )
+    if hidden_true_flags:
+        parser.add_argument(
+            *hidden_true_flags,
+            help=argparse.SUPPRESS,
+            dest=dest,
+            action="store_const",
+            const=True,
+        )
+
+
+class DashPAction(Action):
+    """
+    Support for the tricky backwards compatibility game we're playing with the `-p` flag.
+    It used to mean ``--party``, but now it means ``--port``.
+
+    Note that Daml-LF defines ``PartyIdString`` as starting with a letter and NEVER with a number,
+    so there is no possibility for ambiguity here.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            port_value = int(values)
+            parties_value = None
+        except ValueError:
+            port_value = None
+            parties_value = values.split(",")
+
+        if port_value is not None:
+            namespace.port = port_value
+        else:
+            warnings.warn(
+                "-p called with what appears to be a list of parties; use -u instead. "
+                "This behavior will be unsupported in dazl v9",
+                ConfigWarning,
+            )
+            existing_parties = getattr(namespace, "act_as", None)
+            if existing_parties is None:
+                existing_parties = []
+                namespace.act_as = existing_parties
+            existing_parties.extend(parties_value)
+
+
+class AppendPartySetAction(Action):
+    def __init__(self, option_strings: str, **kwargs):
+        super().__init__(option_strings, metavar="PARTY", nargs="+", **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parties = getattr(namespace, self.dest, None)
+        if parties is None:
+            parties = []
+            setattr(namespace, self.dest, parties)
+
+        parties.extend(party for p in values for party in p.split(","))
+
+
+class IgnoreAction(Action):
+    def __init__(self, warning: Optional[str] = None, *args, **kwargs):
+        self.warning = warning
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        if self.warning is not None:
+            warnings.warn(self.warning, ConfigWarning)

--- a/python/dazl/ledger/config/exc.py
+++ b/python/dazl/ledger/config/exc.py
@@ -1,0 +1,9 @@
+__all__ = ["ConfigError", "ConfigWarning"]
+
+
+class ConfigError(ValueError):
+    pass
+
+
+class ConfigWarning(Warning):
+    pass

--- a/python/dazl/ledger/config/ssl.py
+++ b/python/dazl/ledger/config/ssl.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from os import PathLike, fspath
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    # We refer to the Config class in a docstring and
+    # without this import, Sphinx can't resolve the reference
+    # noinspection PyUnresolvedReferences
+    from . import Config
+
+
+class SSLConfig:
+    """
+    Configuration parameters that affect SSL connections.
+
+    See :meth:`Config.create` for a more detailed description of these parameters.
+    """
+
+    def __init__(
+        self,
+        ca: "Optional[bytes]" = None,
+        ca_file: "Optional[PathLike]" = None,
+        cert: "Optional[bytes]" = None,
+        cert_file: "Optional[PathLike]" = None,
+        cert_key: "Optional[bytes]" = None,
+        cert_key_file: "Optional[PathLike]" = None,
+    ):
+        self._ca: Optional[bytes]
+        self._cert: Optional[bytes]
+        self._cert_key: Optional[bytes]
+
+        if ca_file:
+            if ca:
+                raise ValueError("ca and ca_file cannot both be specified at the same time")
+            with open(fspath(ca_file), "rb") as f:
+                self._ca = f.read()
+        else:
+            self._ca = ca
+
+        if cert_file:
+            if cert:
+                raise ValueError("cert and cert_file cannot both be specified at the same time")
+            with open(fspath(cert_file), "rb") as f:
+                self._cert = f.read()
+        else:
+            self._cert = cert
+
+        if cert_key_file:
+            if cert_key:
+                raise ValueError(
+                    "cert_key and cert_key_file cannot both be specified at the same time"
+                )
+            with open(fspath(cert_key_file), "rb") as f:
+                self._cert_key = f.read()
+        else:
+            self._cert_key = cert_key
+
+    def __bool__(self):
+        """
+        True if SSL settings are supplied; otherwise False if no SSL settings of any kind were
+        supplied.
+        """
+        return bool(self._ca or self._cert or self._cert_key)
+
+    @property
+    def ca(self) -> "Optional[bytes]":
+        """
+        Server certificate authority file.
+        """
+        return self._ca
+
+    @property
+    def cert(self) -> "Optional[bytes]":
+        """
+        Client certificate file.
+        """
+        return self._cert
+
+    @property
+    def cert_key(self) -> "Optional[bytes]":
+        """
+        Client certificate and key file.
+        """
+        return self._cert_key

--- a/python/dazl/ledger/config/url.py
+++ b/python/dazl/ledger/config/url.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from datetime import timedelta
+import ipaddress
+import os
+from reprlib import repr
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+from urllib.parse import urlparse
+import warnings
+
+from ...prim import TimeDeltaLike, to_timedelta
+from .exc import ConfigError, ConfigWarning
+
+__all__ = ["URLConfig", "create_url", "KNOWN_SCHEME_PORTS", "DEFAULT_CONNECT_TIMEOUT"]
+
+if TYPE_CHECKING:
+    # We refer to the Config class in a docstring and
+    # without this import, Sphinx can't resolve the reference
+    # noinspection PyUnresolvedReferences
+    from . import Config
+
+DEFAULT_CONNECT_TIMEOUT = timedelta(seconds=30)
+
+# The set of schemes we understand, and the known ports that map to those schemes. The first port
+# in the list is the default value for the scheme.
+KNOWN_SCHEME_PORTS = MappingProxyType(
+    {"http": (80, 7575, 8080), "https": (443, 8443), "grpc": (6865,), "grpcs": ()}
+)
+
+
+def create_url(
+    *,
+    url: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    scheme: Optional[str] = None,
+    connect_timeout: Optional[TimeDeltaLike] = None,
+    use_http_proxy: Optional[bool] = None,
+):
+    """
+    Create an instance of :class:`URLConfig`, possibly with values taken from environment variables,
+    or defaulted if otherwise unspecified.
+
+    See :meth:`Config.create` for a more detailed description of these parameters.
+    """
+    if not url and not host and not port and not scheme:
+        # use environment variables to provide default values
+        url = os.getenv("DAML_LEDGER_URL")
+        host = os.getenv("DAML_LEDGER_HOST")
+        port = os.getenv("DAML_LEDGER_PORT")
+        scheme = os.getenv("DAML_LEDGER_SCHEME")
+
+    if not url and not host and not port and not scheme:
+        # if no values are supplied _and_ no environment variables are specified either, then
+        # fall back to default values
+        url = "localhost"
+
+    if url:
+        if host or port or scheme:
+            raise ValueError("url or host/port/scheme must be specified, but not both")
+        url = sanitize_url(url)
+    else:
+        url = build_url(host, port, scheme)
+
+    if use_http_proxy is None:
+        use_http_proxy = not is_localhost(urlparse(url).hostname)
+
+    return SimpleURLConfig(
+        url=url,
+        connect_timeout=to_timedelta(connect_timeout) if connect_timeout is not None else None,
+        use_http_proxy=use_http_proxy,
+    )
+
+
+@runtime_checkable
+class URLConfig(Protocol):
+    """
+    Configuration parameters for the remote host, including basic connection parameters that do not
+    belong in :class:`AccessConfig`.
+    """
+
+    @property
+    def url(self) -> str:
+        """
+        The full URL to connect to, including a protocol (scheme), host, and port.
+        """
+        raise NotImplementedError
+
+    @property
+    def use_http_proxy(self) -> bool:
+        """
+        Whether to allow the use of HTTP proxies.
+        """
+        raise NotImplementedError
+
+    @property
+    def connect_timeout(self) -> timedelta:
+        """
+        How long to wait for a connection before giving up.
+
+        The default is 30 seconds.
+        """
+        raise NotImplementedError
+
+
+class SimpleURLConfig:
+    """
+    Trivial implementation of the :class:`URLConfig` protocol.
+    """
+
+    def __init__(self, url: str, connect_timeout: timedelta, use_http_proxy: bool):
+        self.url = url
+        self.connect_timeout = connect_timeout
+        self.use_http_proxy = use_http_proxy
+
+
+def sanitize_url(url: str) -> str:
+    """
+    Perform some basic sanitization on a URL string (see :meth:`build_url`):
+     * Supply a default protocol according to our general rules
+     * Supply a port, even if one wasn't specified
+     * Strip out any trailing slashes
+
+    >>> sanitize_url("somewhere:1000")
+    '//somewhere:1000'
+
+    >>> sanitize_url("http://somewhere:1000")
+    'http://somewhere:1000'
+
+    >>> sanitize_url("http://somewhere:1000/")
+    'http://somewhere:1000/'
+    """
+    first_slash = url.find("/")
+    if first_slash == -1 or first_slash != url.find("//"):
+        url = "//" + url
+
+    original = urlparse(url)
+    sanitized = urlparse(build_url(original.hostname, original.port, original.scheme))
+    return original._replace(
+        netloc=f"{sanitized.hostname}:{sanitized.port}", scheme=sanitized.scheme
+    ).geturl()
+
+
+def build_url(host: Optional[str], port: Optional[int], scheme: Optional[str]) -> str:
+    """
+    Build a URL from host/port/scheme components.
+
+    :param host:
+        The host to connect to. If unspecified, ``"localhost"`` is assumed.
+    :param port:
+        The port to connect to. If provided, must be a valid port number
+        (between 1 and 65535 inclusive).
+    :param scheme:
+        The scheme to use (must be ``"http"``, ``"https"``, ``"grpc"``, ``"grpcs"`` or ``None``).
+    :raises ConfigError: One or more of the passed parameters had invalid values.
+    """
+
+    if not host:
+        host = "localhost"
+
+    if port is not None and port != "":
+        port = int(port)
+        if not 1 <= port <= 65535:
+            raise ConfigError(f"not a valid port number: {repr(port)}")
+
+    if scheme:
+        # Scheme specified; if a port is _not_ specified, the we'll try to figure out a
+        # default from the scheme.
+        scheme = scheme.lower()
+        known_ports = KNOWN_SCHEME_PORTS.get(scheme)
+        if known_ports is None:
+            raise ConfigError(f"not a valid scheme: {repr(scheme)}")
+        if port:
+            return f"{scheme}://{host}:{port}"
+        elif not known_ports:
+            raise ConfigError(
+                f"there is no default port for {scheme} URLs; you must specify a port"
+            )
+        else:
+            return f"{scheme}://{host}:{known_ports[0]}"
+
+    if port:
+        # No scheme provided, but a port was provided.
+        # See if we can infer the scheme from the provided port.
+        for proposed_scheme, ports in KNOWN_SCHEME_PORTS.items():
+            if port in ports:
+                return f"{proposed_scheme}://{host}:{port}"
+
+        warnings.warn(
+            f"A port ({port}) was specified without supplying a scheme (http/https); "
+            "will attempt connecting with https. Unless you are using a standard port, "
+            "you should specify a scheme explicitly.",
+            ConfigWarning,
+        )
+
+    # Neither scheme nor port are provided. If the host is localhost, then assume we're targeting
+    # a sandbox; otherwise prefer an SSL/TLS connection.
+    return f"grpc://{host}:6865" if is_localhost(host) else f"https://{host}:443"
+
+
+def is_localhost(host: str) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+        return addr.is_loopback
+    except ValueError:
+        return False

--- a/python/docs/dazl.ledger.config.rst
+++ b/python/docs/dazl.ledger.config.rst
@@ -1,0 +1,4 @@
+.. Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+   SPDX-License-Identifier: Apache-2.0
+
+.. automodule:: dazl.ledger.config

--- a/python/docs/dazl.rst
+++ b/python/docs/dazl.rst
@@ -13,6 +13,7 @@ Subpackages
     dazl.client
     dazl.damlast
     dazl.ledger
+    dazl.ledger.config
     dazl.model
     dazl.pretty
     dazl.protocols

--- a/python/docs/migrating.rst
+++ b/python/docs/migrating.rst
@@ -5,6 +5,50 @@
 Migrate
 #######
 
+Migrating to dazl v8
+====================
+
+Command-line changes
+--------------------
+
+Commands such as ``dazl ls``, ``dazl tail``, or options provided for your application by calling
+``dazl.run`` have changed:
+
+* ``-p`` is now used to denote the Ledger API port and **not** ``Party``. In dazl v8, supplying a
+  string argument to ``-p`` will be still interpreted as a ``Party`` but you will get a warning;
+  switch to ``--act-as`` or ``--read-as`` instead. This backwards compatible behavior will be
+  removed in dazl v9.
+
+* ``--party``/``--parties`` has been renamed to ``--act-as`` (``-u``); ``--party-groups`` has been
+  renamed to ``--read-as`` (``-r``). Both ``--act-as`` and ``--read-as`` take a comma-separated list
+  of parties, or as an alternative can be specified multiple times. This matches the terminology
+  used in multi-party submissions as added in Daml Connect 1.9. The older forms of these flags will
+  be removed in dazl v9.
+
+* ``--package-fetch-poll-interval`` replaces ``--eager-package-fetch``.
+  If unspecified or zero, package polling is disabled. Note that ``dazl`` will still generally
+  discover packages as it needs to. This is really only of value if you are explicitly interested
+  in keeping metadata up-to-date because you are using package metadata, and you should generally
+  NOT use this for performance reasons.
+
+  Setting ``-eager-package-fetch`` is the same as specifying ``--package-fetch-poll-interval=1``,
+  as dazl previously polled for package updates once a second.
+
+* ``--enable-http-proxy`` has been renamed to ``--use-http-proxy``; the old flag will be removed in
+  dazl v9.
+
+* The following flags have no effect in dazl v8 and will be removed in dazl v9::
+   - ``--idle-timeout``
+   - ``--max-command-batch-timeout``
+   - ``--max-connection-batch-size``
+   - ``--max-connection-count``
+   - ``--max-consequence-depth``
+   - ``--max-event-block-size``
+   - ``--poll-interval``
+   - ``--quiet-count``
+   - ``--use-acs-service``
+
+
 Migrating from dazl v6 from v7
 ==============================
 

--- a/python/tests/unit/test_ledger_config_argv.py
+++ b/python/tests/unit/test_ledger_config_argv.py
@@ -1,0 +1,92 @@
+import argparse
+from io import StringIO
+import logging
+import os
+from typing import Any, Mapping
+
+import pytest
+
+from dazl.ledger.config import configure_parser
+from dazl.ledger.config.argv import WideHelpFormatter
+from dazl.ledger.config.exc import ConfigWarning
+
+
+def _test(cmd_line: str, expected: Mapping[str, Any]):
+    parser = argparse.ArgumentParser(
+        "sample app",
+        add_help=False,
+    )
+    configure_parser(parser)
+    args = parser.parse_args(cmd_line.split(" "))
+    actual = {k: v for k, v in vars(args).items() if v is not None}
+    assert actual == expected
+
+
+def test_can_configure_parser():
+    os.environ["COLUMNS"] = "108"
+    parser = argparse.ArgumentParser(
+        "sample app", add_help=False, formatter_class=WideHelpFormatter
+    )
+    configure_parser(parser)
+    with StringIO() as buf:
+        parser.print_help(buf)
+        logging.info("Sample output:\n\n" + buf.getvalue())
+
+
+def test_basic_args():
+    _test("--host somewhere --port 6865", {"host": "somewhere", "port": 6865})
+
+
+def test_basic_short_args():
+    _test("-h somewhere -p 6865", {"host": "somewhere", "port": 6865})
+
+
+def test_party_compat_alias():
+    _test("--party Alice", {"act_as": ["Alice"]})
+
+
+def test_act_as_multiple_parties_with_comma():
+    _test("--act-as Alice,Bob", {"act_as": ["Alice", "Bob"]})
+
+
+def test_act_as_multiple_parties_with_space():
+    _test("--act-as Alice Bob", {"act_as": ["Alice", "Bob"]})
+
+
+def test_act_as_multiple_times():
+    _test("--act-as Alice --act-as Bob", {"act_as": ["Alice", "Bob"]})
+
+
+def test_mixed_parties():
+    _test(
+        "--act-as Alice --act-as Bob --read-as Carol",
+        {"act_as": ["Alice", "Bob"], "read_as": ["Carol"]},
+    )
+
+
+def test_mixed_parties_short_form():
+    _test("-u Alice -u Bob -r Carol", {"act_as": ["Alice", "Bob"], "read_as": ["Carol"]})
+
+
+def test_specify_token():
+    _test("--oauth-token XYZ", {"oauth_token": "XYZ"})
+
+
+def test_http_proxy_flag():
+    _test("--use-http-proxy", {"use_http_proxy": True})
+    _test("--enable-http-proxy", {"use_http_proxy": True})
+    _test("--no-use-http-proxy", {"use_http_proxy": False})
+
+
+def test_warning_flags():
+    with pytest.warns(ConfigWarning):
+        _test("--poll-interval 30", {})
+
+
+def test_dash_p_compat_alias_for_party():
+    with pytest.warns(ConfigWarning):
+        _test("-p Alice", {"act_as": ["Alice"]})
+
+
+def test_dash_p_compat_alias_for_port():
+    _test("-p 1000", {"port": 1000})

--- a/python/tests/unit/test_ledger_config_url.py
+++ b/python/tests/unit/test_ledger_config_url.py
@@ -1,0 +1,32 @@
+from urllib.parse import urlparse
+
+import pytest
+
+from dazl.ledger.config import create_url
+
+testdata = [
+    # TODO: figure out a way to test the blank default in pytest while also ignoring environment
+    #  variables; right now our tests set DAML_LEDGER_URL for integration tests but this screws
+    #  up the test for the "no values specified" case
+    # ({}, "grpc://localhost:6865"),
+    ({"url": "somewhere"}, "https://somewhere:443"),
+    ({"url": "http://somewhere"}, "http://somewhere:80"),
+    ({"url": "https://somewhere"}, "https://somewhere:443"),
+    ({"url": "somewhere:443"}, "https://somewhere:443"),
+    ({"port": 6865}, "grpc://localhost:6865"),
+    ({"port": 7575}, "http://localhost:7575"),
+    ({"host": "localhost"}, "grpc://localhost:6865"),
+    ({"host": "somewhere"}, "https://somewhere:443"),
+]
+
+
+@pytest.mark.parametrize("kwargs,expected_url", testdata)
+def test_ledger_config_url_all_defaults(kwargs, expected_url):
+    actual = urlparse(create_url(**kwargs).url)
+    expected = urlparse(expected_url)
+    assert expected == actual
+
+
+def test_ledger_config_rejects_overspecified_values():
+    with pytest.raises(ValueError):
+        create_url(url="localhost:6865", host="localhost", port=6865)


### PR DESCRIPTION
Add classes for the new config system that will be used with the v8 API (#109).

Some goals of this implementation:
* Support multiparty submissions more effectively, particularly add support for specifying `--act-as` and `--read-as`
* Be less "magical" than the current implementation (see [dazl/util/config.py](https://github.com/digital-asset/dazl-client/blob/master/python/dazl/util/config.py) and [dazl/util/config_meta.py](https://github.com/digital-asset/dazl-client/blob/master/python/dazl/util/config_meta.py))
* `Network.set_config(**kwargs)` takes a lot of options, but because it's defined as "kwargs", the documentation doesn't show up in an IDE which also hurts discoverability.
* Be easier to plug into client applications; `dazl.run` has been deprecated for a while, but because it handles configuring `argparse` for you, people have had trouble getting off of it
* Produce less spew when running something like `dazl ls --help`; there are a ton of options and they are not well-organized and there is a fair amount of visual noise.

New `dazl ls --help` (as produced by a test)
```
usage: sample app [url config] [access config] [ssl/tls config]

  # connect to a local sandbox acting as Alice and Bob, with Carol read-only
  # (localhost is the default if no url/host is specified)
  sample app -u Alice,Bob -r Carol

  # connect to myledger.daml.app over SSL/TLS using the access token in "token.txt"
  sample app --url https://myledger.daml.app/ --oauth-token-file token.txt

Basic options:
  --url URL                                URL of the gRPC Ledger API/HTTP JSON API (cannot be used with
                                           --host/--port)
  --host/-H HOST                           ledger host (cannot be used with --url; default: localhost)
  --port/-p PORT                           ledger port (cannot be used with --url; default: based on
                                           scheme/host)
  --scheme {http,https,grpc,grpcs}         scheme/protocol (cannot be used with --url)

Access configuration (property-based):
  --act-as/-u PARTY [PARTY ...]            act-as parties
  --read-as/-r PARTY [PARTY ...]           read-as parties
  --admin                                  Add admin flag (HTTP JSON API only)
  --ledger-id LEDGER_ID, -l LEDGER_ID      ledger ID (required on HTTP JSON API)
  --application-name NAME                  application name

Access configuration (token-based):
  --oauth-token TOKEN | --oauth-token-file FILE 
                                           OAuth2 bearer token

Advanced connection options:
  --connect-timeout SECONDS                number of seconds before giving up on a connection (default:
                                           30.0)
  --plaintext                              force the connection to use plaintext instead of SSL/TLS
  --cert CERT | --cert-file FILE           client certificate (mutual TLS)
  --cert-key CERT | --cert-key-file FILE   client certificate private key (mutual TLS)
  --ca CA | --ca-file FILE                 certificate authority
  --[no-]use-http-proxy                    allow/disallow HTTP proxy server usage (default: use, except for
                                           localhost)
  --package-fetch-poll-interval SECONDS    how frequently to fetch ALL packages (default: 0 [don't
                                           periodically fetch])
```

The old spew:

```
usage: dazl ls [-h] [--config CONFIG] [--max-connection-count COUNT] [--quiet-timeout SECONDS]
               [--use-acs-service] [--idle-timeout SECONDS] [--max-consequence-depth COUNT]
               [--package-ids PACKAGE_IDS_TYPE] [--server-host STRING] [--server-port PORT]
               [--oauth-client-id STRING] [--oauth-client-secret STRING] [--oauth-token STRING]
               [--oauth-refresh-token STRING] [--oauth-id-token STRING] [--oauth-token-uri STRING]
               [--oauth-redirect-uri STRING] [--oauth-auth-url STRING] [--oauth-ca-file STRING]
               [--oauth-audience STRING] [--oauth-legacy-username STRING] [--oauth-legacy-password STRING]
               [--parties PARTIES] [--url URL] [--ca-file PATH] [--cert-file PATH] [--cert-key-file PATH]
               [--verify-ssl VERIFY_SSL] [--poll-interval SECONDS] [--connect-timeout SECONDS]
               [--eager-package-fetch] [--enable-http-proxy] [--package-lookup-timeout SECONDS]
               [--application-name STRING] [--log-level LOG_LEVEL] [--max-event-block-size COUNT]
               [--max-command-batch-size COUNT] [--max-command-batch-timeout SECONDS]
               [--party-groups PARTIES] [--format FORMAT] [--template-filter TEMPLATE_FILTER] [--all]

optional arguments:
  -h, --help            show this help message and exit
  --format FORMAT, --fmt FORMAT, -F FORMAT
  --template-filter TEMPLATE_FILTER, -T TEMPLATE_FILTER
  --all, -A

Configuration Settings:
  --config CONFIG       path to a YAML config file

Overall Settings:
  --max-connection-count COUNT
                        Number of concurrent HTTP connections to have outstanding.
  --quiet-timeout SECONDS
                        Number of seconds to wait after the client "thinks" it's done to hang around for
  --use-acs-service     Use Active Contract Set service instead of reading from the Transaction event
                        stream
  --idle-timeout SECONDS
                        Maximum number of seconds of idle activity before automatically closing the client
  --max-consequence-depth COUNT
                        The maximum number of times to wait for all parties to arrive at the same
                        offsetbefore failing with an error
  --package-ids PACKAGE_IDS_TYPE
                        comma-separated list of package IDs to listen on
  --server-host STRING  Server listening host. Used for OAuth web application flow callbacks.
  --server-port PORT    Server listening port. Used for OAuth web application flow callbacks.
  --oauth-client-id STRING
                        OAuth client ID
  --oauth-client-secret STRING
                        OAuth client secret (implies web application flow or backend application flow)
  --oauth-token STRING  OAuth token
  --oauth-refresh-token STRING
                        OAuth refresh token
  --oauth-id-token STRING
                        OpenID token (JWT formatted)
  --oauth-token-uri STRING
                        OAuth token URL
  --oauth-redirect-uri STRING
                        OAuth redirect URI (implies web application flow)
  --oauth-auth-url STRING
                        OAuth auth URL (implies mobile application flow)
  --oauth-ca-file STRING
                        OAuth CA CA Bundle File
  --oauth-audience STRING
                        OAuth audience (Implies Client Credentials Flow)
  --oauth-legacy-username STRING
                        OAuth username (implies legacy application flow)
  --oauth-legacy-password STRING
                        OAuth password (implies legacy application flow)
  --parties PARTIES, -p PARTIES, --party PARTIES
                        comma-separated list of parties serviced by a participant node

Per-Party Settings:
  --url URL, -u URL, --participant-url URL
                        URL where the Ledger API is hosted
  --ca-file PATH        server certificate authority file
  --cert-file PATH      client certificate file
  --cert-key-file PATH  client certificate and key file
  --verify-ssl VERIFY_SSL
                        level of verification to use for SSL
  --poll-interval SECONDS
                        polling interval for receiving new events
  --connect-timeout SECONDS
                        number of seconds before giving up on a connection
  --eager-package-fetch
                        whether to fetch all packages on startup
  --enable-http-proxy   whether to allow the use of HTTP proxies
  --package-lookup-timeout SECONDS
                        number of seconds before giving up on a package
  --application-name STRING
                        The name that this application uses to identify itself to the ledger.
  --log-level LOG_LEVEL, -l LOG_LEVEL
                        logging level for events for this party
  --max-event-block-size COUNT
                        Maximum number of blocks to read in a single call.
  --max-command-batch-size COUNT
                        Maximum number of commands to batch up in a single transaction
  --max-command-batch-timeout SECONDS
                        Maximum number of seconds to wait before sending out a command
  --party-groups PARTIES
                        comma-separated list of broadcast parties
```