### PR TITLE
python: Reduce the amount of noise that comes from normal usage of dazl.

### DIFF
--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -84,18 +84,25 @@ def match_prim_type(
 
 
 def get_old_type(daml_type: "Type") -> "OldType":
-    from ..model.types import UnsupportedType
-
-    return safe_cast(Type, daml_type).Sum_match(
-        _old_type_var,
-        _old_type_con,
-        _old_type_prim,
-        _old_type_syn,
-        _old_forall_type,
-        lambda tuple_: UnsupportedType("Tuple"),
-        lambda nat: UnsupportedType("Nat"),
-        lambda _: UnsupportedType("Syn"),
+    warnings.warn(
+        "get_old_type is deprecated; use the types of dazl.damlast.daml_lf_1 instead",
+        DeprecationWarning,
+        stacklevel=2,
     )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from ..model.types import UnsupportedType
+
+        return safe_cast(Type, daml_type).Sum_match(
+            _old_type_var,
+            _old_type_con,
+            _old_type_prim,
+            _old_type_syn,
+            _old_forall_type,
+            lambda tuple_: UnsupportedType("Tuple"),
+            lambda nat: UnsupportedType("Nat"),
+            lambda _: UnsupportedType("Syn"),
+        )
 
 
 def _old_type_var(var_: "Type.Var") -> "OldType":

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -217,6 +217,10 @@ def find_dependencies_of_type(type_pb) -> "Collection[PackageRef]":
             return find_dependencies_of_fwts(type_pb.tuple.fields)
         elif t == "nat":
             return ()
+        elif t == "interned":
+            # This isn't strictly correct, but we're catching this here to suppress errors
+            # ahead of removal of this deprecated function
+            return ()
         else:
             LOG.warning("Unknown DAML-LF Type: %s (when evaluating %s)", t, type_pb)
             return ()

--- a/python/dazl/util/asyncio_util.py
+++ b/python/dazl/util/asyncio_util.py
@@ -583,7 +583,10 @@ class ContextFreeFuture(Awaitable[T_co]):
         self, fn: "Callable[[ContextFreeFuture[T_co]], None]", context=None
     ) -> None:
         if context is not None:
-            LOG.warning("ContextFreeFutures do not support the use of contexts.")
+            # This used to be a warning, but in newer versions of Python a context
+            # is sometimes supplied and nothing seems to particularly go wrong by
+            # simply doing nothing with this information.
+            pass
         with self._lock:
             if self._loop is not None and self._state != _PENDING:
                 self._loop.call_soon_threadsafe(fn, self)


### PR DESCRIPTION
* Get rid of two warnings that would come about from normal usage.
* Make some of the older dazl `Type` classes more obviously deprecated (PyCharm doesn't seem to mark subclasses as deprecated when their parent classes are deprecated, which is a little annoying.)