### PR TITLE
meta: Fix Blackduck integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           path: python/test-results
   blackduck:
     docker:
-      - image: cimg/python:3.8.7
+      - image: rappdw/docker-java-python
     steps:
       - checkout
 
@@ -70,17 +70,10 @@ jobs:
           key: jq-{{ checksum ".circleci/install-jq" }}
           paths: /home/circleci/.jq
 
-      - restore_cache:
-          key: java-{{ checksum ".circleci/install-java" }}
-      - run:
-          command: .circleci/install-java
-      - save_cache:
-          key: java-{{ checksum ".circleci/install-java" }}
-          paths: /home/circleci/.java
-
       - run:
           name: Run Blackduck Detect
           command: |
+            cp /home/circleci/.jq/bin/jq /usr/local/bin
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_dazl master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
           working_directory: python
           


### PR DESCRIPTION
Apparently trying to switch to CircleCI's base images for Blackduck (#202) has caused problems; so revert that, but preserve the way we're caching `jq` because that still seems to work.

This still requires some further investigation because there is nothing obviously wrong with the original build except for a weird error:

```
2021-04-19 13:55:40 UTC ERROR [main] --- Could not retrieve the bearer token

com.synopsys.integration.exception.IntegrationException: Could not perform the authorization request: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
	at com.synopsys.integration.rest.support.AuthenticationSupport.attemptAuthentication(AuthenticationSupport.java:90) ~[integration-rest-7.1.2.jar!/:na]
	at com.synopsys.integration.rest.support.AuthenticationSupport.attemptAuthentication(AuthenticationSupport.java:59) ~[integration-rest-7.1.2.jar!/:na]
        ...
```

I suspect it may have something to do with how the trust store is installed when `.circleci/install-java` is used.