### PR TITLE
circleci: Use the poetry image in CircleCI's base image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,91 +7,83 @@ jobs:
       - image: cimg/python:3.8.7
 
       # Start an SDK image alongside the tests for purposes of running the Sandbox
-      - image: digitalasset/daml-sdk:1.10.0
+      - image: digitalasset/daml-sdk:1.12.0
         command: daml sandbox -a 0.0.0.0
         
     resource_class: medium+
     steps:
       - checkout
-      - run:
-          name: Install poetry and jq
-          command: |
-            curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python && \
-            source $HOME/.poetry/env && \
-            pip install pipenv && \
-            poetry config virtualenvs.in-project true && \
-            curl -LO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-            chmod 755 jq-linux64 && \
-            mv jq-linux64 /usr/bin/jq
+
       - restore_cache:
-          key: daml-sdk-{{ checksum "_build/daml-install" }}-1.3.0
+          key: jq-{{ checksum ".circleci/install-jq" }}
       - run:
-          command: _build/daml-install 1.3.0
+          command: .circleci/install-jq
       - save_cache:
-          key: daml-sdk-{{ checksum "_build/daml-install" }}-1.3.0
-          paths:
-            - "/home/circleci/.daml"
+          key: jq-{{ checksum ".circleci/install-jq" }}
+          paths: /home/circleci/.jq
+
+      - restore_cache:
+          key: daml-{{ checksum ".circleci/install-daml" }}
+      - run:
+          command: .circleci/install-daml
+      - save_cache:
+          key: daml-{{ checksum ".circleci/install-daml" }}
+          paths: /home/circleci/.daml
+
       - restore_cache:
           key: deps-{{ checksum "python/poetry.lock" }}
       - run:
-          command: |
-            export PATH=$PATH:~/.daml/bin; \
-            source $HOME/.poetry/env && \
-            make -C python deps
+          command: poetry config virtualenvs.in-project true && make -C python deps
       - save_cache:
           key: deps-{{ checksum "python/poetry.lock" }}
-          paths:
-            - "python/.venv"
+          paths: "python/.venv"
+
       - run:
           name: Python format checks
-          command: |
-            make python-format-check
+          command: make python-format-check
       - run:
           name: Python unit tests
           environment:
             DAZL_TEST_DAML_LEDGER_URL: http://localhost:6865
-          command: |
-            export PATH=$PATH:~/.daml/bin; \
-            source $HOME/.poetry/env && \
-            make python-test
+          command: make python-test
       - run:
           name: Python integration tests
           environment:
             DAZL_TEST_DAML_LEDGER_URL: http://localhost:6865
-          command: |
-            export PATH=$PATH:~/.daml/bin; \
-            source $HOME/.poetry/env && \
-            make python-integration-test
+          command: make python-integration-test
       - run:
           name: Python packaging
-          command: |
-            export PATH=$PATH:~/.daml/bin; \
-            source $HOME/.poetry/env && \
-            make -C python package
+          command: make -C python package
       - store_test_results:
           path: python/test-results
   blackduck:
     docker:
-      - image: rappdw/docker-java-python
+      - image: cimg/python:3.8.7
     steps:
       - checkout
+
+      - restore_cache:
+          key: jq-{{ checksum ".circleci/install-jq" }}
       - run:
-          name: Install poetry and jq
-          command: |
-            curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python && \
-            source $HOME/.poetry/env && \
-            pip install pipenv && \
-            poetry config virtualenvs.in-project true && \
-            curl -LO https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-            chmod 755 jq-linux64 && \
-            mv jq-linux64 /usr/bin/jq
+          command: .circleci/install-jq
+      - save_cache:
+          key: jq-{{ checksum ".circleci/install-jq" }}
+          paths: /home/circleci/.jq
+
+      - restore_cache:
+          key: java-{{ checksum ".circleci/install-java" }}
+      - run:
+          command: .circleci/install-java
+      - save_cache:
+          key: java-{{ checksum ".circleci/install-java" }}
+          paths: /home/circleci/.java
+
       - run:
           name: Run Blackduck Detect
           command: |
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_dazl master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
           working_directory: python
           
-
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/install-daml
+++ b/.circleci/install-daml
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+version=1.12.0
+
+function install {
+    if ! link ; then
+        curl -sSL https://get.daml.com/ | sh
+        link
+    fi
+    daml install "${version}"
+}
+
+function link {
+    mkdir -p "$HOME/bin"
+    [ -f "$HOME/.daml/bin/daml" ] && \
+        ln -s "$HOME/.daml/bin/daml" "$HOME/bin/"
+}
+
+install

--- a/.circleci/install-java
+++ b/.circleci/install-java
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euox pipefail
+
+url=https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
+sha256=3784cfc4670f0d4c5482604c7c513beb1a92b005f569df9bf100e8bef6610f2e
+
+function install {
+    if ! link ; then
+        (
+            set -euox pipefail
+
+            mkdir -p "${HOME}/.java"
+            cd "${HOME}/.java"
+            curl -sSL "${url}" -o "jdk-11.tar.gz"
+            actual="$(sha256sum "jdk-11.tar.gz" | cut -f 1 -d' ')"
+            if [ "${actual}" != "${sha256}" ]; then
+                echo "Failed verification!"
+                echo "    URL:             ${url}"
+                echo "    Expected SHA256: ${sha256}"
+                echo "    Actual SHA256:   ${actual}"
+                exit 1
+            fi
+            tar xfz "jdk-11.tar.gz"
+            rm "jdk-11.tar.gz"
+        )
+
+        link
+    fi
+}
+
+function link {
+    mkdir -p "$HOME/bin"
+    [ -f "${HOME}/.java/jdk-11/bin/java" ] && \
+        ln -s "${HOME}/.java/jdk-11/bin/java" "$HOME/bin/"
+}
+
+install

--- a/.circleci/install-jq
+++ b/.circleci/install-jq
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+bin_dir="$HOME/.jq/bin"
+
+function install {
+    if ! link ; then
+        mkdir -p "${bin_dir}"
+        curl -sSL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o "${bin_dir}/jq" 
+        chmod 755 "${bin_dir}/jq"
+        link
+    fi
+}
+
+function link {
+    mkdir -p "$HOME/bin"
+    [ -f "${bin_dir}/jq" ] && \
+        ln -s "${bin_dir}/jq" "$HOME/bin/"
+}
+
+install

--- a/_build/jdk-install
+++ b/_build/jdk-install
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+java_dir="$HOME/.java"
+export PATH="$PATH:$java_dir/bin"
+
+url=https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
+
+if ! command -v java &>/dev/null ; then
+    mkdir -p "${java_dir}"
+    curl -sSL "${url}" -o "${java_dir}/java.tar.gz"
+    (cd "${java_dir}" && tar xfz java.tar.gz)
+    rm "${java_dir}/java.tar.gz"
+fi


### PR DESCRIPTION
Something recently changed in CircleCI's base image that caused our specific way of installing `poetry` to no longer work.

Additionally, `poetry` is actually installed in CircleCI's base image now (it wasn't at the time of #4) so there isn't actually even a reason to try to fix the installer at all.

Separately, improve and clean up the way that dependencies in _general_ are pulled down and installed, particularly the JVM.