### PR TITLE
python: Fix ACS fetches on empty sets

### DIFF
--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -28,7 +28,7 @@ import warnings
 
 from .. import LOG
 from ..damlast import get_dar_package_ids
-from ..damlast.daml_lf_1 import PackageRef
+from ..damlast.daml_lf_1 import PackageRef, TypeConName
 from ..damlast.protocols import SymbolLookup
 from ..metrics import MetricEvents
 from ..model.core import (
@@ -827,7 +827,7 @@ class AIOPartyClient(PartyClient):
 
     def submit_create(
         self,
-        template_name: str,
+        template_name: "Union[str, TypeConName]",
         arguments: "Optional[dict]" = None,
         workflow_id: "Optional[str]" = None,
         deduplication_time: "Optional[TimeDeltaLike]" = None,

--- a/python/dazl/model/writing.py
+++ b/python/dazl/model/writing.py
@@ -472,7 +472,7 @@ class CommandPayload:
 
 
 def create(template, arguments=None):
-    if not isinstance(template, str):
+    if not isinstance(template, (str, TypeConName)):
         raise ValueError(
             "template must be a string name, a template type, or an instantiated template"
         )

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -297,6 +297,8 @@ def grpc_package_sync(package_provider: "PackageProvider", store: "PackageStore"
 
         LOG.debug("grpc_package_sync started...")
 
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
         all_package_ids = package_provider.get_package_ids()
         loaded_package_ids = {a.hash for a in store.archives()}
         expected_package_ids = store.expected_package_ids()
@@ -317,6 +319,8 @@ def grpc_package_sync(package_provider: "PackageProvider", store: "PackageStore"
                 archive_payload = package_provider.fetch_package(package_id)
                 metadatas_pb[package_id] = parse_archive_payload(package_id, archive_payload)
 
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
         adr = find_dependencies(metadatas_pb, loaded_package_ids)
         for package_id, archive_bytes in adr.sorted_archives.items():
             store.register_all(parse_daml_metadata_pb(package_id, archive_bytes))

--- a/python/tests/unit/test_acs_find_active.py
+++ b/python/tests/unit/test_acs_find_active.py
@@ -14,7 +14,7 @@ OperatorNotification = "Simple:OperatorNotification"
 
 
 @pytest.mark.asyncio
-async def test_select_template_retrieves_contracts(sandbox):
+async def test_acs_find_active_retrieves_contracts(sandbox):
     seen_notifications = []
 
     async with async_network(url=sandbox, dars=Simple) as network:

--- a/python/tests/unit/test_autoload_explicit_packages.py
+++ b/python/tests/unit/test_autoload_explicit_packages.py
@@ -1,0 +1,50 @@
+from asyncio import ensure_future
+import logging
+
+import pytest
+
+from dazl import Network
+from dazl.damlast.errors import PackageNotFoundError
+from dazl.damlast.lookup import MultiPackageLookup
+from dazl.damlast.pkgfile import DarFile
+
+from .dars import Simple
+
+
+@pytest.mark.asyncio
+async def test_autoload_explicit_packages(sandbox):
+    with DarFile(Simple) as dar_file:
+        lookup = MultiPackageLookup()
+        lookup.add_archive(*dar_file.archives())
+        fqtn = lookup.template_name("Simple:OperatorRole")
+
+    # Start the sandbox and make sure our package is loaded.
+    logging.info("Preloading the DAR...")
+    network = Network()
+    network.set_config(url=sandbox)
+    await network.aio_global().ensure_dar(Simple)
+
+    # Now start the sandbox again, but without any preloading.
+    logging.info("Now running the real test...")
+    network = Network()
+    network.set_config(url=sandbox, eager_package_fetch=False)
+    client = network.aio_new_party()
+    fut = ensure_future(network.aio_run())
+    await client.ready()
+
+    with pytest.raises(PackageNotFoundError):
+        # this call SHOULD fail because the package has not yet locally been loaded
+        _ = network.lookup.template(fqtn)
+
+    # this call should NOT fail because we tolerate searches on templates when
+    # fully specified but the package has not yet been fetched
+    contracts = client.find_active(fqtn)
+    assert len(contracts) == 0
+
+    # this call should nonetheless succeed because dazl fetches packages that it sees
+    # it's missed
+    logging.info("Submitting the create...")
+    await client.submit_create(fqtn, {"operator": client.party})
+
+    network.shutdown()
+    await fut


### PR DESCRIPTION
Fix a problem where fully-specific template names for ACS fetches would fail when no contracts are discovered.