### PR TITLE
python: Typing fixes to some dazl packages

### DIFF
--- a/python/dazl/__init__.py
+++ b/python/dazl/__init__.py
@@ -66,7 +66,9 @@ def _get_version() -> str:
             poetry_section = config["tool.poetry"]
             return literal_eval(poetry_section["version"])
     except Exception:  # noqa
-        return "unknown"
+        pass
+
+    return "unknown"
 
 
 __version__ = _get_version()

--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     Awaitable,
     Collection,
+    Dict,
     List,
     Optional,
     Sequence,
@@ -50,6 +51,7 @@ from ..model.reading import (
 from ..model.writing import CommandBuilder, CommandDefaults, CommandPayload, EventHandlerResponse
 from ..prim import TimeDeltaLike, to_timedelta
 from ..protocols import LedgerClient, LedgerNetwork
+from ..scheduler import Invoker
 from ..util.asyncio_util import ServiceQueue, completed, named_gather
 from ..util.prim_natural import n_things
 from ..util.typing import safe_cast
@@ -70,10 +72,10 @@ class _PartyClientImpl:
     def __init__(self, parent: "_NetworkImpl", party: "Party"):
         self.parent = parent
         self.metrics = parent._metrics
-        self.invoker = parent.invoker
-        self.party = party
+        self.invoker = parent.invoker  # type: Invoker
+        self.party = party  # type: Party
 
-        self._config_values = dict()
+        self._config_values = dict()  # type: Dict[str, Any]
         self._config = None  # type: Optional[NetworkConfig]
         self._pool = None  # type: Optional[LedgerNetwork]
         self._pool_fut = None  # type: Optional[Awaitable[LedgerNetwork]]
@@ -177,7 +179,9 @@ class _PartyClientImpl:
         """
         return self.bots.notify(data)
 
-    async def emit_ready(self, metadata: LedgerMetadata, time: datetime, offset: str) -> None:
+    async def emit_ready(
+        self, metadata: LedgerMetadata, time: "Optional[datetime]", offset: "Optional[str]"
+    ) -> None:
         """
         Emit a ready event specific to this client. This may also emit initial create events and
         initial package added events.

--- a/python/dazl/client/_run_level.py
+++ b/python/dazl/client/_run_level.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from threading import Event
 
-from ..model.core import RunLevel
+from ..scheduler import RunLevel
+
+__all__ = ["RunState"]
 
 
 class RunState:

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -38,6 +38,7 @@ import warnings
 
 from .. import LOG
 from ..damlast import get_dar_package_ids
+from ..damlast.daml_lf_1 import PackageRef
 from ..damlast.protocols import SymbolLookup
 from ..metrics import MetricEvents
 from ..model.core import (
@@ -237,7 +238,7 @@ class Network:
 
         :param party: The party to get a client for.
         """
-        return self._impl.party_impl(to_party(party), SimplePartyClient)
+        return self._impl.party_impl_wrapper(to_party(party), SimplePartyClient)
 
     def simple_new_party(self) -> "SimplePartyClient":
         """
@@ -252,7 +253,7 @@ class Network:
 
         :param party: The party to get a client for.
         """
-        return self._impl.party_impl(Party(party), AIOPartyClient)
+        return self._impl.party_impl_wrapper(Party(party), AIOPartyClient)
 
     def aio_new_party(self) -> "AIOPartyClient":
         """
@@ -318,6 +319,8 @@ class Network:
                 stacklevel=2,
             )
             return self._main_fut
+        else:
+            return None
 
     def join(self, timeout: "Optional[float]" = None) -> None:
         """
@@ -454,7 +457,9 @@ class AIOGlobalClient(GlobalClient):
         return await self._impl.upload_package(raw_bytes, timeout)
 
     async def ensure_packages(
-        self, package_ids: "Collection[str]", timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS
+        self,
+        package_ids: "Collection[PackageRef]",
+        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that packages with the specified package IDs exist on the ledger. Throw an
@@ -489,7 +494,9 @@ class SimpleGlobalClient(GlobalClient):
         return self._impl.invoker.run_in_loop(lambda: self._impl.upload_package(raw_bytes, timeout))
 
     def ensure_packages(
-        self, package_ids: "Collection[str]", timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS
+        self,
+        package_ids: "Collection[PackageRef]",
+        timeout: "TimeDeltaLike" = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         """
         Validate that packages with the specified package IDs exist on the ledger. Throw an

--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
 from abc import abstractmethod
 from asyncio import Future, InvalidStateError, ensure_future, gather, get_event_loop
 from collections import defaultdict
@@ -27,6 +26,7 @@ from typing import (
     overload,
 )
 from uuid import uuid4
+import warnings
 
 from .. import LOG
 from ..model.core import Party, SourceLocation
@@ -130,7 +130,10 @@ class Bot:
         """
         # noinspection PyBroadException
         try:
-            self._signal = Signal()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                # noinspection PyDeprecation
+                self._signal = Signal()
             while self._run_level != _BotRunLevel.TERMINATE:
                 # the main queue contains either events we have not yet processed yet or ``None``
                 # markers that merely indicate running status should be "re-checked"
@@ -317,12 +320,10 @@ class BotCollection(Sequence[Bot]):
             return len(self._bots)
 
     @overload
-    @abstractmethod
     def __getitem__(self, i: int) -> Bot:
         ...
 
     @overload
-    @abstractmethod
     def __getitem__(self, s: slice) -> Sequence[Bot]:
         ...
 

--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -5,9 +5,25 @@
 This module contains configuration parameters used by the rest of the library.
 """
 
+# We override types in this file LOTS because mypy does not understand what is happening
+# with the ``config_field`` function. There doesn't appear to be a way to describe
+# a dataclasses-like ``field`` function, which is why this config will be dropped
+# in dazl 8's API.
+
 import argparse
 from dataclasses import asdict, dataclass, field, fields
-from typing import TYPE_CHECKING, Any, Collection, List, Mapping, Optional, Sequence, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    no_type_check,
+)
 import warnings
 
 from .. import LOG
@@ -49,7 +65,7 @@ class URLConfig:
     Configuration for something that requires a URL.
     """
 
-    url: str = config_field(
+    url: str = config_field(  # type: ignore
         "URL where the Ledger API is hosted",
         param_type=URL_TYPE,
         short_alias="u",
@@ -57,51 +73,53 @@ class URLConfig:
         deprecated_alias="participant_url",
     )
 
-    ca_file: Optional[str] = config_field(
+    ca_file: Optional[str] = config_field(  # type: ignore
         "server certificate authority file", param_type=PATH_TYPE, default_value=None
     )
 
-    cert_file: Optional[str] = config_field("client certificate file", param_type=PATH_TYPE)
+    cert_file: Optional[str] = config_field(  # type: ignore
+        "client certificate file", param_type=PATH_TYPE
+    )
 
-    cert_key_file: Optional[str] = config_field(
+    cert_key_file: Optional[str] = config_field(  # type: ignore
         "client certificate and key file", param_type=PATH_TYPE
     )
 
-    verify_ssl: Optional[str] = config_field(
+    verify_ssl: Optional[str] = config_field(  # type: ignore
         "level of verification to use for SSL", param_type=VERIFY_SSL_TYPE
     )
 
-    poll_interval: Optional[float] = config_field(
+    poll_interval: Optional[float] = config_field(  # type: ignore
         "polling interval for receiving new events", param_type=SECONDS_TYPE, default_value=0.1
     )
 
-    connect_timeout: Optional[float] = config_field(
+    connect_timeout: Optional[float] = config_field(  # type: ignore
         "number of seconds before giving up on a connection",
         param_type=SECONDS_TYPE,
         default_value=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
 
-    eager_package_fetch: Optional[bool] = config_field(
+    eager_package_fetch: Optional[bool] = config_field(  # type: ignore
         "whether to fetch all packages on startup", param_type=BOOLEAN_TYPE, default_value=True
     )
 
-    enable_http_proxy: Optional[bool] = config_field(
+    enable_http_proxy: Optional[bool] = config_field(  # type: ignore
         "whether to allow the use of HTTP proxies", param_type=BOOLEAN_TYPE, default_value=True
     )
 
-    package_lookup_timeout: Optional[float] = config_field(
+    package_lookup_timeout: Optional[float] = config_field(  # type: ignore
         "number of seconds before giving up on a package",
         param_type=SECONDS_TYPE,
         default_value=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
 
-    application_name: Optional[str] = config_field(
+    application_name: Optional[str] = config_field(  # type: ignore
         "The name that this application uses to identify itself to the ledger.",
         param_type=STRING_TYPE,
         default_value="DAZL-Client",
     )
 
-    log_level: Optional[int] = config_field(
+    log_level: Optional[int] = config_field(  # type: ignore
         "logging level for events for this party",
         param_type=LOG_LEVEL_TYPE,
         environment_variable="DAZL_LOG_LEVEL",
@@ -115,25 +133,25 @@ class _PartyConfig(URLConfig):
     Configuration for a specific party's client.
     """
 
-    max_event_block_size: Optional[int] = config_field(
+    max_event_block_size: Optional[int] = config_field(  # type: ignore
         "Maximum number of blocks to read in a single call.",
         param_type=COUNT_TYPE,
         default_value=100,
     )
 
-    max_command_batch_size: Optional[int] = config_field(
+    max_command_batch_size: Optional[int] = config_field(  # type: ignore
         "Maximum number of commands to batch up in a single transaction",
         param_type=COUNT_TYPE,
         default_value=100,
     )
 
-    max_command_batch_timeout: Optional[float] = config_field(
+    max_command_batch_timeout: Optional[float] = config_field(  # type: ignore
         "Maximum number of seconds to wait before sending out a command",
         param_type=SECONDS_TYPE,
         default_value=0.25,
     )
 
-    party_groups: Optional[Collection[str]] = config_field(
+    party_groups: Optional[Collection[str]] = config_field(  # type: ignore
         "comma-separated list of broadcast parties", param_type=PARTIES_TYPE
     )
 
@@ -148,100 +166,108 @@ class _NetworkConfig(URLConfig):
     their own URL.
     """
 
-    log_level: Optional[int] = config_field(
+    log_level: Optional[int] = config_field(  # type: ignore
         "logging level for events for this party",
         param_type=LOG_LEVEL_TYPE,
         environment_variable="DAZL_LOG_LEVEL",
         short_alias="l",
     )
 
-    max_connection_count: Optional[int] = config_field(
+    max_connection_count: Optional[int] = config_field(  # type: ignore
         "Number of concurrent HTTP connections to have outstanding.",
         param_type=COUNT_TYPE,
         default_value=20,
     )
 
-    quiet_timeout: Optional[float] = config_field(
+    quiet_timeout: Optional[float] = config_field(  # type: ignore
         'Number of seconds to wait after the client "thinks" it\'s done to hang around for',
         param_type=SECONDS_TYPE,
         default_value=1,
     )
 
-    use_acs_service: bool = config_field(
+    use_acs_service: bool = config_field(  # type: ignore
         "Use Active Contract Set service instead of reading from the Transaction event stream",
         param_type=BOOLEAN_TYPE,
         default_value=True,
     )
 
-    idle_timeout: Optional[float] = config_field(
+    idle_timeout: Optional[float] = config_field(  # type: ignore
         "Maximum number of seconds of idle activity before automatically closing the client",
         param_type=SECONDS_TYPE,
         default_value=120,
     )
 
-    max_consequence_depth: Optional[int] = config_field(
+    max_consequence_depth: Optional[int] = config_field(  # type: ignore
         "The maximum number of times to wait for all parties to arrive at the same offset"
         + "before failing with an error",
         param_type=COUNT_TYPE,
         default_value=50,
     )
 
-    party_groups: Optional[Collection[str]] = config_field(
+    party_groups: Optional[Collection[str]] = config_field(  # type: ignore
         "comma-separated list of broadcast parties", param_type=PARTIES_TYPE
     )
 
-    package_ids: Optional[Collection[str]] = config_field(
+    package_ids: Optional[Collection[str]] = config_field(  # type: ignore
         "comma-separated list of package IDs to listen on", param_type=PACKAGE_IDS_TYPE
     )
 
-    server_host: Optional[str] = config_field(
+    server_host: Optional[str] = config_field(  # type: ignore
         "Server listening host. Used for OAuth web application flow callbacks.",
         param_type=STRING_TYPE,
         environment_variable="DAZL_SERVER_HOST",
     )
 
-    server_port: Optional[int] = config_field(
+    server_port: Optional[int] = config_field(  # type: ignore
         "Server listening port. Used for OAuth web application flow callbacks.",
         param_type=PORT_TYPE,
         environment_variable="DAZL_SERVER_PORT",
     )
 
-    oauth_client_id: Optional[str] = config_field("OAuth client ID", param_type=STRING_TYPE)
+    oauth_client_id: Optional[str] = config_field(  # type: ignore
+        "OAuth client ID", param_type=STRING_TYPE
+    )
 
-    oauth_client_secret: Optional[str] = config_field(
+    oauth_client_secret: Optional[str] = config_field(  # type: ignore
         "OAuth client secret (implies web application flow or backend application flow)",
         param_type=STRING_TYPE,
     )
 
-    oauth_token: Optional[str] = config_field("OAuth token", param_type=STRING_TYPE)
+    oauth_token: Optional[str] = config_field("OAuth token", param_type=STRING_TYPE)  # type: ignore
 
-    oauth_refresh_token: Optional[str] = config_field("OAuth refresh token", param_type=STRING_TYPE)
+    oauth_refresh_token: Optional[str] = config_field(  # type: ignore
+        "OAuth refresh token", param_type=STRING_TYPE
+    )
 
-    oauth_id_token: Optional[str] = config_field(
+    oauth_id_token: Optional[str] = config_field(  # type: ignore
         "OpenID token (JWT formatted)", param_type=STRING_TYPE
     )
 
-    oauth_token_uri: Optional[str] = config_field("OAuth token URL", param_type=STRING_TYPE)
+    oauth_token_uri: Optional[str] = config_field(  # type: ignore
+        "OAuth token URL", param_type=STRING_TYPE
+    )
 
-    oauth_redirect_uri: Optional[str] = config_field(
+    oauth_redirect_uri: Optional[str] = config_field(  # type: ignore
         "OAuth redirect URI (implies web application flow)", param_type=STRING_TYPE
     )
 
-    oauth_auth_url: Optional[str] = config_field(
+    oauth_auth_url: Optional[str] = config_field(  # type: ignore
         "OAuth auth URL (implies mobile application flow)", param_type=STRING_TYPE
     )
 
-    oauth_ca_file: Optional[str] = config_field("OAuth CA CA Bundle File", param_type=STRING_TYPE)
+    oauth_ca_file: Optional[str] = config_field(  # type: ignore
+        "OAuth CA CA Bundle File", param_type=STRING_TYPE
+    )
 
-    oauth_audience: Optional[str] = config_field(
+    oauth_audience: Optional[str] = config_field(  # type: ignore
         "OAuth audience (Implies Client Credentials Flow)", param_type=STRING_TYPE
     )
 
-    oauth_legacy_username: Optional[str] = config_field(
+    oauth_legacy_username: Optional[str] = config_field(  # type: ignore
         "OAuth username (implies legacy application flow)", param_type=STRING_TYPE
     )
 
-    oauth_legacy_password: Optional[str] = config_field(
+    oauth_legacy_password: Optional[str] = config_field(  # type: ignore
         "OAuth password (implies legacy application flow)", param_type=STRING_TYPE
     )
 
@@ -256,7 +282,7 @@ class _FlatConfig(_NetworkConfig, _PartyConfig):
     from environment variables or command-line arguments.
     """
 
-    parties: Collection[Party] = config_field(
+    parties: Collection[Party] = config_field(  # type: ignore
         "comma-separated list of parties serviced by a participant node",
         param_type=PARTIES_TYPE,
         long_alias="party",
@@ -329,6 +355,7 @@ class NetworkConfig(_NetworkConfig, _TopLevelConfig):
     parties: "Sequence[PartyConfig]" = field(default_factory=tuple)
 
     @classmethod
+    @no_type_check
     def unflatten(cls, config: "_FlatConfig") -> "NetworkConfig":
         """
         Convert a :class:`_FlatConfig` to a :class:`NetworkConfig`.
@@ -361,6 +388,7 @@ class AnonymousNetworkConfig(_NetworkConfig, _TopLevelConfig):
     """
 
     @classmethod
+    @no_type_check
     def unflatten(cls, config: "_FlatConfig") -> "AnonymousNetworkConfig":
         """
         Convert a :class:`_FlatConfig` to a :class:`NetworkConfig`.
@@ -422,6 +450,7 @@ def configure_parser(
     return arg_parser
 
 
+@no_type_check
 def fetch_config(path_or_url: "Optional[str]") -> "Optional[str]":
     """
     Attempts to fetch a config file from what looks like either a path or a URL.
@@ -470,7 +499,10 @@ def _get_env_defaults() -> "Mapping[str, Any]":
         if param.environment_variable:
             value = getenv(param.environment_variable)
             if value:
-                kwargs[fld.name] = param.param_type.value_ctor(value)
+                if param.param_type is not None:
+                    kwargs[fld.name] = param.param_type.value_ctor(value)
+                else:
+                    raise RuntimeError("configuration error")
     return kwargs
 
 
@@ -485,6 +517,7 @@ def _parse_args_ns(args: "argparse.Namespace") -> "Mapping[str, Any]":
     }
 
 
+@no_type_check
 def _parse_args_dict(d: "Mapping[str, Any]") -> "Mapping[str, Any]":
     """
     Convert the key-value pairs in this mapping to keys that are defined on :class:`_FlatConfig`.

--- a/python/dazl/damlast/_builtins_meta.py
+++ b/python/dazl/damlast/_builtins_meta.py
@@ -6,7 +6,7 @@ This module contains supporting infrastructure for built-in method definitions f
 DAML-LF files.
 """
 
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Sequence, Type as PyType, Union
 import warnings
 
 from .daml_lf_1 import BuiltinFunction, Expr, Type, ValName
@@ -47,16 +47,16 @@ class Builtin(metaclass=_BuiltinMeta):
     def evaluate(self, type_args: "Sequence[Type]", args: "Sequence[Any]") -> "Any":
         raise NotImplementedError()
 
-    def simplify(self, type_args: "Sequence[Type]", args: "Sequence[Expr]") -> "Expr":
+    def simplify(self, type_args: "Sequence[Type]", args: "Sequence[Expr]") -> "Optional[Expr]":
         raise NotImplementedError()
 
 
 class BuiltinTable:
     def __init__(self):
-        self.by_name = dict()
-        self.by_builtin = dict()
+        self.by_name = dict()  # type: [BuiltinFunction, PyType[Builtin]]
+        self.by_builtin = dict()  # type: [str, PyType[Builtin]]
 
-    def add(self, builtin: Builtin):
+    def add(self, builtin: "PyType[Builtin]"):
         if builtin.builtin is not None:
             self.by_builtin[builtin.builtin] = builtin
         elif builtin.name is not None:

--- a/python/dazl/damlast/builtins.py
+++ b/python/dazl/damlast/builtins.py
@@ -37,6 +37,7 @@ class Concat(Builtin):
             return xxs.cons.front[0]
         if xxs.nil is not None:
             return Expr(nil=Expr.Nil(xxs.nil.type.prim.args[0]))
+        return None
 
 
 @builtins.add
@@ -59,6 +60,9 @@ class AppendText(Builtin):
     def evaluate(self, _: "Sequence[Type]", args: "Sequence[Any]") -> "Any":
         return args[0] + args[1]
 
-    def simplify(self, _: "Sequence[Type]", args: "Sequence[Expr]") -> "Expr":
+    def simplify(self, _: "Sequence[Type]", args: "Sequence[Expr]") -> "Optional[Expr]":
         if args[0].prim_lit is not None and args[1].prim_lit is not None:
-            return Expr(prim_lit=PrimLit(text=args[0].prim_lit.text + args[1].prim_lit.text))
+            return Expr(
+                prim_lit=PrimLit(text=(args[0].prim_lit.text or "") + (args[1].prim_lit.text or ""))
+            )
+        return None

--- a/python/dazl/damlast/compat.py
+++ b/python/dazl/damlast/compat.py
@@ -70,5 +70,7 @@ def parse_template(
                 )
 
             return template_id.name.con, DeprecatedTypeReference(template_id.name.con)
+        else:
+            raise ValueError("unknown dazl.model.types.Type implementation")
     else:
         raise ValueError("template_id must be a TypeConName")

--- a/python/dazl/damlast/daml_lf_1.py
+++ b/python/dazl/damlast/daml_lf_1.py
@@ -21,9 +21,9 @@ DAML-LF Archive types
 from dataclasses import dataclass
 from enum import Enum
 from io import StringIO
-from typing import Callable, NewType, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, NewType, Optional, Sequence, Tuple, Union
 
-from ._base import MISSING, T
+from ._base import MISSING, T, _Missing
 
 __all__ = [
     "Archive",
@@ -298,7 +298,9 @@ class Binding:
 
 
 class Kind:
-    __slots__ = ("_Sum_name", "_Sum_value")
+    __slots__ = "_Sum_name", "_Sum_value"
+    _Sum_name: str
+    _Sum_value: Any
 
     class Arrow:
         params: "Sequence[Kind]"
@@ -308,7 +310,12 @@ class Kind:
             self.params = params
             self.result = result
 
-    def __init__(self, star: "Unit" = MISSING, arrow: "Arrow" = MISSING, nat: "Unit" = MISSING):
+    def __init__(
+        self,
+        star: "Union[Unit, _Missing]" = MISSING,
+        arrow: "Union[Arrow, _Missing]" = MISSING,
+        nat: "Union[Unit, _Missing]" = MISSING,
+    ):
         if star is not MISSING:
             object.__setattr__(self, "_Sum_name", "star")
             object.__setattr__(self, "_Sum_value", star)
@@ -421,16 +428,18 @@ class Type:
         args: "Sequence[Type]"
 
     __slots__ = "_Sum_name", "_Sum_value"
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        var: "Type.Var" = MISSING,
-        con: "Type.Con" = MISSING,
-        prim: "Type.Prim" = MISSING,
-        forall: "Type.Forall" = MISSING,
-        tuple: "Type.Tuple" = MISSING,
-        nat: int = MISSING,
-        syn: "Type.Syn" = MISSING,
+        var: "Union[Type.Var, _Missing]" = MISSING,
+        con: "Union[Type.Con, _Missing]" = MISSING,
+        prim: "Union[Type.Prim, _Missing]" = MISSING,
+        forall: "Union[Type.Forall, _Missing]" = MISSING,
+        tuple: "Union[Type.Tuple, _Missing]" = MISSING,
+        nat: "Union[int, _Missing]" = MISSING,
+        syn: "Union[Type.Syn, _Missing]" = MISSING,
     ):
         if var is not MISSING:
             object.__setattr__(self, "_Sum_name", "var")
@@ -546,17 +555,19 @@ class Type:
 
 
 class PrimLit:
-    __slots__ = ("_Sum_name", "_Sum_value")
+    __slots__ = "_Sum_name", "_Sum_value"
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        int64: int = MISSING,
-        decimal: str = MISSING,
-        text: str = MISSING,
-        timestamp: float = MISSING,
-        party: str = MISSING,
-        date: int = MISSING,
-        numeric: str = MISSING,
+        int64: "Union[int, _Missing]" = MISSING,
+        decimal: "Union[str, _Missing]" = MISSING,
+        text: "Union[str, _Missing]" = MISSING,
+        timestamp: "Union[float, _Missing]" = MISSING,
+        party: "Union[str, _Missing]" = MISSING,
+        date: "Union[int, _Missing]" = MISSING,
+        numeric: "Union[str, _Missing]" = MISSING,
     ):
         if int64 is not MISSING:
             object.__setattr__(self, "_Sum_name", "int64")
@@ -656,7 +667,11 @@ class Location:
     module: "ModuleRef"
     range: "Range"
 
-    def __init__(self, module: "ModuleRef" = MISSING, range: "Range" = MISSING):
+    def __init__(
+        self,
+        module: "Union[ModuleRef, _Missing]" = MISSING,
+        range: "Union[Range, _Missing]" = MISSING,
+    ):
         object.__setattr__(self, "module", module)
         object.__setattr__(self, "range", range)
 
@@ -852,39 +867,42 @@ class Expr:
             self.type = type
 
     __slots__ = "location", "_Sum_name", "_Sum_value"
+    location: Location
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        var: "str" = MISSING,
-        val: "ValName" = MISSING,
-        builtin: "BuiltinFunction" = MISSING,
-        prim_con: "PrimCon" = MISSING,
-        prim_lit: "PrimLit" = MISSING,
-        rec_con: "RecCon" = MISSING,
-        rec_proj: "RecProj" = MISSING,
-        variant_con: "VariantCon" = MISSING,
-        enum_con: "EnumCon" = MISSING,
-        struct_con: "StructCon" = MISSING,
-        struct_proj: "StructProj" = MISSING,
-        app: "App" = MISSING,
-        ty_app: "TyApp" = MISSING,
-        abs: "Abs" = MISSING,
-        ty_abs: "TyAbs" = MISSING,
-        case: "Case" = MISSING,
-        let: "Block" = MISSING,
-        nil: "Nil" = MISSING,
-        cons: "Cons" = MISSING,
-        update: "Update" = MISSING,
-        scenario: "Scenario" = MISSING,
-        rec_upd: "RecUpd" = MISSING,
-        struct_upd: "StructUpd" = MISSING,
-        optional_none: "OptionalNone" = MISSING,
-        optional_some: "OptionalSome" = MISSING,
-        location: "Location" = MISSING,
-        to_any: "ToAny" = MISSING,
-        from_any: "FromAny" = MISSING,
-        to_text_template_id: "ToTextTemplateId" = MISSING,
-        type_rep: "Type" = MISSING,
+        var: "Union[str, _Missing]" = MISSING,
+        val: "Union[ValName, _Missing]" = MISSING,
+        builtin: "Union[BuiltinFunction, _Missing]" = MISSING,
+        prim_con: "Union[PrimCon, _Missing]" = MISSING,
+        prim_lit: "Union[PrimLit, _Missing]" = MISSING,
+        rec_con: "Union[RecCon, _Missing]" = MISSING,
+        rec_proj: "Union[RecProj, _Missing]" = MISSING,
+        variant_con: "Union[VariantCon, _Missing]" = MISSING,
+        enum_con: "Union[EnumCon, _Missing]" = MISSING,
+        struct_con: "Union[StructCon, _Missing]" = MISSING,
+        struct_proj: "Union[StructProj, _Missing]" = MISSING,
+        app: "Union[App, _Missing]" = MISSING,
+        ty_app: "Union[TyApp, _Missing]" = MISSING,
+        abs: "Union[Abs, _Missing]" = MISSING,
+        ty_abs: "Union[TyAbs, _Missing]" = MISSING,
+        case: "Union[Case, _Missing]" = MISSING,
+        let: "Union[Block, _Missing]" = MISSING,
+        nil: "Union[Nil, _Missing]" = MISSING,
+        cons: "Union[Cons, _Missing]" = MISSING,
+        update: "Union[Update, _Missing]" = MISSING,
+        scenario: "Union[Scenario, _Missing]" = MISSING,
+        rec_upd: "Union[RecUpd, _Missing]" = MISSING,
+        struct_upd: "Union[StructUpd, _Missing]" = MISSING,
+        optional_none: "Union[OptionalNone, _Missing]" = MISSING,
+        optional_some: "Union[OptionalSome, _Missing]" = MISSING,
+        location: "Union[Location, _Missing]" = MISSING,
+        to_any: "Union[ToAny, _Missing]" = MISSING,
+        from_any: "Union[FromAny, _Missing]" = MISSING,
+        to_text_template_id: "Union[ToTextTemplateId, _Missing]" = MISSING,
+        type_rep: "Union[Type, _Missing]" = MISSING,
     ):
         object.__setattr__(self, "location", location)
         if var is not MISSING:
@@ -1125,68 +1143,68 @@ class Expr:
         optional_none: "Callable[[OptionalNone], T]",
         optional_some: "Callable[[OptionalSome], T]",
         to_any: "Callable[[ToAny], T]",
-        from_any: "Callable[[ToAny], T]",
+        from_any: "Callable[[FromAny], T]",
         to_text_template_id: "Callable[[ToTextTemplateId], T]",
-        type_rep: "Callable[[Type], T",
+        type_rep: "Callable[[Type], T]",
     ) -> "T":
         if self._Sum_name == "var":
-            return var(self.var)
+            return var(self.var)  # type: ignore
         elif self._Sum_name == "val":
-            return val(self.val)
+            return val(self.val)  # type: ignore
         elif self._Sum_name == "builtin":
-            return builtin(self.builtin)
+            return builtin(self.builtin)  # type: ignore
         elif self._Sum_name == "prim_con":
-            return prim_con(self.prim_con)
+            return prim_con(self.prim_con)  # type: ignore
         elif self._Sum_name == "prim_lit":
-            return prim_lit(self.prim_lit)
+            return prim_lit(self.prim_lit)  # type: ignore
         elif self._Sum_name == "rec_con":
-            return rec_con(self.rec_con)
+            return rec_con(self.rec_con)  # type: ignore
         elif self._Sum_name == "rec_proj":
-            return rec_proj(self.rec_proj)
+            return rec_proj(self.rec_proj)  # type: ignore
         elif self._Sum_name == "variant_con":
-            return variant_con(self.variant_con)
+            return variant_con(self.variant_con)  # type: ignore
         elif self._Sum_name == "enum_con":
-            return enum_con(self.enum_con)
+            return enum_con(self.enum_con)  # type: ignore
         elif self._Sum_name == "struct_con":
-            return struct_con(self.struct_con)
+            return struct_con(self.struct_con)  # type: ignore
         elif self._Sum_name == "struct_proj":
-            return struct_proj(self.struct_proj)
+            return struct_proj(self.struct_proj)  # type: ignore
         elif self._Sum_name == "app":
-            return app(self.app)
+            return app(self.app)  # type: ignore
         elif self._Sum_name == "ty_app":
-            return ty_app(self.ty_app)
+            return ty_app(self.ty_app)  # type: ignore
         elif self._Sum_name == "abs":
-            return abs(self.abs)
+            return abs(self.abs)  # type: ignore
         elif self._Sum_name == "ty_abs":
-            return ty_abs(self.ty_abs)
+            return ty_abs(self.ty_abs)  # type: ignore
         elif self._Sum_name == "case":
-            return case(self.case)
+            return case(self.case)  # type: ignore
         elif self._Sum_name == "let":
-            return let(self.let)
+            return let(self.let)  # type: ignore
         elif self._Sum_name == "nil":
-            return nil(self.nil)
+            return nil(self.nil)  # type: ignore
         elif self._Sum_name == "cons":
-            return cons(self.cons)
+            return cons(self.cons)  # type: ignore
         elif self._Sum_name == "update":
-            return update(self.update)
+            return update(self.update)  # type: ignore
         elif self._Sum_name == "scenario":
-            return scenario(self.scenario)
+            return scenario(self.scenario)  # type: ignore
         elif self._Sum_name == "rec_upd":
-            return rec_upd(self.rec_upd)
+            return rec_upd(self.rec_upd)  # type: ignore
         elif self._Sum_name == "struct_upd":
-            return struct_upd(self.struct_upd)
+            return struct_upd(self.struct_upd)  # type: ignore
         elif self._Sum_name == "optional_none":
-            return optional_none(self.optional_none)
+            return optional_none(self.optional_none)  # type: ignore
         elif self._Sum_name == "optional_some":
-            return optional_some(self.optional_some)
+            return optional_some(self.optional_some)  # type: ignore
         elif self._Sum_name == "to_any":
-            return to_any(self.to_any)
+            return to_any(self.to_any)  # type: ignore
         elif self._Sum_name == "from_any":
-            return from_any(self.from_any)
+            return from_any(self.from_any)  # type: ignore
         elif self._Sum_name == "to_text_template_id":
-            return to_text_template_id(self.to_text_template_id)
+            return to_text_template_id(self.to_text_template_id)  # type: ignore
         elif self._Sum_name == "type_rep":
-            return type_rep(self.type_rep)
+            return type_rep(self.type_rep)  # type: ignore
         else:
             raise Exception
 
@@ -1221,18 +1239,20 @@ class CaseAlt:
 
     __slots__ = "body", "_Sum_name", "_Sum_value"
     body: "Expr"
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        default: "Unit" = MISSING,
-        variant: "Variant" = MISSING,
-        prim_con: "PrimCon" = MISSING,
-        nil: "Unit" = MISSING,
-        cons: "Cons" = MISSING,
-        optional_none: "Unit" = MISSING,
-        optional_some: "OptionalSome" = MISSING,
-        body: "Expr" = MISSING,
-        enum: "Enum" = MISSING,
+        default: "Union[Unit, _Missing]" = MISSING,
+        variant: "Union[Variant, _Missing]" = MISSING,
+        prim_con: "Union[PrimCon, _Missing]" = MISSING,
+        nil: "Union[Unit, _Missing]" = MISSING,
+        cons: "Union[Cons, _Missing]" = MISSING,
+        optional_none: "Union[Unit, _Missing]" = MISSING,
+        optional_some: "Union[OptionalSome, _Missing]" = MISSING,
+        body: "Union[Expr, _Missing]" = MISSING,
+        enum: "Union[Enum, _Missing]" = MISSING,
     ):
         object.__setattr__(self, "body", body)
         if default is not MISSING:
@@ -1305,21 +1325,21 @@ class CaseAlt:
         enum: "Callable[[Enum], T]",
     ):
         if self._Sum_name == "default":
-            return default(self.default)
+            return default(self.default)  # type: ignore
         elif self._Sum_name == "variant":
-            return variant(self.variant)
+            return variant(self.variant)  # type: ignore
         elif self._Sum_name == "prim_con":
-            return prim_con(self.prim_con)
+            return prim_con(self.prim_con)  # type: ignore
         elif self._Sum_name == "nil":
-            return nil(self.nil)
+            return nil(self.nil)  # type: ignore
         elif self._Sum_name == "cons":
-            return cons(self.cons)
+            return cons(self.cons)  # type: ignore
         elif self._Sum_name == "optional_none":
-            return optional_none(self.optional_none)
+            return optional_none(self.optional_none)  # type: ignore
         elif self._Sum_name == "optional_some":
-            return optional_some(self.optional_some)
+            return optional_some(self.optional_some)  # type: ignore
         elif self._Sum_name == "enum":
-            return enum(self.enum)
+            return enum(self.enum)  # type: ignore
         else:
             raise Exception
 
@@ -1392,18 +1412,20 @@ class Update:
             self.key = key
 
     __slots__ = "_Sum_name", "_Sum_value"
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        pure: "Pure" = MISSING,
-        block: "Block" = MISSING,
-        create: "Create" = MISSING,
-        exercise: "Exercise" = MISSING,
-        fetch: "Fetch" = MISSING,
-        get_time: "Unit" = MISSING,
-        lookup_by_key: "RetrieveByKey" = MISSING,
-        fetch_by_key: "RetrieveByKey" = MISSING,
-        embed_expr: "EmbedExpr" = MISSING,
+        pure: "Union[Pure, _Missing]" = MISSING,
+        block: "Union[Block, _Missing]" = MISSING,
+        create: "Union[Create, _Missing]" = MISSING,
+        exercise: "Union[Exercise, _Missing]" = MISSING,
+        fetch: "Union[Fetch, _Missing]" = MISSING,
+        get_time: "Union[Unit, _Missing]" = MISSING,
+        lookup_by_key: "Union[RetrieveByKey, _Missing]" = MISSING,
+        fetch_by_key: "Union[RetrieveByKey, _Missing]" = MISSING,
+        embed_expr: "Union[EmbedExpr, _Missing]" = MISSING,
     ):
         if pure is not MISSING:
             object.__setattr__(self, "_Sum_name", "pure")
@@ -1437,40 +1459,40 @@ class Update:
     def pure(self) -> "Optional[Pure]":
         """this is purely for compact serialization -- specifically to
         reduce the AST depth. it adds no expressive power."""
-        return self._Sum_value if self._Sum_name == "pure" else None
+        return self._Sum_value if self._Sum_name == "pure" else None  # type: ignore
 
     @property
     def block(self) -> "Optional[Block]":
-        return self._Sum_value if self._Sum_name == "block" else None
+        return self._Sum_value if self._Sum_name == "block" else None  # type: ignore
 
     @property
     def create(self) -> "Optional[Create]":
-        return self._Sum_value if self._Sum_name == "create" else None
+        return self._Sum_value if self._Sum_name == "create" else None  # type: ignore
 
     @property
     def exercise(self) -> "Optional[Exercise]":
-        return self._Sum_value if self._Sum_name == "exercise" else None
+        return self._Sum_value if self._Sum_name == "exercise" else None  # type: ignore
 
     @property
     def fetch(self) -> "Optional[Fetch]":
-        return self._Sum_value if self._Sum_name == "fetch" else None
+        return self._Sum_value if self._Sum_name == "fetch" else None  # type: ignore
 
     @property
     def get_time(self) -> "Optional[Unit]":
-        return self._Sum_value if self._Sum_name == "get_time" else None
+        return self._Sum_value if self._Sum_name == "get_time" else None  # type: ignore
 
     @property
     def lookup_by_key(self) -> "Optional[RetrieveByKey]":
-        return self._Sum_value if self._Sum_name == "lookup_by_key" else None
+        return self._Sum_value if self._Sum_name == "lookup_by_key" else None  # type: ignore
 
     @property
     def fetch_by_key(self) -> "Optional[RetrieveByKey]":
-        return self._Sum_value if self._Sum_name == "fetch_by_key" else None
+        return self._Sum_value if self._Sum_name == "fetch_by_key" else None  # type: ignore
 
     @property
     def embed_expr(self) -> "Optional[EmbedExpr]":
         """see similar constructor in `Scenario` on why this is useful."""
-        return self._Sum_value if self._Sum_name == "embed_expr" else None
+        return self._Sum_value if self._Sum_name == "embed_expr" else None  # type: ignore
 
     def Sum_match(
         self,
@@ -1485,23 +1507,23 @@ class Update:
         embed_expr: "Callable[[EmbedExpr], T]",
     ) -> T:
         if self._Sum_name == "pure":
-            return pure(self._Sum_value)
+            return pure(self._Sum_value)  # type: ignore
         if self._Sum_name == "block":
-            return block(self._Sum_value)
+            return block(self._Sum_value)  # type: ignore
         if self._Sum_name == "create":
-            return create(self._Sum_value)
+            return create(self._Sum_value)  # type: ignore
         if self._Sum_name == "exercise":
-            return exercise(self._Sum_value)
+            return exercise(self._Sum_value)  # type: ignore
         if self._Sum_name == "fetch":
-            return fetch(self._Sum_value)
+            return fetch(self._Sum_value)  # type: ignore
         if self._Sum_name == "get_time":
-            return get_time(self._Sum_value)
+            return get_time(self._Sum_value)  # type: ignore
         if self._Sum_name == "lookup_by_key":
-            return lookup_by_key(self._Sum_value)
+            return lookup_by_key(self._Sum_value)  # type: ignore
         if self._Sum_name == "fetch_by_key":
-            return fetch_by_key(self._Sum_value)
+            return fetch_by_key(self._Sum_value)  # type: ignore
         if self._Sum_name == "embed_expr":
-            return embed_expr(self._Sum_value)
+            return embed_expr(self._Sum_value)  # type: ignore
         else:
             raise ValueError(f"Unknown Update.Sum case: {self._Sum_name}")
 
@@ -1527,17 +1549,19 @@ class Scenario:
             self.body = body
 
     __slots__ = "_Sum_name", "_Sum_value"
+    _Sum_name: str
+    _Sum_value: Any
 
     def __init__(
         self,
-        pure: "Pure" = MISSING,
-        block: "Block" = MISSING,
-        commit: "Commit" = MISSING,
-        must_fail_at: "Commit" = MISSING,
-        pass_: "Expr" = MISSING,
-        get_time: "Unit" = MISSING,
-        get_party: "Expr" = MISSING,
-        embed_expr: "EmbedExpr" = MISSING,
+        pure: "Union[Pure, _Missing]" = MISSING,
+        block: "Union[Block, _Missing]" = MISSING,
+        commit: "Union[Commit, _Missing]" = MISSING,
+        must_fail_at: "Union[Commit, _Missing]" = MISSING,
+        pass_: "Union[Expr, _Missing]" = MISSING,
+        get_time: "Union[Unit, _Missing]" = MISSING,
+        get_party: "Union[Expr, _Missing]" = MISSING,
+        embed_expr: "Union[EmbedExpr, _Missing]" = MISSING,
     ):
         if pure is not MISSING:
             object.__setattr__(self, "_Sum_name", "pure")
@@ -1902,11 +1926,17 @@ class DefTemplate:
 
         @property
         def key(self) -> "Optional[KeyExpr]":
-            return self._key_expr_value if self._key_expr_name == "key" else None
+            if self._key_expr_name == "key":
+                return self._key_expr_value  # type: ignore
+            else:
+                return None
 
         @property
         def complex_key(self) -> "Optional[Expr]":
-            return self._key_expr_value if self._key_expr_name == "complex_key" else None
+            if self._key_expr_name == "complex_key":
+                return self._key_expr_value  # type: ignore
+            else:
+                return None
 
     # The type constructor for the template, acting as both
     # the name of the template and the type of the template argument.
@@ -1960,37 +1990,37 @@ class DefDataType:
     name: DottedName
     params: "Sequence[TypeVarWithKind]"
     _DataCons_name: str
-    _DataCons_value: "Fields"
+    _DataCons_value: "Any"
     serializable: bool
     location: "Location"
 
     def __init__(
         self,
-        name: DottedName = MISSING,
-        params: "Sequence[TypeVarWithKind]" = MISSING,
-        record: "DefDataType.Fields" = MISSING,
-        variant: "DefDataType.Fields" = MISSING,
-        enum: "DefDataType.EnumConstructors" = MISSING,
-        synonym: "Type" = MISSING,
-        serializable: bool = MISSING,
-        location: "Location" = MISSING,
+        name: "Union[DottedName, _Missing]" = MISSING,
+        params: "Union[Sequence[TypeVarWithKind], _Missing]" = MISSING,
+        record: "Union[DefDataType.Fields, _Missing]" = MISSING,
+        variant: "Union[DefDataType.Fields, _Missing]" = MISSING,
+        enum: "Union[DefDataType.EnumConstructors, _Missing]" = MISSING,
+        synonym: "Union[Type, _Missing]" = MISSING,
+        serializable: "Union[bool, _Missing]" = MISSING,
+        location: "Union[Location, _Missing]" = MISSING,
     ):
-        self.name = name
-        self.params = params
+        self.name = name  # type: ignore
+        self.params = params  # type: ignore
         if record is not MISSING:
             self._DataCons_name = "record"
-            self._DataCons_value = record
+            self._DataCons_value = record  # type: ignore
         elif variant is not MISSING:
             self._DataCons_name = "variant"
-            self._DataCons_value = variant
+            self._DataCons_value = variant  # type: ignore
         elif enum is not MISSING:
             self._DataCons_name = "enum"
-            self._DataCons_value = enum
+            self._DataCons_value = enum  # type: ignore
         elif synonym is not MISSING:
             self._DataCons_name = "synonym"
-            self._DataCons_value = synonym
-        self.serializable = serializable
-        self.location = location
+            self._DataCons_value = synonym  # type: ignore
+        self.serializable = serializable  # type: ignore
+        self.location = location  # type: ignore
 
     @property
     def record(self) -> "Optional[DefDataType.Fields]":
@@ -2002,11 +2032,17 @@ class DefDataType:
 
     @property
     def enum(self) -> "Optional[DefDataType.EnumConstructors]":
-        return self._DataCons_value if self._DataCons_name == "enum" else None
+        if self._DataCons_name == "enum":
+            return self._DataCons_value  # type: ignore
+        else:
+            return None
 
     @property
     def synonym(self) -> "Optional[Type]":
-        return self._DataCons_value if self._DataCons_name == "synonym" else None
+        if self._DataCons_name == "synonym":
+            return self._DataCons_value  # type: ignore
+        else:
+            return None
 
 
 @dataclass(frozen=True)

--- a/python/dazl/damlast/parse.py
+++ b/python/dazl/damlast/parse.py
@@ -14,6 +14,7 @@ in turn contain templates, data types, and values.
 
 import sys
 import time
+from typing import Optional
 
 from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import ArchivePayload
 from .daml_lf_1 import Archive, PackageRef
@@ -34,7 +35,9 @@ def parse_archive(package_id: "PackageRef", archive_bytes: bytes) -> "Archive":
     return Archive(package_id, package)
 
 
-def parse_archive_payload(package_id: "PackageRef", archive_bytes: bytes) -> "ArchivePayload":
+def parse_archive_payload(
+    package_id: "Optional[PackageRef]", archive_bytes: bytes
+) -> "ArchivePayload":
     """
     Convert ``bytes`` into a :class:`G.ArchivePayload`.
 
@@ -55,7 +58,7 @@ def parse_archive_payload(package_id: "PackageRef", archive_bytes: bytes) -> "Ar
         archive_payload.ParseFromString(archive_bytes)
     except DecodeError:
         # noinspection PyPackageRequirements
-        from google.protobuf.internal import api_implementation
+        from google.protobuf.internal import api_implementation  # type: ignore
 
         if api_implementation.Type() == "cpp":
             LOG.error("Failed to decode metadata. This may be due to bugs in the native Protobuf")

--- a/python/dazl/damlast/pkgfile.py
+++ b/python/dazl/damlast/pkgfile.py
@@ -26,6 +26,8 @@ class DarFile:
     This class is _not_ thread-safe.
     """
 
+    filename: Optional[str]
+
     def __init__(self, dar: "Dar"):
         """
         Initialize a new DarFile.
@@ -97,7 +99,7 @@ class DarFile:
         :class:`CachedDarFile` is a better choice than `DarFile` if this method is frequently called
         on the same :class:`DarFile`, as package parsing is an expensive operation.
         """
-        return [parse_archive(a.hash, a.payload) for a in self._pb_archives()]
+        return [parse_archive(PackageRef(a.hash), a.payload) for a in self._pb_archives()]
 
     def package(self, package_id: "PackageRef") -> "Package":
         """
@@ -133,13 +135,13 @@ class DarFile:
         """
         Return the set of package IDs from this DAR.
         """
-        return frozenset(a.hash for a in self._pb_archives())
+        return frozenset(PackageRef(a.hash) for a in self._pb_archives())
 
-    def _dalf_names(self) -> "Generator[str, None, None]":
+    def _dalf_names(self) -> "Generator[PackageRef, None, None]":
         """
         Return a generator over the names of DALF files in this DarFile.
         """
-        return (name for name in self._zip.namelist() if name.endswith(".dalf"))
+        return (PackageRef(name) for name in self._zip.namelist() if name.endswith(".dalf"))
 
     def _pb_archives(self) -> "Generator[pb.Archive, None, None]":
         """
@@ -167,7 +169,7 @@ class CachedDarFile:
         from threading import Lock
 
         self._lock = Lock()
-        self._archives = None
+        self._archives = None  # type: Optional[Collection[Archive]]
 
     def archives(self) -> "Collection[Archive]":
         if self._archives is None:

--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Callable, Optional
+from typing import Callable, Optional, no_type_check
 import warnings
 
 from ..model.types import Type as OldType
@@ -142,6 +142,7 @@ def _old_type_prim(prim: "Type.Prim") -> "OldType":
     )
 
 
+@no_type_check
 def _old_type_syn(tysyn: "Type.Syn") -> "OldType":
     from ..model.types import TypeApp, TypeReference
 

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -34,14 +34,13 @@ def var(var: str) -> "Type":
 def values_by_module(
     store: "PackageStore",
 ) -> "Mapping[ModuleRef, Mapping[Sequence[str], Union[Expr, OldType]]]":
-    from collections import defaultdict
+    warnings.warn(
+        "dazl.damlast.util.values_by_module is deprecated; there is no replacement.",
+        DeprecationWarning,
+    )
+    from ..pretty.render_python import values_by_module  # type: ignore
 
-    d = defaultdict(defaultdict)
-    for vn, vv in store._value_types.items():
-        d[vn.module][vn.name] = vv
-    for vn, vv in store._data_types.items():
-        d[vn.module][vn.name] = vv
-    return d
+    return values_by_module(store)  # type: ignore
 
 
 # noinspection PyShadowingBuiltins

--- a/python/dazl/damlast/visitor.py
+++ b/python/dazl/damlast/visitor.py
@@ -288,8 +288,7 @@ class IdentityVisitor(ExprVisitor[Expr], IdentityTypeVisitor):
         )
 
     def visit_expr_enum_con(self, enum_con: "Expr.EnumCon") -> "Expr":
-        new_type_con = self.visit_type_con(enum_con.tycon).con
-        return Expr(enum_con=Expr.EnumCon(tycon=new_type_con, enum_con=enum_con.enum_con))
+        return Expr(enum_con=Expr.EnumCon(tycon=enum_con.tycon, enum_con=enum_con.enum_con))
 
     def visit_expr_struct_con(self, struct_con: "Expr.StructCon") -> "Expr":
         new_fields = tuple(
@@ -373,7 +372,7 @@ class IdentityVisitor(ExprVisitor[Expr], IdentityTypeVisitor):
 
     def visit_expr_from_any(self, from_any: "Expr.FromAny") -> "Expr":
         return Expr(
-            from_any=Expr.ToAny(
+            from_any=Expr.FromAny(
                 type=self.visit_type(from_any.type), expr=self.visit_expr(from_any.expr)
             )
         )

--- a/python/dazl/damleval/__init__.py
+++ b/python/dazl/damleval/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .expr_eval import ExpressionEvaluator
-from .type_eval import TypeComputer
+from .type_eval import TypeComputer  # type: ignore

--- a/python/dazl/damleval/type_eval.py
+++ b/python/dazl/damleval/type_eval.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
+# ^ This file will be removed in dazl v8. It mostly doesn't work.
 
 from typing import Optional
 

--- a/python/dazl/pretty/__init__.py
+++ b/python/dazl/pretty/__init__.py
@@ -16,9 +16,9 @@ from typing import TYPE_CHECKING, Optional, Type
 from ..model.types_store import PackageStore
 from ._render_base import PrettyPrintBase, pretty_print_syntax
 from .options import PrettyOptions
-from .render_csharp import CSharpPrettyPrint
-from .render_daml import DEFAULT_PRINTER as DAML_PRETTY_PRINTER, DamlPrettyPrinter
-from .render_python import PythonPrettyPrint
+from .render_csharp import CSharpPrettyPrint  # type: ignore
+from .render_daml import DEFAULT_PRINTER as DAML_PRETTY_PRINTER, DamlPrettyPrinter  # type: ignore
+from .render_python import PythonPrettyPrint  # type: ignore
 from .util import maybe_parentheses
 
 if TYPE_CHECKING:
@@ -38,7 +38,7 @@ def _import_daml_lexer() -> "Optional[Type[_DAMLLexer_TYPE]]":
 DAMLLexer = _import_daml_lexer()
 
 
-ALL_PRINTER_TYPES = [CSharpPrettyPrint, DamlPrettyPrinter, PythonPrettyPrint]
+ALL_PRINTER_TYPES = [CSharpPrettyPrint, DamlPrettyPrinter, PythonPrettyPrint]  # type: ignore
 
 
 # noinspection PyShadowingBuiltins,PyShadowingNames

--- a/python/dazl/pretty/_render_base.py
+++ b/python/dazl/pretty/_render_base.py
@@ -79,6 +79,9 @@ class PrettyPrintBase(PackageVisitor[str], ModuleVisitor[str], ExprVisitor[str],
         """
         Render everything in a :class:`PackageStore`.
         """
+        if self.lookup is None:
+            raise RuntimeError("render_store cannot be used unless lookup is provided")
+
         with StringIO() as buf:
             buf.write("from dazl import create, exercise, module, TemplateMeta, ChoiceMeta\n\n")
             for archive in self.lookup.archives():
@@ -876,10 +879,6 @@ def decode_special_chars(pp: str) -> str:
 
 
 class _PrettyPrinters:
-    """
-    Holder for
-    """
-
     def __init__(self):
         self._printers = {}  # type: Dict[str, TType[PrettyPrintBase]]
 
@@ -892,6 +891,7 @@ class _PrettyPrinters:
         for key, format_type in self._printers.items():
             if key.startswith(format):
                 return format_type
+        raise ValueError(f"unknown format: {format}")
 
 
 _PRETTY_PRINTERS = _PrettyPrinters()

--- a/python/dazl/pretty/render_csharp.py
+++ b/python/dazl/pretty/render_csharp.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from typing import Mapping, Optional, Sequence, Union
 

--- a/python/dazl/pretty/render_csv.py
+++ b/python/dazl/pretty/render_csv.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
+
 from io import StringIO
 from typing import Dict, List, Tuple
 

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from io import StringIO
 from typing import Optional, Sequence, Union

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from io import StringIO
 from typing import Mapping, Optional, Sequence, Union

--- a/python/dazl/pretty/table/model.py
+++ b/python/dazl/pretty/table/model.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import AbstractSet, Dict, Iterable, Iterator, Optional
-
-__all__ = ["Formatter", "RowBuilder", "TableBuilder"]
+from typing import AbstractSet, Dict, Iterable, Iterator, List, Optional
 
 from ...damlast.protocols import SymbolLookup
 from ...prim import ContractData, ContractId, Party
+
+__all__ = ["Formatter", "RowBuilder", "TableBuilder"]
 
 
 class Formatter:
@@ -42,7 +42,7 @@ class TableBuilder:
         self,
         party: "Party",
         cid: "ContractId",
-        cdata: "Optional[ContractData]",
+        cdata: "ContractData",
         time: "Optional[datetime]" = None,
     ) -> None:
         entry = self.entries.get(cid)
@@ -77,9 +77,9 @@ class RowBuilder:
         self.cid = cid
         self.cdata = cdata
         self.time = time
-        self.errors = []
+        self.errors = []  # type: List[Exception]
 
-    def extend(self, party: "Party", cdata: "ContractData") -> None:
+    def extend(self, party: "Party", cdata: "Optional[ContractData]") -> None:
         self.parties[party] = cdata is not None
 
     def is_archived(self) -> bool:

--- a/python/dazl/prim/basic.py
+++ b/python/dazl/prim/basic.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from typing import Any, Optional
 
 __all__ = ["to_bool", "to_str"]
 
 
-def to_bool(obj: "Any") -> bool:
+def to_bool(obj: "Optional[Any]") -> "Optional[bool]":
     """
     Convert any of the common wire representations of a ``bool`` to a ``bool``.
     """

--- a/python/dazl/prim/complex.py
+++ b/python/dazl/prim/complex.py
@@ -6,7 +6,7 @@ Contains functions for working with "native" Python types as they correspond to 
 Ledger API.
 """
 
-from typing import Any, Mapping, Tuple
+from typing import Any, Dict, Mapping, Tuple
 
 __all__ = ["to_record", "to_variant"]
 
@@ -23,7 +23,7 @@ def to_record(obj: "Any") -> "Mapping[str, Any]":
         raise ValueError("a mapping is required")
 
     # pull out any specialized dotted-field mappings
-    reformatted = dict()
+    reformatted = dict()  # type: Dict[str, Any]
     for key, value in obj.items():
         k1, d, k2 = key.partition(".")
         if d:

--- a/python/dazl/prim/contracts.py
+++ b/python/dazl/prim/contracts.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
-from ..damlast.daml_lf_1 import TypeConName
+if TYPE_CHECKING:
+    from ..damlast.daml_lf_1 import TypeConName
 
 __all__ = ["ContractId", "ContractData"]
 
@@ -11,29 +12,37 @@ __all__ = ["ContractId", "ContractData"]
 class ContractId:
     """
     A typed contract ID.
-
-    Instance attributes:
-
-    .. attribute:: ContractId.value
-
-        The raw contract ID value (for example, ``"#4:1"``).
-
-    .. attribute:: ContractId.value_type
-
-        The type of template that is pointed to by this :class:`ContractId`.
-
     """
 
-    __slots__ = "value", "value_type"
+    __slots__ = "_value", "_value_type"
+    if TYPE_CHECKING:
+        _value: str
+        _value_type: TypeConName
 
     def __init__(self, value_type: "TypeConName", value: str):
+        from ..damlast.daml_lf_1 import TypeConName
+
         if not isinstance(value_type, TypeConName):
             raise ValueError("value_type must be a TypeConName")
         if not isinstance(value, str):
             raise ValueError("value must be a string")
 
-        object.__setattr__(self, "value_type", value_type)
-        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "_value_type", value_type)
+        object.__setattr__(self, "_value", value)
+
+    @property
+    def value(self) -> str:
+        """
+        Return the raw contract ID value (for example, ``"#4:1"``).
+        """
+        return self._value
+
+    @property
+    def value_type(self) -> "TypeConName":
+        """
+        Return the type of template that is pointed to by this :class:`ContractId`.
+        """
+        return self._value_type
 
     def __str__(self):
         """

--- a/python/dazl/prim/datetime.py
+++ b/python/dazl/prim/datetime.py
@@ -4,7 +4,7 @@
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from functools import partial
-from typing import Any, Union
+from typing import Any, Callable, Sequence, Union
 
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -48,12 +48,12 @@ def _parse_nano_format(value: str) -> "datetime":
         raise ValueError("could not parse")
 
 
-DATE_FORMATS = [
+DATE_FORMATS: Sequence[Callable[[str], datetime]] = [
     partial(_parse, "%Y-%m-%d"),
     partial(_parse, "%Y.%m.%d"),
 ]
 
-DATETIME_FORMATS = [
+DATETIME_FORMATS: Sequence[Callable[[str], datetime]] = [
     partial(_parse, DATETIME_ISO8601_Z_FORMAT),
     _parse_nano_format,
     partial(_parse, "%Y-%m-%dT%H:%M:%S.%f"),
@@ -215,6 +215,6 @@ def timedelta_to_duration(obj: "timedelta") -> "Duration":
     Return the Python ``timestamp`` as a Protobuf ``google.protobuf.Duration``.
     """
     d = Duration()
-    d.seconds = obj.total_seconds()
+    d.seconds = int(obj.total_seconds())
     d.nanos = obj.microseconds * 1000
     return d

--- a/python/dazl/prim/numbers.py
+++ b/python/dazl/prim/numbers.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 __all__ = ["to_int", "to_decimal", "decimal_to_str"]
 
@@ -17,7 +17,7 @@ def to_int(obj: "Any") -> int:
     raise ValueError(f"Could not parse as an int: {obj!r}")
 
 
-def to_decimal(obj: "Any") -> "Decimal":
+def to_decimal(obj: "Optional[Any]") -> "Optional[Decimal]":
     """
     Convert any of the common wire representations of a ``Decimal`` to a ``Decimal``.
     """

--- a/python/dazl/protocols/autodetect.py
+++ b/python/dazl/protocols/autodetect.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import datetime
+from datetime import datetime
 from threading import Event, RLock, Thread
 from typing import Awaitable, Dict, Iterable, Optional, Union
 
@@ -64,7 +64,7 @@ class AutodetectLedgerNetwork(LedgerNetwork):
         if ledger.protocol_version == "v1":
             from .v1.grpc import GRPCv1LedgerClient
 
-            return GRPCv1LedgerClient(conn, ledger, party)
+            return GRPCv1LedgerClient(conn, ledger, Party(party))
         elif ledger.protocol_version == "v0":
             raise RuntimeError(f"Unsupported protocol version: {ledger.protocol_version}")
         else:

--- a/python/dazl/scheduler/_invoker.py
+++ b/python/dazl/scheduler/_invoker.py
@@ -4,11 +4,11 @@
 The core scheduling of logic, managing the tricky interaction between the man asyncio event loop and
 background threads.
 """
-
 from asyncio import CancelledError, Future, InvalidStateError, gather, get_event_loop, wait_for
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 import signal
+import warnings
 
 from ..prim import to_timedelta
 from ..util.asyncio_util import execute_in_loop, safe_create_future
@@ -44,7 +44,9 @@ class Invoker:
             pass
 
     def create_future(self):
-        f = safe_create_future()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            f = safe_create_future()
         f.add_done_callback(self._unhook_future)
         self._futures.append(f)
         return f

--- a/python/dazl/server/management.py
+++ b/python/dazl/server/management.py
@@ -6,7 +6,7 @@ Endpoints for managing parties/bots connected via a dazl client.
 """
 
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Collection, Sequence
+from typing import TYPE_CHECKING, Collection, NoReturn, Optional, Sequence
 
 from ..client import Bot, _NetworkImpl
 from ..model.core import DazlImportError, Party, SourceLocation
@@ -32,7 +32,7 @@ class BotInfo:
 @dataclass(frozen=True)
 class BotInfoEntry:
     event_key: str
-    source_location: "SourceLocation"
+    source_location: "Optional[SourceLocation]"
 
 
 def build_routes(network_impl: "_NetworkImpl") -> "Collection[web.AbstractRouteDef]":
@@ -65,7 +65,7 @@ def build_routes(network_impl: "_NetworkImpl") -> "Collection[web.AbstractRouteD
         return web.json_response(asdict(_get_bot_info(bot)))
 
     @routes.post("/bots/{bot_id}/state/{action}")
-    async def change_bot_state(request: "web.Request") -> "web.Response":
+    async def change_bot_state(request: "web.Request") -> "NoReturn":
         bot = get_bot(request)
         action = request.match_info["action"]
 

--- a/python/dazl/server/oauth_callback.py
+++ b/python/dazl/server/oauth_callback.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 
 from asyncio import get_event_loop
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 import uuid
 
 from ..model.network import OAuthSettings

--- a/python/dazl/values/json.py
+++ b/python/dazl/values/json.py
@@ -42,7 +42,8 @@ class JsonEncoder(CanonicalMapper):
         return obj.contract_id
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return decimal_to_str(d) if d is not None else None
 
     def _ctor_value_to_variant(
         self,

--- a/python/dazl/values/protobuf.py
+++ b/python/dazl/values/protobuf.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, Optional, Type as PyType, TypeVar
 
 from google.protobuf import timestamp_pb2
 from google.protobuf.empty_pb2 import Empty
@@ -222,7 +222,8 @@ class ProtobufEncoder(ValueMapper):
         return "map", msg
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return "numeric", decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return "numeric", decimal_to_str(d) if d is not None else None
 
     def prim_gen_map(
         self, context: "Context", key_type: "Type", value_type: "Type", obj: "Any"
@@ -237,7 +238,7 @@ class ProtobufEncoder(ValueMapper):
         return "gen_map", msg
 
 
-def get_value(obj: "Any", field: str, pb_type: "Type[T]") -> "T":
+def get_value(obj: "Any", field: str, pb_type: "PyType[T]") -> "T":
     return obj if isinstance(obj, pb_type) else getattr(obj, field)
 
 

--- a/python/dazl/values/string.py
+++ b/python/dazl/values/string.py
@@ -110,7 +110,8 @@ class StringMapperBase(ValueMapper):
         )
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return decimal_to_str(d) if d is not None else None
 
     def prim_gen_map(
         self, context: "Context", key_type: "Type", value_type: "Type", obj: "Any"

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -6,10 +6,16 @@ ignore_missing_imports = True
 [mypy-prometheus_client.*]
 ignore_missing_imports = True
 
+[mypy-psutil.*]
+ignore_missing_imports = True
+
 [mypy-pygments.*]
 ignore_missing_imports = True
 
 [mypy-semver.*]
+ignore_missing_imports = True
+
+[mypy-toposort.*]
 ignore_missing_imports = True
 
 [mypy-dazl._gen.*]


### PR DESCRIPTION
Apply fixes as identified by `mypy` to:
* `dazl`
* `dazl.client`
* `dazl.damlast`
* `dazl.prim`
* `dazl.protocols`
* `dazl.server`
* `dazl.values`

And tweak the mypy file to exclude libraries that don't have typing rules.

The bulk of the PR is simply:
* adding type annotations where they were missing
* making the `dazl.damlast` packages better behaved with missing parameters
* mypy isn't wild about functions that have a defined return type but no return statement, so added `return None` in places where it doesn't change behavior, but makes the intent of the method perhaps more obvious.