### PR TITLE
python: Mostly formatting tweaks pulled up from #108.

### DIFF
--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -17,6 +17,8 @@ This module contains the public API for interacting with the ledger from the per
 specific party.
 """
 
+from __future__ import annotations
+
 from asyncio import ensure_future, get_event_loop
 from contextlib import contextmanager
 from functools import wraps
@@ -80,10 +82,10 @@ DEFAULT_TIMEOUT_SECONDS = 30
 
 @contextmanager
 def simple_client(
-    url: "Optional[str]" = None,
-    party: "Union[None, str, Party]" = None,
-    log_level: "Optional[int]" = INFO,
-) -> "ContextManager[SimplePartyClient]":
+    url: Optional[str] = None,
+    party: Union[None, str, Party] = None,
+    log_level: Optional[int] = INFO,
+) -> ContextManager[SimplePartyClient]:
     """
     Start up a single client connecting to a single specific party.
 
@@ -142,7 +144,9 @@ class async_network:
     """
 
     def __init__(
-        self, url: "Optional[str]" = None, dars: "Optional[Union[Dar, Collection[Dar]]]" = None
+        self,
+        url: Optional[str] = None,
+        dars: Optional[Union[Dar, Collection[Dar]]] = None,
     ):
         LOG.debug("async_network.__init__")
         self.network = Network()
@@ -181,28 +185,28 @@ class Network:
     instances.
     """
 
-    def __init__(self, metrics: "Optional[MetricEvents]" = None):
+    def __init__(self, metrics: Optional[MetricEvents] = None):
         self._impl = _NetworkImpl(metrics)
         self._main_fut = None
 
     def set_config(
         self,
-        *config: "Union[NetworkConfig, AnonymousNetworkConfig]",
-        url: "Optional[str]" = None,
-        admin_url: "Optional[str]" = None,
+        *config: Union[NetworkConfig, AnonymousNetworkConfig],
+        url: Optional[str] = None,
+        admin_url: Optional[str] = None,
         **kwargs
     ):
         self._impl.set_config(*config, url=url, admin_url=admin_url, **kwargs)
 
     @property
-    def lookup(self) -> "SymbolLookup":
+    def lookup(self) -> SymbolLookup:
         """
         Return a :class:`SymbolLookup` that provides type and package information for known
         packages.
         """
         return self._impl.lookup
 
-    def resolved_config(self) -> "NetworkConfig":
+    def resolved_config(self) -> NetworkConfig:
         """
         Calculate the configuration that will be used for this client when it is instantiated.
         """
@@ -210,14 +214,14 @@ class Network:
 
     # <editor-fold desc="Global/Party client creation">
 
-    def simple_global(self) -> "SimpleGlobalClient":
+    def simple_global(self) -> SimpleGlobalClient:
         """
         Return a :class:`GlobalClient` that exposes thread-safe, synchronous (blocking) methods for
         communicating with a ledger. Callbacks are dispatched to background threads.
         """
         return self._impl.global_impl(SimpleGlobalClient)
 
-    def aio_global(self) -> "AIOGlobalClient":
+    def aio_global(self) -> AIOGlobalClient:
         """
         Return a :class:`GlobalClient` that works on an asyncio event loop.
 
@@ -228,7 +232,7 @@ class Network:
         self._impl.freeze()
         return client
 
-    def simple_party(self, party: "Union[str, Party]") -> "SimplePartyClient":
+    def simple_party(self, party: Union[str, Party]) -> SimplePartyClient:
         """
         Return a :class:`PartyClient` that exposes thread-safe, synchronous (blocking) methods for
         communicating with a ledger. Callbacks are dispatched to background threads.
@@ -237,14 +241,14 @@ class Network:
         """
         return self._impl.party_impl(to_party(party), SimplePartyClient)
 
-    def simple_new_party(self) -> "SimplePartyClient":
+    def simple_new_party(self) -> SimplePartyClient:
         """
         Return a :class:`PartyClient` that exposes thread-safe, synchronous (blocking) methods for
         communicating with a ledger. Callbacks are dispatched to background threads.
         """
         return self.simple_party(str(uuid4()))
 
-    def aio_party(self, party: "Union[str, Party]") -> "AIOPartyClient":
+    def aio_party(self, party: Union[str, Party]) -> AIOPartyClient:
         """
         Return a :class:`PartyClient` that works on an asyncio event loop.
 
@@ -252,7 +256,7 @@ class Network:
         """
         return self._impl.party_impl(Party(party), AIOPartyClient)
 
-    def aio_new_party(self) -> "AIOPartyClient":
+    def aio_new_party(self) -> AIOPartyClient:
         """
         Return a :class:`PartyClient` for a random party that works on an asyncio event loop.
         This will never return the same object twice.
@@ -260,8 +264,8 @@ class Network:
         return self.aio_party(str(uuid4()))
 
     def party_bots(
-        self, party: "Union[str, Party]", if_missing: IfMissingPartyBehavior = CREATE_IF_MISSING
-    ) -> "BotCollection":
+        self, party: Union[str, Party], if_missing: IfMissingPartyBehavior = CREATE_IF_MISSING
+    ) -> BotCollection:
         """
         Return the collection of bots associated with a party.
 
@@ -283,7 +287,7 @@ class Network:
     # <editor-fold desc="Daemon thread-based scheduling API">
 
     def start_in_background(
-        self, daemon: bool = True, install_signal_handlers: "Optional[bool]" = None
+        self, daemon: bool = True, install_signal_handlers: Optional[bool] = None
     ) -> None:
         """
         Connect to the ledger in a background thread.
@@ -296,7 +300,7 @@ class Network:
             self._impl.invoker.install_signal_handlers()
         return self._impl.start(daemon)
 
-    def shutdown(self) -> "Optional[Awaitable[None]]":
+    def shutdown(self) -> Optional[Awaitable[None]]:
         """
         Gracefully shut down all network connections and notify all clients that they are about to
         be terminated.
@@ -317,7 +321,7 @@ class Network:
             )
             return self._main_fut
 
-    def join(self, timeout: "Optional[float]" = None) -> None:
+    def join(self, timeout: Optional[float] = None) -> None:
         """
         Block the current thread until the client is shut down.
 
@@ -340,7 +344,7 @@ class Network:
         self._main_fut = ensure_future(self.aio_run(keep_open=False))
 
     def run_until_complete(
-        self, *coroutines: "Awaitable[None]", install_signal_handlers: "Optional[bool]" = None
+        self, *coroutines: Awaitable[None], install_signal_handlers: Optional[bool] = None
     ) -> None:
         """
         Block the main thread and run the application in an event loop on the main thread. The loop
@@ -395,13 +399,13 @@ class Network:
 
     # </editor-fold>
 
-    def parties(self) -> "Collection[Party]":
+    def parties(self) -> Collection[Party]:
         """
         Return a snapshot of the set of parties that exist right now.
         """
         return self._impl.parties()
 
-    def bots(self) -> "Collection[Bot]":
+    def bots(self) -> Collection[Bot]:
         """
         Return a collection of bots.
 
@@ -431,15 +435,15 @@ class GlobalClient:
     management and current time.
     """
 
-    def __init__(self, impl: "_NetworkImpl"):
+    def __init__(self, impl: _NetworkImpl):
         self._impl = impl
 
 
 class AIOGlobalClient(GlobalClient):
     async def ensure_dar(
         self,
-        contents: "Union[str, Path, bytes, BinaryIO]",
-        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
+        contents: Union[str, Path, bytes, BinaryIO],
+        timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that the ledger has the packages specified by the given contents (as a byte array).
@@ -452,7 +456,7 @@ class AIOGlobalClient(GlobalClient):
         return await self._impl.upload_package(raw_bytes, timeout)
 
     async def ensure_packages(
-        self, package_ids: "Collection[str]", timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS
+        self, package_ids: Collection[str], timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS
     ) -> None:
         """
         Validate that packages with the specified package IDs exist on the ledger. Throw an
@@ -473,8 +477,8 @@ class AIOGlobalClient(GlobalClient):
 class SimpleGlobalClient(GlobalClient):
     def ensure_dar(
         self,
-        contents: "Union[str, Path, bytes, BinaryIO]",
-        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
+        contents: Union[str, Path, bytes, BinaryIO],
+        timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that the ledger has the packages specified by the given contents (as a byte array).
@@ -487,7 +491,7 @@ class SimpleGlobalClient(GlobalClient):
         return self._impl.invoker.run_in_loop(lambda: self._impl.upload_package(raw_bytes, timeout))
 
     def ensure_packages(
-        self, package_ids: "Collection[str]", timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS
+        self, package_ids: Collection[str], timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS
     ) -> None:
         """
         Validate that packages with the specified package IDs exist on the ledger. Throw an
@@ -500,7 +504,7 @@ class SimpleGlobalClient(GlobalClient):
             lambda: self._impl.ensure_package_ids(package_ids, timeout)
         )
 
-    def metadata(self, timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS) -> "LedgerMetadata":
+    def metadata(self, timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS) -> LedgerMetadata:
         """
         Return the current set of known packages.
         """
@@ -513,19 +517,19 @@ class PartyClient:
     with a Ledger API implementation from the perspective of a single client.
     """
 
-    def __init__(self, impl: "_PartyClientImpl"):
+    def __init__(self, impl: _PartyClientImpl):
         self._impl = impl
 
     # <editor-fold desc="Ledger/client metadata">
 
     @property
-    def party(self) -> "Party":
+    def party(self) -> Party:
         """
         Return the party serviced by this client.
         """
         return self._impl.party
 
-    def resolved_config(self) -> "PartyConfig":
+    def resolved_config(self) -> PartyConfig:
         """
         Calculate the configuration that will be used for this client when it is instantiated.
         """
@@ -542,14 +546,14 @@ class AIOPartyClient(PartyClient):
 
     # <editor-fold desc="Event handler registration">
 
-    def ledger_init(self) -> "AEventHandlerDecorator[InitEvent]":
+    def ledger_init(self) -> AEventHandlerDecorator[InitEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` has been
         instructed to begin, but before any network activity is started.
         """
         return fluentize(self.add_ledger_init)
 
-    def add_ledger_init(self, handler: "AEventHandler[InitEvent]") -> None:
+    def add_ledger_init(self, handler: AEventHandler[InitEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has been instructed to
         begin, but before any network activity is started.
@@ -561,7 +565,7 @@ class AIOPartyClient(PartyClient):
         for key in EventKey.init():
             self._impl.add_event_handler(key, handler, None, self)
 
-    def ledger_ready(self) -> "AEventHandlerDecorator[ReadyEvent]":
+    def ledger_ready(self) -> AEventHandlerDecorator[ReadyEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` has caught
         up to the head of the ledger, but before any :meth:`ledger_create` or :meth:`ledger_archive`
@@ -569,7 +573,7 @@ class AIOPartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_ready)
 
-    def add_ledger_ready(self, handler: "AEventHandler[ReadyEvent]") -> None:
+    def add_ledger_ready(self, handler: AEventHandler[ReadyEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has caught up to the head of
         the ledger, but before any :meth:`ledger_create` or :meth:`ledger_archive` callbacks are
@@ -584,7 +588,7 @@ class AIOPartyClient(PartyClient):
 
     def ledger_packages_added(
         self, initial: bool = False
-    ) -> "AEventHandlerDecorator[PackagesAddedEvent]":
+    ) -> AEventHandlerDecorator[PackagesAddedEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` has
         detected new packages added to the ledger.
@@ -600,7 +604,7 @@ class AIOPartyClient(PartyClient):
         return fluentize(self.add_ledger_packages_added, initial=initial)
 
     def add_ledger_packages_added(
-        self, handler: "AEventHandler[PackagesAddedEvent]", initial: bool = False
+        self, handler: AEventHandler[PackagesAddedEvent], initial: bool = False
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has detected new packages
@@ -620,7 +624,7 @@ class AIOPartyClient(PartyClient):
         for key in EventKey.packages_added(initial=initial, changed=True):
             self._impl.add_event_handler(key, handler, None, self)
 
-    def ledger_transaction_start(self) -> "AEventHandlerDecorator[TransactionStartEvent]":
+    def ledger_transaction_start(self) -> AEventHandlerDecorator[TransactionStartEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` receives a
         new transaction. Called before individual :meth:`ledger_create` and :meth:`ledger_archive`
@@ -628,7 +632,7 @@ class AIOPartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_transaction_start)
 
-    def add_ledger_transaction_start(self, handler: "AEventHandler[TransactionStartEvent]") -> None:
+    def add_ledger_transaction_start(self, handler: AEventHandler[TransactionStartEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` receives a new transaction.
         Called before individual :meth:`ledger_create` and :meth:`ledger_archive` callbacks.
@@ -640,7 +644,7 @@ class AIOPartyClient(PartyClient):
         for key in EventKey.transaction_start():
             self._impl.add_event_handler(key, handler, None, self)
 
-    def ledger_transaction_end(self) -> "AEventHandlerDecorator[TransactionEndEvent]":
+    def ledger_transaction_end(self) -> AEventHandlerDecorator[TransactionEndEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` receives a
         new transaction. Called after individual :meth:`ledger_create` and :meth:`ledger_archive`
@@ -648,7 +652,7 @@ class AIOPartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_transaction_end)
 
-    def add_ledger_transaction_end(self, handler: "AEventHandler[TransactionEndEvent]") -> None:
+    def add_ledger_transaction_end(self, handler: AEventHandler[TransactionEndEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` receives a new transaction.
         Called after individual :meth:`ledger_create` and :meth:`ledger_archive` callbacks.
@@ -661,8 +665,8 @@ class AIOPartyClient(PartyClient):
             self._impl.add_event_handler(key, handler, None, self)
 
     def ledger_created(
-        self, template: Any, match: "Optional[ContractMatch]" = None
-    ) -> "AEventHandlerDecorator[ContractCreateEvent]":
+        self, template: Any, match: Optional[ContractMatch] = None
+    ) -> AEventHandlerDecorator[ContractCreateEvent]:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly created
         template.
@@ -674,8 +678,8 @@ class AIOPartyClient(PartyClient):
         """
 
         def _register_created(
-            cb: "AEventHandler[ContractCreateEvent]",
-        ) -> "AEventHandler[ContractCreateEvent]":
+            cb: AEventHandler[ContractCreateEvent],
+        ) -> AEventHandler[ContractCreateEvent]:
             self.add_ledger_created(template, match=match, handler=cb)
             return cb
 
@@ -684,9 +688,9 @@ class AIOPartyClient(PartyClient):
     def add_ledger_created(
         self,
         template: Any,
-        handler: "AEventHandler[ContractCreateEvent]",
-        match: "Optional[ContractMatch]" = None,
-    ) -> "Bot":
+        handler: AEventHandler[ContractCreateEvent],
+        match: Optional[ContractMatch] = None,
+    ) -> Bot:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly created
         contract instance of a template.
@@ -704,7 +708,7 @@ class AIOPartyClient(PartyClient):
 
     def ledger_exercised(
         self, template: Any, choice: str
-    ) -> "AEventHandlerDecorator[ContractExercisedEvent]":
+    ) -> AEventHandlerDecorator[ContractExercisedEvent]:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters an exercised
         choice event.
@@ -716,15 +720,15 @@ class AIOPartyClient(PartyClient):
         """
 
         def _register_exercised(
-            cb: "AEventHandler[ContractExercisedEvent]",
-        ) -> "AEventHandler[ContractExercisedEvent]":
+            cb: AEventHandler[ContractExercisedEvent],
+        ) -> AEventHandler[ContractExercisedEvent]:
             self.add_ledger_exercised(template, choice, handler=cb)
             return cb
 
         return _register_exercised
 
     def add_ledger_exercised(
-        self, template: Any, choice: str, handler: "AEventHandler[ContractExercisedEvent]"
+        self, template: Any, choice: str, handler: AEventHandler[ContractExercisedEvent]
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters an exercised
@@ -741,8 +745,8 @@ class AIOPartyClient(PartyClient):
             self._impl.add_event_handler(key, handler, None, self)
 
     def ledger_archived(
-        self, template: Any, match: "Optional[ContractMatch]" = None
-    ) -> "AEventHandlerDecorator[ContractArchiveEvent]":
+        self, template: Any, match: Optional[ContractMatch] = None
+    ) -> AEventHandlerDecorator[ContractArchiveEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` encounters
         a newly archived contract instance of a template.
@@ -754,8 +758,8 @@ class AIOPartyClient(PartyClient):
         """
 
         def _register_archived(
-            cb: "AEventHandler[ContractArchiveEvent]",
-        ) -> "AEventHandler[ContractArchiveEvent]":
+            cb: AEventHandler[ContractArchiveEvent],
+        ) -> AEventHandler[ContractArchiveEvent]:
             self.add_ledger_archived(template, match=match, handler=cb)
             return cb
 
@@ -764,8 +768,8 @@ class AIOPartyClient(PartyClient):
     def add_ledger_archived(
         self,
         template: Any,
-        handler: "AEventHandler[ContractArchiveEvent]",
-        match: "Optional[ContractMatch]" = None,
+        handler: AEventHandler[ContractArchiveEvent],
+        match: Optional[ContractMatch] = None,
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly archived
@@ -787,10 +791,10 @@ class AIOPartyClient(PartyClient):
 
     def submit(
         self,
-        commands: "EventHandlerResponse",
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
-    ) -> "Awaitable[None]":
+        commands: EventHandlerResponse,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
+    ) -> Awaitable[None]:
         """
         Submit commands to the ledger.
 
@@ -813,10 +817,10 @@ class AIOPartyClient(PartyClient):
     def submit_create(
         self,
         template_name: str,
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
-    ) -> "Awaitable[None]":
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
+    ) -> Awaitable[None]:
         """
         Submit a single create command. Equivalent to calling :meth:`submit` with a single
         ``create``.
@@ -845,12 +849,12 @@ class AIOPartyClient(PartyClient):
 
     def submit_exercise(
         self,
-        cid: "ContractId",
+        cid: ContractId,
         choice_name: str,
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
-    ) -> "Awaitable[None]":
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
+    ) -> Awaitable[None]:
         """
         Submit a single exercise choice. Equivalent to calling :meth:`submit` with a single
         ``exercise``.
@@ -882,13 +886,13 @@ class AIOPartyClient(PartyClient):
 
     def submit_exercise_by_key(
         self,
-        template_name: "Union[str, TypeConName]",
-        contract_key: "Any",
+        template_name: Union[str, TypeConName],
+        contract_key: Any,
         choice_name: str,
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
-    ) -> "Awaitable[None]":
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
+    ) -> Awaitable[None]:
         """
         Synchronously submit a single exercise choice. Equivalent to calling :meth:`submit` with a
         single ``exercise_by_key``.
@@ -919,13 +923,13 @@ class AIOPartyClient(PartyClient):
 
     def submit_create_and_exercise(
         self,
-        template_name: "Union[str, TypeConName]",
-        arguments: "dict",
+        template_name: Union[str, TypeConName],
+        arguments: dict,
         choice_name: str,
-        choice_arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
-    ) -> "Awaitable[None]":
+        choice_arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
+    ) -> Awaitable[None]:
         """
         Synchronously submit a single create-and-exercise command. Equivalent to calling
         :meth:`submit` with a single ``create_and_exercise``.
@@ -957,15 +961,15 @@ class AIOPartyClient(PartyClient):
 
     # <editor-fold desc="Active contract set">
 
-    def find_by_id(self, cid: "Union[str, ContractId]") -> "Optional[ContractContextualData]":
+    def find_by_id(self, cid: Union[str, ContractId]) -> Optional[ContractContextualData]:
         return self._impl.find_by_id(cid)
 
     def find(
-        self, template: Any, match: "ContractMatch" = None, include_archived: bool = False
-    ) -> "ContractContextualDataCollection":
+        self, template: Any, match: ContractMatch = None, include_archived: bool = False
+    ) -> ContractContextualDataCollection:
         return self._impl.find(template, match, include_archived=include_archived)
 
-    def find_active(self, template: Any, match: "ContractMatch" = None) -> "ContractsState":
+    def find_active(self, template: Any, match: ContractMatch = None) -> ContractsState:
         """
         Immediately return data from the current active contract set.
 
@@ -987,8 +991,8 @@ class AIOPartyClient(PartyClient):
         return self._impl.find_active(template, match)
 
     def find_historical(
-        self, template: Any, match: "ContractMatch" = None
-    ) -> "ContractContextualDataCollection":
+        self, template: Any, match: ContractMatch = None
+    ) -> ContractContextualDataCollection:
         """
         Immediately return data from the current active and historical contract set as
         a contextual data collection
@@ -1011,7 +1015,7 @@ class AIOPartyClient(PartyClient):
 
     def find_one(
         self, template: Any, match: "ContractMatch" = None, timeout: float = DEFAULT_TIMEOUT_SECONDS
-    ) -> "Awaitable[Tuple[ContractId, ContractData]]":
+    ) -> Awaitable[Tuple[ContractId, ContractData]]:
         """
         Return data from the current active contract set when at least some amount of rows exist in
         the active contract set.
@@ -1033,11 +1037,11 @@ class AIOPartyClient(PartyClient):
 
     def find_nonempty(
         self,
-        template: "Any",
-        match: "ContractMatch",
+        template: Any,
+        match: ContractMatch,
         min_count: int = 1,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
-    ) -> "Awaitable[ContractsState]":
+    ) -> Awaitable[ContractsState]:
         """
         Return data from the current active contract set when at least some amount of rows exist in
         the active contract set.
@@ -1065,8 +1069,8 @@ class AIOPartyClient(PartyClient):
 
     async def ensure_dar(
         self,
-        contents: "Union[str, Path, bytes, BinaryIO]",
-        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
+        contents: Union[str, Path, bytes, BinaryIO],
+        timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that the ledger has the packages specified by the given contents (as a byte array).
@@ -1107,7 +1111,7 @@ class SimplePartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_init)
 
-    def add_ledger_init(self, handler: "EventHandler[InitEvent]") -> None:
+    def add_ledger_init(self, handler: EventHandler[InitEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has been instructed to
         begin, but before any network activity is started.
@@ -1118,13 +1122,13 @@ class SimplePartyClient(PartyClient):
         """
 
         @wraps(handler)
-        def _background_ledger_init(event: "InitEvent") -> "Awaitable[EventHandlerResponse]":
+        def _background_ledger_init(event: InitEvent) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.init():
             self._impl.add_event_handler(key, _background_ledger_init, None, self)
 
-    def ledger_ready(self) -> "EventHandlerDecorator[ReadyEvent]":
+    def ledger_ready(self) -> EventHandlerDecorator[ReadyEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` has caught
         up to the head of the ledger, but before any :meth:`ledger_create` or :meth:`ledger_archive`
@@ -1132,7 +1136,7 @@ class SimplePartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_ready)
 
-    def add_ledger_ready(self, handler: "EventHandler[ReadyEvent]") -> None:
+    def add_ledger_ready(self, handler: EventHandler[ReadyEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has caught up to the head of
         the ledger, but before any :meth:`ledger_create` or :meth:`ledger_archive` callbacks are
@@ -1144,7 +1148,7 @@ class SimplePartyClient(PartyClient):
         """
 
         @wraps(handler)
-        def _background_ledger_ready(event: "ReadyEvent") -> "Awaitable[EventHandlerResponse]":
+        def _background_ledger_ready(event: ReadyEvent) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.ready():
@@ -1152,7 +1156,7 @@ class SimplePartyClient(PartyClient):
 
     def ledger_packages_added(
         self, initial: bool = False
-    ) -> "EventHandlerDecorator[PackagesAddedEvent]":
+    ) -> EventHandlerDecorator[PackagesAddedEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` has
         detected new packages added to the ledger.
@@ -1168,7 +1172,7 @@ class SimplePartyClient(PartyClient):
         return fluentize(self.add_ledger_packages_added, initial=initial)
 
     def add_ledger_packages_added(
-        self, handler: "EventHandler[PackagesAddedEvent]", initial: bool = False
+        self, handler: EventHandler[PackagesAddedEvent], initial: bool = False
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` has detected new packages
@@ -1188,14 +1192,14 @@ class SimplePartyClient(PartyClient):
 
         @wraps(handler)
         def _background_ledger_packages_added(
-            event: "PackagesAddedEvent",
-        ) -> "Awaitable[EventHandlerResponse]":
+            event: PackagesAddedEvent,
+        ) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.packages_added(initial=initial, changed=True):
             self._impl.add_event_handler(key, _background_ledger_packages_added, None, self)
 
-    def ledger_transaction_start(self) -> "EventHandlerDecorator[TransactionStartEvent]":
+    def ledger_transaction_start(self) -> EventHandlerDecorator[TransactionStartEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` receives a
         new transaction. Called before individual :meth:`ledger_create` and :meth:`ledger_archive`
@@ -1203,7 +1207,7 @@ class SimplePartyClient(PartyClient):
         """
         return fluentize(self.add_ledger_transaction_start)
 
-    def add_ledger_transaction_start(self, handler: "EventHandler[TransactionStartEvent]") -> None:
+    def add_ledger_transaction_start(self, handler: EventHandler[TransactionStartEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` receives a new transaction.
         Called before individual :meth:`ledger_create` and :meth:`ledger_archive` callbacks.
@@ -1222,7 +1226,7 @@ class SimplePartyClient(PartyClient):
         for key in EventKey.transaction_start():
             self._impl.add_event_handler(key, _background_ledger_transaction_start, None, self)
 
-    def ledger_transaction_end(self) -> "EventHandlerDecorator[TransactionEndEvent]":
+    def ledger_transaction_end(self) -> EventHandlerDecorator[TransactionEndEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` receives a
         new transaction. Called after individual :meth:`ledger_create` and :meth:`ledger_archive`
@@ -1230,14 +1234,14 @@ class SimplePartyClient(PartyClient):
         """
 
         def _register_transaction_end(
-            cb: "EventHandler[TransactionEndEvent]",
-        ) -> "EventHandler[TransactionEndEvent]":
+            cb: EventHandler[TransactionEndEvent],
+        ) -> EventHandler[TransactionEndEvent]:
             self.add_ledger_transaction_end(cb)
             return cb
 
         return _register_transaction_end
 
-    def add_ledger_transaction_end(self, handler: "EventHandler[TransactionEndEvent]") -> None:
+    def add_ledger_transaction_end(self, handler: EventHandler[TransactionEndEvent]) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` receives a new transaction.
         Called after individual :meth:`ledger_create` and :meth:`ledger_archive` callbacks.
@@ -1249,16 +1253,16 @@ class SimplePartyClient(PartyClient):
 
         @wraps(handler)
         def _background_ledger_transaction_end(
-            event: "TransactionEndEvent",
-        ) -> "Awaitable[EventHandlerResponse]":
+            event: TransactionEndEvent,
+        ) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.transaction_end():
             self._impl.add_event_handler(key, _background_ledger_transaction_end, None, self)
 
     def ledger_created(
-        self, template: Any, match: "Optional[ContractMatch]" = None
-    ) -> "EventHandlerDecorator[ContractCreateEvent]":
+        self, template: Any, match: Optional[ContractMatch] = None
+    ) -> EventHandlerDecorator[ContractCreateEvent]:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly created
         template.
@@ -1270,8 +1274,8 @@ class SimplePartyClient(PartyClient):
         """
 
         def _register_created(
-            cb: "EventHandler[ContractCreateEvent]",
-        ) -> "EventHandler[ContractCreateEvent]":
+            cb: EventHandler[ContractCreateEvent],
+        ) -> EventHandler[ContractCreateEvent]:
             self.add_ledger_created(template, match=match, handler=cb)
             return cb
 
@@ -1279,9 +1283,9 @@ class SimplePartyClient(PartyClient):
 
     def add_ledger_created(
         self,
-        template: "Any",
-        handler: "EventHandler[ContractCreateEvent]",
-        match: "Optional[ContractMatch]" = None,
+        template: Any,
+        handler: EventHandler[ContractCreateEvent],
+        match: Optional[ContractMatch] = None,
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly created
@@ -1297,8 +1301,8 @@ class SimplePartyClient(PartyClient):
 
         @wraps(handler)
         def _background_ledger_contract_create(
-            event: "ContractCreateEvent",
-        ) -> "Awaitable[EventHandlerResponse]":
+            event: ContractCreateEvent,
+        ) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.contract_created(True, template):
@@ -1306,7 +1310,7 @@ class SimplePartyClient(PartyClient):
 
     def ledger_exercised(
         self, template: "Any", choice: str
-    ) -> "EventHandlerDecorator[ContractExercisedEvent]":
+    ) -> EventHandlerDecorator[ContractExercisedEvent]:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters an exercised
         choice event.
@@ -1318,15 +1322,15 @@ class SimplePartyClient(PartyClient):
         """
 
         def _register_exercised(
-            cb: "EventHandler[ContractExercisedEvent]",
-        ) -> "EventHandler[ContractExercisedEvent]":
+            cb: EventHandler[ContractExercisedEvent],
+        ) -> EventHandler[ContractExercisedEvent]:
             self.add_ledger_exercised(template, choice, handler=cb)
             return cb
 
         return _register_exercised
 
     def add_ledger_exercised(
-        self, template: Any, choice: str, handler: "EventHandler[ContractExercisedEvent]"
+        self, template: Any, choice: str, handler: EventHandler[ContractExercisedEvent]
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters an exercised
@@ -1350,8 +1354,8 @@ class SimplePartyClient(PartyClient):
             self._impl.add_event_handler(key, _background_ledger_contract_exercised, None, self)
 
     def ledger_archived(
-        self, template: "Any", match: "Optional[ContractMatch]" = None
-    ) -> "EventHandlerDecorator[ContractArchiveEvent]":
+        self, template: Any, match: Optional[ContractMatch] = None
+    ) -> EventHandlerDecorator[ContractArchiveEvent]:
         """
         Decorator for registering a callback to be invoked when the :class:`PartyClient` encounters
         a newly archived contract instance of a template.
@@ -1363,8 +1367,8 @@ class SimplePartyClient(PartyClient):
         """
 
         def _register_archived(
-            cb: "EventHandler[ContractArchiveEvent]",
-        ) -> "EventHandler[ContractArchiveEvent]":
+            cb: EventHandler[ContractArchiveEvent],
+        ) -> EventHandler[ContractArchiveEvent]:
             self.add_ledger_archived(template, match=match, handler=cb)
             return cb
 
@@ -1372,9 +1376,9 @@ class SimplePartyClient(PartyClient):
 
     def add_ledger_archived(
         self,
-        template: "Any",
-        handler: "EventHandler[ContractArchiveEvent]",
-        match: "Optional[ContractMatch]" = None,
+        template: Any,
+        handler: EventHandler[ContractArchiveEvent],
+        match: Optional[ContractMatch] = None,
     ) -> None:
         """
         Register a callback to be invoked when the :class:`PartyClient` encounters a newly archived
@@ -1390,8 +1394,8 @@ class SimplePartyClient(PartyClient):
 
         @wraps(handler)
         def _background_ledger_contract_archived(
-            event: "ContractArchiveEvent",
-        ) -> "Awaitable[EventHandlerResponse]":
+            event: ContractArchiveEvent,
+        ) -> Awaitable[EventHandlerResponse]:
             return self._impl.invoker.run_in_executor(lambda: handler(event))
 
         for key in EventKey.contract_archived(True, template):
@@ -1404,8 +1408,8 @@ class SimplePartyClient(PartyClient):
     def submit(
         self,
         commands,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
     ) -> None:
         """
         Submit commands to the ledger.
@@ -1430,10 +1434,10 @@ class SimplePartyClient(PartyClient):
 
     def submit_create(
         self,
-        template_name: "Union[str, TypeConName]",
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
+        template_name: Union[str, TypeConName],
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
     ) -> None:
         """
         Synchronously submit a single create command. Equivalent to calling :meth:`submit` with a
@@ -1460,11 +1464,11 @@ class SimplePartyClient(PartyClient):
 
     def submit_exercise(
         self,
-        cid: "ContractId",
+        cid: ContractId,
         choice_name: str,
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
     ) -> None:
         """
         Synchronously submit a single exercise choice. Equivalent to calling :meth:`submit` with a
@@ -1494,12 +1498,12 @@ class SimplePartyClient(PartyClient):
 
     def submit_exercise_by_key(
         self,
-        template_name: "Union[str, TypeConName]",
-        contract_key: "Any",
+        template_name: Union[str, TypeConName],
+        contract_key: Any,
         choice_name: str,
-        arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
+        arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
     ) -> None:
         """
         Synchronously submit a single exercise choice. Equivalent to calling :meth:`submit` with a
@@ -1531,12 +1535,12 @@ class SimplePartyClient(PartyClient):
 
     def submit_create_and_exercise(
         self,
-        template_name: "Union[str, TypeConName]",
-        arguments: "dict",
+        template_name: Union[str, TypeConName],
+        arguments: dict,
         choice_name: str,
-        choice_arguments: "Optional[dict]" = None,
-        workflow_id: "Optional[str]" = None,
-        deduplication_time: "Optional[TimeDeltaLike]" = None,
+        choice_arguments: Optional[dict] = None,
+        workflow_id: Optional[str] = None,
+        deduplication_time: Optional[TimeDeltaLike] = None,
     ) -> None:
         """
         Synchronously submit a single create-and-exercise command. Equivalent to calling
@@ -1569,12 +1573,12 @@ class SimplePartyClient(PartyClient):
 
     # <editor-fold desc="Active contract set">
 
-    def find_by_id(self, cid: "Union[str, ContractId]") -> "Optional[ContractContextualData]":
+    def find_by_id(self, cid: Union[str, ContractId]) -> Optional[ContractContextualData]:
         return self._impl.invoker.run_in_loop(lambda: self._impl.find_by_id(cid))
 
     def find(
         self, template: Any, match: ContractMatch = None, include_archived: bool = False
-    ) -> "ContractContextualDataCollection":
+    ) -> ContractContextualDataCollection:
         return self._impl.invoker.run_in_loop(
             lambda: self._impl.find(template, match, include_archived=include_archived)
         )
@@ -1684,8 +1688,8 @@ class SimplePartyClient(PartyClient):
 
     def ensure_dar(
         self,
-        contents: "Union[str, Path, bytes, BinaryIO]",
-        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
+        contents: Union[str, Path, bytes, BinaryIO],
+        timeout: TimeDeltaLike = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that the ledger has the packages specified by the given contents (as a byte array).

--- a/python/dazl/client/state.py
+++ b/python/dazl/client/state.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from asyncio import Future, sleep
+from __future__ import annotations
+
+from asyncio import Future, get_event_loop, sleep
 from collections import defaultdict
 from dataclasses import dataclass
 import datetime
@@ -31,7 +33,7 @@ ContractsHistoricalState = Dict[ContractId, Tuple[ContractData, bool]]
 
 
 class ContractContextualDataCollection(tuple):
-    def __getitem__(self, index: "Union[int, str, ContractId]"):
+    def __getitem__(self, index: Union[int, str, ContractId]):
         if index is None:
             raise ValueError("the index cannot be None")
         elif isinstance(index, int):
@@ -52,15 +54,15 @@ class ContractContextualDataCollection(tuple):
 
 @dataclass(frozen=True)
 class ContractContextualData:
-    cid: "ContractId"
-    cdata: "Optional[ContractData]"
+    cid: ContractId
+    cdata: Optional[ContractData]
     effective_at: datetime
-    archived_at: "Optional[datetime]"
+    archived_at: Optional[datetime]
     active: bool
 
 
 class ActiveContractSet:
-    def __init__(self, invoker: "Invoker", lookup: "SymbolLookup"):
+    def __init__(self, invoker: Optional[Invoker], lookup: SymbolLookup):
         self.invoker = invoker
         self.lookup = lookup
         self._tcdata = defaultdict(
@@ -73,7 +75,7 @@ class ActiveContractSet:
     def handle_archive(self, event: ContractArchiveEvent) -> None:
         self._tcdata[event.cid.value_type].handle_archive(event)
 
-    def get(self, cid: "Union[str, ContractId]") -> "Optional[ContractContextualData]":
+    def get(self, cid: Union[str, ContractId]) -> Optional[ContractContextualData]:
         """
         Return information for the associated :class:`ContractId`.
 
@@ -105,7 +107,7 @@ class ActiveContractSet:
 
     async def read_async(
         self, template_name: str, match: ContractMatch = None, min_count: int = 1
-    ) -> "ContractsState":
+    ) -> ContractsState:
         from .. import LOG
 
         # Fetch matching names; we may need to wait for a package to be fetched in order to do this.
@@ -149,7 +151,7 @@ class ActiveContractSet:
 
         return await await_then(query.future, lambda cxds: {cxd.cid: cxd.cdata for cxd in cxds})
 
-    def _get_template_state(self, template_name: str) -> "Dict[TypeConName, TemplateContractData]":
+    def _get_template_state(self, template_name: str) -> Dict[TypeConName, TemplateContractData]:
         names = self.lookup.template_names(template_name)
         if not names:
             warnings.warn(
@@ -188,27 +190,31 @@ class TemplateContractData:
             active=False,
         )
 
-    def get(self, cid: "Union[str, ContractId]") -> "Optional[ContractContextualData]":
+    def get(self, cid: Union[str, ContractId]) -> Optional[ContractContextualData]:
         if isinstance(cid, ContractId):
             cid = cid.value
         return self._data.get(cid)
 
     def subset(
-        self, match: "ContractMatch", include_archived: bool
-    ) -> "Collection[ContractContextualData]":
+        self, match: ContractMatch, include_archived: bool
+    ) -> Collection[ContractContextualData]:
         return [
             cxd
             for cxd in self._data.values()
             if (include_archived or cxd.active) and is_match(match, cxd.cdata)
         ]
 
-    def register_query(self, query: "PendingQuery") -> None:
+    def register_query(self, query: PendingQuery) -> None:
         self._queries.append(query)
 
 
 class PendingQuery:
-    def __init__(self, invoker: "Invoker", match, min_count: int):
-        self.future = invoker.create_future()  # type: Awaitable[Collection[ContractContextualData]]
+    future: Awaitable[Collection[ContractContextualData]]
+
+    def __init__(self, invoker: Optional[Invoker], match, min_count: int):
+        self.future = (
+            invoker.create_future() if invoker is not None else get_event_loop().create_future()
+        )
         self.match = match
         self.min_count = min_count
 

--- a/python/dazl/query/__init__.py
+++ b/python/dazl/query/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 __all__ = ["ContractMatch", "is_match"]
 

--- a/python/dazl/query/query.py
+++ b/python/dazl/query/query.py
@@ -1,16 +1,18 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
-from typing import Callable, Union
+from typing import Any, Callable, Mapping, Union
 
 from ..prim import ContractData
 
-__all__ = ["ContractMatch", "is_match"]
+__all__ = ["ContractMatch", "is_match", "Query"]
 
 ContractMatch = Union[None, Callable[[ContractData], bool], ContractData]
+Query = Mapping[str, Any]
 
 
-def is_match(predicate: "ContractMatch", cdata: "ContractData") -> bool:
+def is_match(predicate: ContractMatch, cdata: ContractData) -> bool:
     """
     Determine whether a contract matches a predicate expression.
     """


### PR DESCRIPTION
`from __future__ import annotations` (available in Python 3.7) enables type forward references to work, which means the quotes are finally no longer needed around type annotations in the dazl codebase.