### PR TITLE
python: Add a grpc-stubs library.

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,8 +1,5 @@
 [mypy]
 
-[mypy-google.protobuf.pyext.*]
-ignore_missing_imports = True
-
 [mypy-prometheus_client.*]
 ignore_missing_imports = True
 

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -171,7 +171,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
-version = "1.27.1"
+version = "1.28.0"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -186,6 +186,19 @@ version = ">=3.1.4,<5"
 [package.extras]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)"]
 pyopenssl = ["pyopenssl (>=20.0.0)"]
+
+[[package]]
+category = "dev"
+description = "Mypy stubs for gRPC"
+name = "grpc-stubs"
+optional = false
+python-versions = ">=3.6"
+version = "1.24.5"
+
+[package.dependencies]
+grpcio = "*"
+mypy = ">=0.730"
+typing-extensions = "*"
 
 [[package]]
 category = "main"
@@ -740,7 +753,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.3"
+version = "1.26.4"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -784,7 +797,7 @@ description = "A formatter for Python code."
 name = "yapf"
 optional = false
 python-versions = "*"
-version = "0.30.0"
+version = "0.31.0"
 
 [[package]]
 category = "main"
@@ -805,7 +818,7 @@ pygments = ["pygments"]
 server = ["aiohttp"]
 
 [metadata]
-content-hash = "7e4928447dd57782785c6e05724719190c61f42fc7e869567f38f42d5ddd5522"
+content-hash = "9d1c98b140d5fc2bd9b469774defed3305be489fb19fc6821ed98f039e859c6c"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -904,8 +917,12 @@ flask = [
     {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
 ]
 google-auth = [
-    {file = "google-auth-1.27.1.tar.gz", hash = "sha256:d8958af6968e4ecd599f82357ebcfeb126f826ed0656126ad68416f810f7531e"},
-    {file = "google_auth-1.27.1-py2.py3-none-any.whl", hash = "sha256:63a5636d7eacfe6ef5b7e36e112b3149fa1c5b5ad77dd6df54910459bcd6b89f"},
+    {file = "google-auth-1.28.0.tar.gz", hash = "sha256:9bd436d19ab047001a1340720d2b629eb96dd503258c524921ec2af3ee88a80e"},
+    {file = "google_auth-1.28.0-py2.py3-none-any.whl", hash = "sha256:dcaba3aa9d4e0e96fd945bf25a86b6f878fcb05770b67adbeb50a63ca4d28a5e"},
+]
+grpc-stubs = [
+    {file = "grpc-stubs-1.24.5.tar.gz", hash = "sha256:d875d5827e0a1ee6003aa5848243ea5df650f89cef8cf8abd917a27493e970e7"},
+    {file = "grpc_stubs-1.24.5-py3-none-any.whl", hash = "sha256:2ce3a4ce40a7bb755620f012bf7301a63fa42cfa7d2fb715f69854d9123ceaa9"},
 ]
 grpcio = [
     {file = "grpcio-1.36.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:e3a83c5db16f95daac1d96cf3c9018d765579b5a29bb336758d793028e729921"},
@@ -1387,8 +1404,8 @@ untokenize = [
     {file = "untokenize-0.1.1.tar.gz", hash = "sha256:3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
-    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 watchdog = [
     {file = "watchdog-2.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1f518a6940cde8720b8826a705c164e6b9bd6cf8c00f14269ffac51e017e06ec"},
@@ -1418,8 +1435,8 @@ werkzeug = [
     {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
 ]
 yapf = [
-    {file = "yapf-0.30.0-py2.py3-none-any.whl", hash = "sha256:3abf61ba67cf603069710d30acbc88cfe565d907e16ad81429ae90ce9651e0c9"},
-    {file = "yapf-0.30.0.tar.gz", hash = "sha256:3000abee4c28daebad55da6c85f3cd07b8062ce48e2e9943c8da1b9667d48427"},
+    {file = "yapf-0.31.0-py2.py3-none-any.whl", hash = "sha256:e3a234ba8455fe201eaa649cdac872d590089a18b661e39bbac7020978dd9c2e"},
+    {file = "yapf-0.31.0.tar.gz", hash = "sha256:408fb9a2b254c302f49db83c59f9aa0b4b0fd0ec25be3a5c51181327922ff63d"},
 ]
 yarl = [
     {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,7 @@ toposort = "*"
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
 flask = "^1.0"
+grpc-stubs = "*"
 grpcio-tools = ">=1.32.0"
 isort = "^5"
 mypy = "*"


### PR DESCRIPTION
Add a `grpc-stubs` library; the `grpcio` library doesn't support typing natively, but it turns out there are stub libraries out int he wild that can split the difference!