### PR TITLE
python: Backport dazl/prim/*.py from the v7 release branch.

### DIFF
--- a/python/dazl/prim/basic.py
+++ b/python/dazl/prim/basic.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 import re
-from typing import Any
+from typing import Any, Optional
 
 __all__ = [
     "LEDGER_STRING_REGEX",
@@ -20,7 +21,7 @@ PARTY_ID_STRING_REGEX = re.compile(r"[A-Za-z0-9:\-_ ]")
 LEDGER_STRING_REGEX = re.compile(r"[A-Za-z0-9#:\-_/ ]")
 
 
-def to_bool(obj: Any) -> bool:
+def to_bool(obj: "Optional[Any]") -> "Optional[bool]":
     """
     Convert any of the common wire representations of a ``bool`` to a ``bool``.
     """
@@ -41,7 +42,7 @@ def to_bool(obj: Any) -> bool:
     raise ValueError(f"Could not parse as a boolean: {obj!r}")
 
 
-def to_str(obj: Any) -> str:
+def to_str(obj: "Any") -> str:
     """
     Convert any object to a string. This simply calls ``str`` on the object to produce a string
     representation.

--- a/python/dazl/prim/complex.py
+++ b/python/dazl/prim/complex.py
@@ -6,7 +6,7 @@ Contains functions for working with "native" Python types as they correspond to 
 Ledger API.
 """
 
-from typing import Any, Mapping, Tuple
+from typing import Any, Dict, Mapping, Tuple
 
 __all__ = ["to_record", "to_variant"]
 
@@ -23,7 +23,7 @@ def to_record(obj: "Any") -> "Mapping[str, Any]":
         raise ValueError("a mapping is required")
 
     # pull out any specialized dotted-field mappings
-    reformatted = dict()
+    reformatted = dict()  # type: Dict[str, Any]
     for key, value in obj.items():
         k1, d, k2 = key.partition(".")
         if d:

--- a/python/dazl/prim/contracts.py
+++ b/python/dazl/prim/contracts.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
-from ..damlast.daml_lf_1 import TypeConName
+if TYPE_CHECKING:
+    from ..damlast.daml_lf_1 import TypeConName
 
 __all__ = ["ContractId", "ContractData"]
 
@@ -11,29 +12,37 @@ __all__ = ["ContractId", "ContractData"]
 class ContractId:
     """
     A typed contract ID.
-
-    Instance attributes:
-
-    .. attribute:: ContractId.value
-
-        The raw contract ID value (for example, ``"#4:1"``).
-
-    .. attribute:: ContractId.value_type
-
-        The type of template that is pointed to by this :class:`ContractId`.
-
     """
 
-    __slots__ = "value", "value_type"
+    __slots__ = "_value", "_value_type"
+    if TYPE_CHECKING:
+        _value: str
+        _value_type: TypeConName
 
     def __init__(self, value_type: "TypeConName", value: str):
+        from ..damlast.daml_lf_1 import TypeConName
+
         if not isinstance(value_type, TypeConName):
             raise ValueError("value_type must be a TypeConName")
         if not isinstance(value, str):
             raise ValueError("value must be a string")
 
-        object.__setattr__(self, "value_type", value_type)
-        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "_value_type", value_type)
+        object.__setattr__(self, "_value", value)
+
+    @property
+    def value(self) -> str:
+        """
+        Return the raw contract ID value (for example, ``"#4:1"``).
+        """
+        return self._value
+
+    @property
+    def value_type(self) -> "TypeConName":
+        """
+        Return the type of template that is pointed to by this :class:`ContractId`.
+        """
+        return self._value_type
 
     def __str__(self):
         """

--- a/python/dazl/prim/datetime.py
+++ b/python/dazl/prim/datetime.py
@@ -4,7 +4,7 @@
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from functools import partial
-from typing import Any, Union
+from typing import Any, Callable, Sequence, Union
 
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -48,12 +48,12 @@ def _parse_nano_format(value: str) -> "datetime":
         raise ValueError("could not parse")
 
 
-DATE_FORMATS = [
+DATE_FORMATS: Sequence[Callable[[str], datetime]] = [
     partial(_parse, "%Y-%m-%d"),
     partial(_parse, "%Y.%m.%d"),
 ]
 
-DATETIME_FORMATS = [
+DATETIME_FORMATS: Sequence[Callable[[str], datetime]] = [
     partial(_parse, DATETIME_ISO8601_Z_FORMAT),
     _parse_nano_format,
     partial(_parse, "%Y-%m-%dT%H:%M:%S.%f"),
@@ -215,6 +215,6 @@ def timedelta_to_duration(obj: "timedelta") -> "Duration":
     Return the Python ``timestamp`` as a Protobuf ``google.protobuf.Duration``.
     """
     d = Duration()
-    d.seconds = obj.total_seconds()
+    d.seconds = int(obj.total_seconds())
     d.nanos = obj.microseconds * 1000
     return d

--- a/python/dazl/prim/numbers.py
+++ b/python/dazl/prim/numbers.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 __all__ = ["to_int", "to_decimal", "decimal_to_str"]
 
@@ -17,7 +17,7 @@ def to_int(obj: "Any") -> int:
     raise ValueError(f"Could not parse as an int: {obj!r}")
 
 
-def to_decimal(obj: "Any") -> "Decimal":
+def to_decimal(obj: "Optional[Any]") -> "Optional[Decimal]":
     """
     Convert any of the common wire representations of a ``Decimal`` to a ``Decimal``.
     """


### PR DESCRIPTION
This is a backport of the files in `dazl/prim` exactly as-is from the release branch, _except_ for also including the regular expressions defined here, which have been added to `master` but not on the release branch.

https://github.com/digital-asset/daml/blob/988f3e509ebc3f164cc355fcb9b65e2eafa67db6/ledger-api/grpc-definitions/com/daml/ledger/api/v1/value.proto#L18-L21