### PR TITLE
python: Break dazl.protocols' compile-time dependency on dazl.models.

### DIFF
--- a/python/dazl/model/types.py
+++ b/python/dazl/model/types.py
@@ -47,7 +47,7 @@ import warnings
 
 from .. import LOG
 from ..damlast.daml_lf_1 import DottedName, Expr, ModuleRef, PackageRef, TypeConName
-from ..model.core import ContractData, Party
+from ..prim import ContractData, Party
 from ..util.typing import safe_cast, safe_dict_cast, safe_optional_cast
 
 warnings.warn("The symbols in dazl.model.types are deprecated", DeprecationWarning, stacklevel=2)

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -7,17 +7,21 @@ process that implements the Ledger API.
 """
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from .. import LOG
 from ..damlast.lookup import MultiPackageLookup
-from ..model.ledger import LedgerMetadata
-from ..model.network import HTTPConnectionSettings
-from ..model.reading import BaseEvent, ContractFilter, TransactionFilter
-from ..model.writing import CommandPayload
 from ..prim import Party
 from ..scheduler import Invoker
-from ..util.typing import safe_cast, safe_optional_cast
+
+if TYPE_CHECKING:
+    from ..model.ledger import LedgerMetadata
+    from ..model.network import HTTPConnectionSettings
+    from ..model.reading import BaseEvent, ContractFilter, TransactionFilter
+    from ..model.writing import CommandPayload
+
+
+__all__ = ["LedgerConnectionOptions", "LedgerNetwork", "LedgerClient", "_LedgerConnection"]
 
 
 @dataclass(frozen=True)
@@ -36,7 +40,7 @@ class LedgerNetwork:
     async def connect(
         self,
         party: "Union[str, Party]",
-        settings: HTTPConnectionSettings,
+        settings: "HTTPConnectionSettings",
         context_path: "Optional[str]",
     ) -> "LedgerClient":
         """
@@ -128,16 +132,16 @@ class _LedgerConnection:
         self,
         invoker: "Invoker",
         options: "LedgerConnectionOptions",
-        settings: HTTPConnectionSettings,
+        settings: "HTTPConnectionSettings",
         context_path: Optional[str],
     ):
         LOG.debug("Creating a gRPC channel for %s...", settings)
         import threading
 
-        self.invoker = safe_cast(Invoker, invoker)
-        self.options = safe_cast(LedgerConnectionOptions, options)
-        self.settings = safe_cast(HTTPConnectionSettings, settings)
-        self.context_path = safe_optional_cast(str, context_path)
+        self.invoker = invoker
+        self.options = options
+        self.settings = settings
+        self.context_path = context_path
         self.close_evt = threading.Event()
 
     def close(self):

--- a/python/dazl/protocols/oauth.py
+++ b/python/dazl/protocols/oauth.py
@@ -2,19 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import TYPE_CHECKING
 
-import requests
+if TYPE_CHECKING:
+    from ..model.network import OAuthSettings
 
-from ..model.network import OAuthSettings
+
+__all__ = ["oauth_flow"]
 
 
-async def oauth_flow(settings: OAuthSettings) -> OAuthSettings:
+async def oauth_flow(settings: "OAuthSettings") -> "OAuthSettings":
     """
     Implementation of an OAuth flow that ensures that a token is provided.
 
     :param settings:
     :return:
     """
+    import requests
+
+    from ..model.network import OAuthSettings
+
     if not settings.token:
 
         if settings.auth_audience == None:

--- a/python/dazl/protocols/v0/json_ser_command.py
+++ b/python/dazl/protocols/v0/json_ser_command.py
@@ -7,13 +7,18 @@ types over the wire on the REST interface using JSON.
 """
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import warnings
 
 from ...damlast.daml_lf_1 import TypeConName
-from ...model.writing import AbstractSerializer, CommandPayload
+from ...model.writing import AbstractSerializer
 from ...prim import ContractId, JSONEncoder
 from ...values.json import JsonEncoder
+
+if TYPE_CHECKING:
+    from ...model.writing import CommandPayload
+
+__all__ = ["LedgerJSONEncoder", "to_api_datetime", "JsonSerializer"]
 
 
 class LedgerJSONEncoder(JSONEncoder):
@@ -65,7 +70,7 @@ class JsonSerializer(AbstractSerializer):
 
     mapper = JsonEncoder()
 
-    def serialize_command_request(self, command_payload: CommandPayload) -> dict:
+    def serialize_command_request(self, command_payload: "CommandPayload") -> dict:
         commands = [self.serialize_command(command) for command in command_payload.commands]
         return dict(
             businessIntent=command_payload.command_id,

--- a/python/dazl/protocols/v1/model/__init__.py
+++ b/python/dazl/protocols/v1/model/__init__.py
@@ -1,6 +1,12 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
+warnings.warn(
+    "dazl.protocols.v1.model is deprecated; use the types in dazl._gen instead", DeprecationWarning
+)
+
 from ...._gen.com.daml.daml_lf_dev.daml_lf_1_pb2 import (
     DefDataType,
     DefTemplate,

--- a/python/dazl/protocols/v1/pb_parse_event.py
+++ b/python/dazl/protocols/v1/pb_parse_event.py
@@ -244,7 +244,7 @@ class TransactionEventDeserializationContext(BaseEventDeserializationContext):
 
 
 def serialize_transactions_request(
-    f: "TransactionFilter", ledger_id: str, party: str
+    f: "TransactionFilter", ledger_id: str, party: Party
 ) -> "txs_pb2.GetTransactionsRequest":
     if f.current_offset is not None:
         ledger_offset = lo_pb2.LedgerOffset()
@@ -269,7 +269,7 @@ def serialize_transactions_request(
 
 
 def serialize_acs_request(
-    f: "ContractFilter", ledger_id: str, party: str
+    f: "ContractFilter", ledger_id: str, party: Party
 ) -> "acs_pb2.GetActiveContractsRequest":
     return acs_pb2.GetActiveContractsRequest(
         ledger_id=ledger_id, filter=serialize_transaction_filter(f, party)
@@ -277,7 +277,7 @@ def serialize_acs_request(
 
 
 def serialize_event_id_request(
-    ledger_id: str, event_id: str, requesting_parties: "Sequence[str]"
+    ledger_id: str, event_id: str, requesting_parties: "Sequence[Party]"
 ) -> "txs_pb2.GetTransactionByEventIdRequest":
     return txs_pb2.GetTransactionByEventIdRequest(
         ledger_id=ledger_id, event_id=event_id, requesting_parties=requesting_parties
@@ -285,7 +285,7 @@ def serialize_event_id_request(
 
 
 def serialize_transaction_filter(
-    contract_filter: "ContractFilter", party: str
+    contract_filter: "ContractFilter", party: Party
 ) -> "txf_pb2.TransactionFilter":
     from .pb_ser_command import as_identifier
 

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -19,10 +19,11 @@ from ...damlast.daml_lf_1 import (
     TypeConName,
     ValName,
 )
-from ...damlast.types import get_old_type
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
+
+    from ...damlast.types import get_old_type
     from ...model.types import (
         SCALAR_TYPE_UNIT,
         EnumType,
@@ -318,14 +319,13 @@ def _parse_daml_metadata_pb(archive: "Archive") -> "PackageStore":
         return psb.build()
 
 
+# noinspection PyDeprecation
 def create_data_type(
     current_module_ref: "ModuleRef", dt: "DefDataType"
 ) -> "Union[RecordType, VariantType, EnumType, ScalarType]":
     warnings.warn(
         "create_data_type is deprecated; there is no replacement.", DeprecationWarning, stacklevel=2
     )
-
-    from ...damlast.types import get_old_type
 
     type_vars = tuple(TypeVariable(type_var.var) for type_var in dt.params)
     tt = TypeReference(con=TypeConName(current_module_ref, dt.name.segments))

--- a/python/dazl/protocols/v1/pb_ser_command.py
+++ b/python/dazl/protocols/v1/pb_ser_command.py
@@ -7,19 +7,31 @@ Conversion methods to Ledger API Protobuf-generated types from dazl/Pythonic typ
 from typing import Any, Union
 import warnings
 
-# noinspection PyPep8Naming
-from . import model as G
+from ..._gen.com.daml.ledger.api.v1.command_submission_service_pb2 import (
+    SubmitRequest as G_SubmitRequest,
+)
+from ..._gen.com.daml.ledger.api.v1.commands_pb2 import (
+    Command as G_Command,
+    Commands as G_Commands,
+    CreateAndExerciseCommand as G_CreateAndExerciseCommand,
+    CreateCommand as G_CreateCommand,
+    ExerciseByKeyCommand as G_ExerciseByKeyCommand,
+    ExerciseCommand as G_ExerciseCommand,
+)
+from ..._gen.com.daml.ledger.api.v1.value_pb2 import Identifier as G_Identifier
 from ...damlast.daml_lf_1 import TypeConName
-from ...model.writing import AbstractSerializer, CommandPayload
+from ...damlast.util import module_local_name, module_name, package_ref
+from ...model.writing import AbstractSerializer
 from ...prim import ContractId, timedelta_to_duration
 from ...values.protobuf import ProtobufEncoder, set_value
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
     from ...model.types import TypeReference
+    from ...model.writing import CommandPayload
 
 
-def as_identifier(tref: "Union[TypeReference, TypeConName]") -> "G.Identifier":
+def as_identifier(tref: "Union[TypeReference, TypeConName]") -> "G_Identifier":
     if isinstance(tref, TypeReference):
         warnings.warn(
             "as_identifier(TypeReference) is deprecated; use as_identifier(TypeConName) instead.",
@@ -30,7 +42,7 @@ def as_identifier(tref: "Union[TypeReference, TypeConName]") -> "G.Identifier":
         tref = tref.con
 
     if isinstance(tref, TypeConName):
-        identifier = G.Identifier()
+        identifier = G_Identifier()
         _set_template(identifier, tref)
         return identifier
 
@@ -46,10 +58,10 @@ class ProtobufSerializer(AbstractSerializer):
     # COMMAND serializers
     ################################################################################################
 
-    def serialize_command_request(self, command_payload: CommandPayload) -> G.SubmitRequest:
+    def serialize_command_request(self, command_payload: "CommandPayload") -> G_SubmitRequest:
         commands = [self.serialize_command(command) for command in command_payload.commands]
-        return G.SubmitRequest(
-            commands=G.Commands(
+        return G_SubmitRequest(
+            commands=G_Commands(
                 ledger_id=command_payload.ledger_id,
                 workflow_id=command_payload.workflow_id,
                 application_id=command_payload.application_id,
@@ -64,28 +76,28 @@ class ProtobufSerializer(AbstractSerializer):
             )
         )
 
-    def serialize_create_command(self, name: "TypeConName", template_args: "Any") -> G.Command:
+    def serialize_create_command(self, name: "TypeConName", template_args: "Any") -> G_Command:
         create_ctor, create_value = template_args
         if create_ctor != "record":
             raise ValueError("Template values must resemble records")
 
-        cmd = G.CreateCommand()
+        cmd = G_CreateCommand()
         _set_template(cmd.template_id, name)
         cmd.create_arguments.MergeFrom(create_value)
-        return G.Command(create=cmd)
+        return G_Command(create=cmd)
 
     def serialize_exercise_command(
         self, contract_id: "ContractId", choice_name: str, choice_args: "Any"
-    ) -> G.Command:
+    ) -> G_Command:
         type_ref = contract_id.value_type
         ctor, value = choice_args
 
-        cmd = G.ExerciseCommand()
+        cmd = G_ExerciseCommand()
         _set_template(cmd.template_id, type_ref)
         cmd.contract_id = contract_id.value
         cmd.choice = choice_name
         set_value(cmd.choice_argument, ctor, value)
-        return G.Command(exercise=cmd)
+        return G_Command(exercise=cmd)
 
     def serialize_exercise_by_key_command(
         self,
@@ -93,16 +105,16 @@ class ProtobufSerializer(AbstractSerializer):
         key_arguments: Any,
         choice_name: str,
         choice_arguments: Any,
-    ) -> G.Command:
+    ) -> G_Command:
         key_ctor, key_value = key_arguments
         choice_ctor, choice_value = choice_arguments
 
-        cmd = G.ExerciseByKeyCommand()
+        cmd = G_ExerciseByKeyCommand()
         _set_template(cmd.template_id, template_name)
         set_value(cmd.contract_key, key_ctor, key_value)
         cmd.choice = choice_name
         set_value(cmd.choice_argument, choice_ctor, choice_value)
-        return G.Command(exerciseByKey=cmd)
+        return G_Command(exerciseByKey=cmd)
 
     def serialize_create_and_exercise_command(
         self,
@@ -110,23 +122,21 @@ class ProtobufSerializer(AbstractSerializer):
         create_arguments: "Any",
         choice_name: str,
         choice_arguments: Any,
-    ) -> G.Command:
+    ) -> G_Command:
         create_ctor, create_value = create_arguments
         if create_ctor != "record":
             raise ValueError("Template values must resemble records")
         choice_ctor, choice_value = choice_arguments
 
-        cmd = G.CreateAndExerciseCommand()
+        cmd = G_CreateAndExerciseCommand()
         _set_template(cmd.template_id, template_name)
         cmd.create_arguments.MergeFrom(create_value)
         cmd.choice = choice_name
         set_value(cmd.choice_argument, choice_ctor, choice_value)
-        return G.Command(createAndExercise=cmd)
+        return G_Command(createAndExercise=cmd)
 
 
-def _set_template(message: G.Identifier, name: "TypeConName") -> None:
-    from ...damlast.util import module_local_name, module_name, package_ref
-
+def _set_template(message: G_Identifier, name: "TypeConName") -> None:
     message.package_id = package_ref(name)
     message.module_name = str(module_name(name))
     message.entity_name = module_local_name(name)


### PR DESCRIPTION
This is in preparation for simply lifting the implementation of `dazl.protocols` as-is on the release branch into `master` (see #207).

On `master`, the `dazl.model` package is entirely deprecated; this will be the case for dazl v7.5 as well, but one thing required to make that a reality is that _no_ package can depend on `dazl.model`, as otherwise circular imports could be introduced. This PR moves the relevant imports either under a `if TYPE_CHECKING:` guard, or internally into functions that specifically still refer to those symbols.

This also drops the usage of `dazl.protocols.v1.model`, which was meant to be a convenient collection of Protobuf types. (I mostly dropped this because in trying to prepare this PR, I was looking for imports that contained the word `model` and those were in the list.)