### PR TITLE
python: Replace the contents of dazl/pretty on master with v7

### DIFF
--- a/python/dazl/pretty/__init__.py
+++ b/python/dazl/pretty/__init__.py
@@ -14,15 +14,18 @@ This module contains utilities for pretty-printing various types in dazl.
 from typing import TYPE_CHECKING, Optional, Type
 
 from ..damlast.protocols import SymbolLookup
-from ._render_base import PrettyPrintBase, pretty_print_syntax
+from ._render_base import PrettyPrintBase, pretty_print_syntax  # type: ignore
 from .options import PrettyOptions
-from .render_csharp import CSharpPrettyPrint
-from .render_daml import DEFAULT_PRINTER as DAML_PRETTY_PRINTER, DamlPrettyPrinter
-from .render_python import PythonPrettyPrint
+from .render_csharp import CSharpPrettyPrint  # type: ignore
+from .render_daml import DEFAULT_PRINTER as DAML_PRETTY_PRINTER, DamlPrettyPrinter  # type: ignore
+from .render_python import PythonPrettyPrint  # type: ignore
 from .util import maybe_parentheses
 
 if TYPE_CHECKING:
     from .pygments_daml_lexer import DAMLLexer as _DAMLLexer_TYPE
+
+
+__all__ = ["get_pretty_printer", "DAMLLexer", "ALL_PRINTER_TYPES", "PrettyOptions"]
 
 
 def _import_daml_lexer() -> "Optional[Type[_DAMLLexer_TYPE]]":
@@ -38,7 +41,7 @@ def _import_daml_lexer() -> "Optional[Type[_DAMLLexer_TYPE]]":
 DAMLLexer = _import_daml_lexer()
 
 
-ALL_PRINTER_TYPES = [CSharpPrettyPrint, DamlPrettyPrinter, PythonPrettyPrint]
+ALL_PRINTER_TYPES = [CSharpPrettyPrint, DamlPrettyPrinter, PythonPrettyPrint]  # type: ignore
 
 
 # noinspection PyShadowingBuiltins,PyShadowingNames

--- a/python/dazl/pretty/_module_builder.py
+++ b/python/dazl/pretty/_module_builder.py
@@ -4,8 +4,9 @@
 
 from typing import Dict, List, Sequence
 
-from ..damlast.daml_lf_1 import DottedName, Module, ModuleRef
+from ..damlast.daml_lf_1 import DottedName, Module
 from ..damlast.util import module_name, package_ref
+from ..model.types import ModuleRef
 
 
 class ModuleHierarchy:

--- a/python/dazl/pretty/render_csharp.py
+++ b/python/dazl/pretty/render_csharp.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from typing import Mapping, Optional, Sequence, Union
 
@@ -19,7 +20,12 @@ from ..damlast.daml_lf_1 import (
     ValName,
 )
 from ..damlast.util import pack_arrow_type, unpack_arrow_type
-from ._render_base import CodeContext, PrettyPrintBase, decode_special_chars
+from ._render_base import (
+    CodeContext,
+    PrettyPrintBase,
+    decode_special_chars,
+    register_pretty_printer,
+)
 
 
 class CSharpPrettyPrint(PrettyPrintBase):

--- a/python/dazl/pretty/render_csv.py
+++ b/python/dazl/pretty/render_csv.py
@@ -1,12 +1,15 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
+
 from io import StringIO
 from typing import Dict, List, Tuple
 
-from ..damlast.protocols import SymbolLookup
+from dazl.model.types import ContractIdType, ListType, RecordType, Type, TypeReference
+from dazl.model.types_store import PackageStore
 
 
-def write_csv(lookup: "SymbolLookup") -> str:
+def write_csv(store: PackageStore) -> str:
     templates = {
         template.data_type.name.full_name: template for template in store.resolve_template("*")
     }

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from io import StringIO
 from typing import Optional, Sequence, Union
@@ -13,13 +14,44 @@ from ..damlast.daml_lf_1 import (
     PrimType,
     Pure,
     Scenario,
-    Type,
+    Type as NewType,
     TypeConName,
     Update,
 )
 from ..damlast.util import module_name, package_local_name
+from ..model.types import (
+    SCALAR_TYPE_BOOL,
+    SCALAR_TYPE_CHAR,
+    SCALAR_TYPE_DATE,
+    SCALAR_TYPE_DECIMAL,
+    SCALAR_TYPE_INTEGER,
+    SCALAR_TYPE_PARTY,
+    SCALAR_TYPE_RELTIME,
+    SCALAR_TYPE_TEXT,
+    SCALAR_TYPE_TIME,
+    SCALAR_TYPE_UNIT,
+    ContractIdType,
+    EnumType,
+    ForAllType,
+    ListType,
+    OptionalType,
+    RecordType,
+    ScalarType,
+    TextMapType,
+    Type as OldType,
+    TypeApp,
+    TypeReference,
+    TypeVariable,
+    UpdateType,
+    VariantType,
+    type_dispatch_table,
+)
 from ._render_base import PrettyPrintBase
 from .util import maybe_parentheses
+
+_OldTypePrim = Union[
+    ScalarType, ContractIdType, ListType, OptionalType, TextMapType, UpdateType, NewType.Prim
+]
 
 
 class DamlPrettyPrinter(PrettyPrintBase):
@@ -310,12 +342,15 @@ class DamlPrettyPrinter(PrettyPrintBase):
 
     # region visit_type_* methods
 
-    def visit_type(self, type: "Union[str, Type, TypeConName]", parenthesize: bool = False) -> str:
+    def visit_type(
+        self, type: "Union[str, NewType, OldType, TypeConName]", parenthesize: bool = False
+    ) -> str:
         from ..damlast.daml_lf_1 import TypeConName
+        from ..model.types import TypeReference
 
         if isinstance(type, str):
             type_str = type
-        elif isinstance(type, Type):
+        elif isinstance(type, NewType):
             type_str = type.Sum_match(
                 var=self.visit_type_var,
                 con=self.visit_type_con,
@@ -326,63 +361,107 @@ class DamlPrettyPrinter(PrettyPrintBase):
                 nat=self.visit_type_nat,
                 syn=self.visit_type_syn,
             )
+        elif isinstance(type, UpdateType):
+            type_str = self.visit_type_prim(type)
+        elif isinstance(type, ForAllType):
+            type_str = self.visit_type_forall(type)
+        elif isinstance(type, OldType):
+            type_str = type_dispatch_table(
+                on_type_var=self.visit_type_var,
+                on_type_ref=self.visit_type_con,
+                on_scalar=self.visit_type_prim,
+                on_contract_id=self.visit_type_prim,
+                on_list=self.visit_type_prim,
+                on_optional=self.visit_type_prim,
+                on_text_map=self.visit_type_prim,
+                on_record=self.visit_type_con,
+                on_variant=self.visit_type_con,
+                on_enum=self.visit_type_con,
+                on_type_app=self._visit_type_app,
+                on_unsupported=repr,
+            )(type)
         elif isinstance(type, TypeConName):
-            type_str = self.visit_type_con(type)
+            type_str = self.visit_type_con(TypeReference(type))
         else:
             raise TypeError(f"A DAML Type is required here (got {type!r} instead")
 
         return maybe_parentheses(type_str) if parenthesize else type_str
 
-    def visit_type_var(self, var: "Union[str, Type.Var]"):
-        if isinstance(var, Type.Var):
+    def visit_type_var(self, var: "Union[str, TypeVariable, NewType.Var]"):
+        if isinstance(var, NewType.Var):
             return self._visit_type_app((var.var, *var.args))
+        elif isinstance(var, TypeVariable):
+            return var.name
         elif isinstance(var, str):
             return var
         else:
             raise TypeError(f"A DAML Type variable is required here (got {var!r} instead")
 
-    def visit_type_con(self, con: "Union[Type.Con]") -> str:
-        if isinstance(con, Type.Con):
+    def visit_type_con(
+        self, con: "Union[TypeReference, RecordType, VariantType, EnumType, NewType.Con]"
+    ) -> str:
+        if isinstance(con, TypeReference):
+            return package_local_name(con.con)
+        elif isinstance(con, (RecordType, VariantType, EnumType)):
+            if con.name is None:
+                raise ValueError("A named Record, Variant, or Enum type is required here")
+            return package_local_name(con.name.con)
+        elif isinstance(con, NewType.Con):
             return self._visit_type_app((package_local_name(con.tycon), *con.args))
         else:
             raise TypeError(f"A DAML Type constructor is required here (got {con!r} instead")
 
-    def visit_type_prim(self, prim: "Type.Prim") -> str:
-        prim_type = prim.prim if isinstance(prim, Type.Prim) else None
+    def visit_type_prim(self, prim: "_OldTypePrim") -> str:
+        prim_type = prim.prim if isinstance(prim, NewType.Prim) else None
 
-        if PrimType.UNIT == prim_type:
-            return "()"
-        elif PrimType.BOOL == prim_type:
+        if PrimType.UNIT == prim_type or SCALAR_TYPE_UNIT == prim:
+            return "Unit"
+        elif PrimType.BOOL == prim_type or SCALAR_TYPE_BOOL == prim:
             return "Bool"
-        elif PrimType.INT64 == prim_type:
+        elif PrimType.INT64 == prim_type or SCALAR_TYPE_INTEGER == prim:
             return "Int"
-        elif PrimType.DECIMAL == prim_type:
+        elif PrimType.DECIMAL == prim_type or SCALAR_TYPE_DECIMAL == prim:
             return "Decimal"
-        elif PrimType.CHAR == prim_type:
+        elif PrimType.CHAR == prim_type or SCALAR_TYPE_CHAR == prim:
             return "Char"
-        elif PrimType.TEXT == prim_type:
+        elif PrimType.TEXT == prim_type or SCALAR_TYPE_TEXT == prim:
             return "Text"
-        elif PrimType.TIMESTAMP == prim_type:
+        elif PrimType.TIMESTAMP == prim_type or SCALAR_TYPE_TIME == prim:
             return "Time"
-        elif PrimType.RELTIME == prim_type:
+        elif PrimType.RELTIME == prim_type or SCALAR_TYPE_RELTIME == prim:
             return "RelTime"
-        elif PrimType.PARTY == prim_type:
+        elif PrimType.PARTY == prim_type or SCALAR_TYPE_PARTY == prim:
             return "Party"
+
         elif PrimType.LIST == prim_type:
             if len(prim.args) == 0:
                 return "List"
             else:
                 return f"[{self.visit_type(prim.args[0])}]"
+        elif isinstance(prim, ListType):
+            return f"[{self.visit_type(prim.type_parameter)}]"
+
         elif PrimType.UPDATE == prim_type:
             return self._visit_type_app(("Update", *prim.args))
+        elif isinstance(prim, UpdateType):
+            return self._visit_type_app(("Update", prim.type_parameter))
+
         elif PrimType.SCENARIO == prim_type:
             return self._visit_type_app(("Scenario", *prim.args))
-        elif PrimType.DATE == prim_type:
+
+        elif PrimType.DATE == prim_type or SCALAR_TYPE_DATE == prim:
             return "Date"
+
         elif PrimType.CONTRACT_ID == prim_type:
             return self._visit_type_app(("ContractId", *prim.args))
+        elif isinstance(prim, ContractIdType):
+            return self._visit_type_app(("ContractId", prim.type_parameter))
+
         elif PrimType.OPTIONAL == prim_type:
             return self._visit_type_app(("Optional", *prim.args))
+        elif isinstance(prim, OptionalType):
+            return self._visit_type_app(("Optional", prim.type_parameter))
+
         elif PrimType.ARROW == prim_type:
             arrow_operator = " -> "
             return arrow_operator.join(
@@ -404,17 +483,25 @@ class DamlPrettyPrinter(PrettyPrintBase):
         else:
             raise TypeError(f"A DAML Type primitive is required here (got {prim!r} instead")
 
-    def visit_type_forall(self, forall: "Type.Forall") -> str:
-        if isinstance(forall, Type.Forall):
+    def visit_type_forall(self, forall: "Union[ForAllType, NewType.Forall]") -> str:
+        if isinstance(forall, NewType.Forall):
             return f'forall {" ".join(self.visit_type_var(v.var) for v in forall.vars)}. {self.visit_type(forall.body)}'
+        elif isinstance(forall, ForAllType):
+            return (
+                f'forall {" ".join(self.visit_type_var(v.var) for v in forall.type_vars)}. '
+                f"{self.visit_type(forall.body_type)}"
+            )
         else:
             raise TypeError(f"A DAML forall Type is required here (got {forall!r} instead")
 
     # noinspection PyShadowingBuiltins
-    def visit_type_tuple(self, tuple: "Type.Tuple") -> str:
+    def visit_type_tuple(self, tuple: "NewType.Tuple") -> str:
         return "(" + ",".join(self.visit_type(t.type) for t in tuple.fields) + ")"
 
-    def _visit_type_app(self, types: "Sequence[Union[str, Type]]"):
+    def _visit_type_app(self, types: "Union[TypeApp, Sequence[Union[str, NewType, OldType]]]"):
+        if isinstance(types, TypeApp):
+            types = (types.body, *types.arguments)
+
         return " ".join(self.visit_type(c, True) for c in types)
 
     # endregion

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# type: ignore
 
 from io import StringIO
-from typing import Optional, Sequence
+from typing import Mapping, Optional, Sequence, Union
 
 from .. import LOG
 from ..damlast import daml_types as daml
@@ -12,7 +13,6 @@ from ..damlast.daml_lf_1 import (
     DefDataType,
     DefTemplate,
     Expr,
-    ModuleRef,
     PrimType,
     Scenario,
     Type,
@@ -20,10 +20,23 @@ from ..damlast.daml_lf_1 import (
     Update,
 )
 from ..damlast.util import def_value, module_name
+from ..model.types import ModuleRef, Type as OldType
+from ..model.types_store import PackageStore
 from ._render_base import PrettyPrintBase, pretty_print_syntax
 from .util import indent, maybe_parentheses
 
-__all__ = ["PythonPrettyPrint"]
+
+def values_by_module(
+    store: "PackageStore",
+) -> "Mapping[ModuleRef, Mapping[Sequence[str], Union[Expr, OldType]]]":
+    from collections import defaultdict
+
+    d = defaultdict(defaultdict)
+    for vn, vv in store._value_types.items():
+        d[vn.module][vn.name] = vv
+    for vn, vv in store._data_types.items():
+        d[vn.module][vn.name] = vv
+    return d
 
 
 @pretty_print_syntax("python")
@@ -78,19 +91,26 @@ class PythonPrettyPrint(PrettyPrintBase):
             lines.append('    """')
             lines.append("    Example usage:")
             lines.append(f'        create({template_full_name.replace(":", ".")},')
-            lines.append(f"               {python_example_object(self.lookup, def_data_type)})")
+            lines.append(f"               {python_example_object(self.store, def_data_type)})")
             for choice in template.choices:
                 lines.append(
-                    f"        exercise(cid, {choice.name!r}, {python_example_object(self.lookup, choice.arg_binder.type)})"
+                    f"        exercise(cid, {choice.name!r}, {python_example_object(self.store, choice.arg_binder.type)})"
                 )
             lines.append('    """')
             lines.append(indent(self._visit_def_type_body(slot_names), 4))
             for choice in template.choices:
                 ct = choice.arg_binder.type
+                if ct.prim is not None and ct.prim.prim == PrimType.UNIT:
+                    choice_slot_names = ()
+                else:
+                    tt = self.store.resolve_type_reference(ct.con.tycon)
+                    choice_slot_names = (
+                        tuple(name for name, _ in tt.named_args) if tt is not None else ()
+                    )
                 lines.append(
                     f"    class {choice.name}(metaclass=ChoiceMeta, template_name={template_full_name!r}, choice_name={choice.name!r}):"
                 )
-                lines.append(indent(self._visit_def_type_body(()), 8))
+                lines.append(indent(self._visit_def_type_body(choice_slot_names), 8))
             return "\n".join(lines)
         else:
             return ""

--- a/python/dazl/pretty/table/fmt_pretty.py
+++ b/python/dazl/pretty/table/fmt_pretty.py
@@ -49,7 +49,7 @@ class PrettyFormatter(Formatter):
             header_row = ["", "#cid", *(expand_record_field_names(context, Type.Con(name, ())))]
 
             with LOG.debug_timed("Render entries as strings"):
-                rows = [
+                orig_rows = [
                     (
                         sort.key(entry),
                         [
@@ -62,8 +62,8 @@ class PrettyFormatter(Formatter):
                 ]
 
             with LOG.debug_timed("Sort rows"):
-                rows.sort(key=lambda val: val[0])
-                rows = [row for _, row in rows]
+                orig_rows.sort(key=lambda val: val[0])
+                rows = [row for _, row in orig_rows]
                 rows.insert(0, header_row)
 
             with LOG.debug_timed("Measure entry sizes"):

--- a/python/dazl/pretty/table/model.py
+++ b/python/dazl/pretty/table/model.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import AbstractSet, Dict, Iterable, Iterator, Optional
-
-__all__ = ["Formatter", "RowBuilder", "TableBuilder"]
+from typing import AbstractSet, Dict, Iterable, Iterator, List, Optional
 
 from ...damlast.protocols import SymbolLookup
 from ...prim import ContractData, ContractId, Party
+
+__all__ = ["Formatter", "RowBuilder", "TableBuilder"]
 
 
 class Formatter:
@@ -42,7 +42,7 @@ class TableBuilder:
         self,
         party: "Party",
         cid: "ContractId",
-        cdata: "Optional[ContractData]",
+        cdata: "ContractData",
         time: "Optional[datetime]" = None,
     ) -> None:
         entry = self.entries.get(cid)
@@ -77,9 +77,9 @@ class RowBuilder:
         self.cid = cid
         self.cdata = cdata
         self.time = time
-        self.errors = []
+        self.errors = []  # type: List[Exception]
 
-    def extend(self, party: "Party", cdata: "ContractData") -> None:
+    def extend(self, party: "Party", cdata: "Optional[ContractData]") -> None:
         self.parties[party] = cdata is not None
 
     def is_archived(self) -> bool:


### PR DESCRIPTION
Replace the contents of `dazl/pretty` on master with files from the v7 release branch.

This undoes some of the changes in #159, but also makes it so that `dazl/pretty` typechecks on master.

Depends on #211, which reintroduces the `dazl.model.types` symbols that `dazl/pretty` depends on in v7.