### PR TITLE
python: Backport dazl/values/*.py from the v7 release branch.

### DIFF
--- a/python/dazl/values/canonical.py
+++ b/python/dazl/values/canonical.py
@@ -18,6 +18,8 @@ from ..prim import (
 from .context import Context
 from .mapper import ValueMapper
 
+__all__ = ["CanonicalMapper"]
+
 
 class CanonicalMapper(ValueMapper):
     """

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -194,6 +194,38 @@ class Context:
             for key, value in elements.items()
         }
 
+    def convert_gen_map(
+        self,
+        key_type: "Type",
+        value_type: "Type",
+        elements: "Mapping[Any, Any]",
+        mapper: "Optional[ValueMapper]" = None,
+    ) -> "Dict[str, Any]":
+        """
+        Convert a _map_ of elements, each of an assumed type.
+
+        This is a convenience method for :class:`ValueMapper` implementations where DAML-LF TextMaps
+        are represented as Python dictionaries. Note that a :class:`ValueMapper` may choose to
+        implement TextMap type conversion in a completely different way instead of calling this
+        function, which may be necessary if a TextMap of DAML-LF values is encoded in a way other
+        than a Python dict (i.e., Protobuf).
+
+        :param key_type:
+            The :class:`Type` of the key.
+        :param value_type:
+            The :class:`Type` of the value.
+        :param elements:
+            A mapping of keys to values.
+        :param mapper:
+            If not ``None``, an alternate mapper to use when descending down the object.
+        """
+        return {
+            self.append_path("[i]", mapper=mapper)
+            .convert(key_type, key): self.append_path(key, mapper=mapper)
+            .convert(value_type, value)
+            for i, (key, value) in enumerate(elements.items())
+        }
+
     def convert_contract_id(self, element_type: "Type", contract_id: "Any") -> "ContractId":
         """
         Convert a contract ID string to a :class:`ContractId`.
@@ -310,6 +342,13 @@ class Context:
         raise ValueError(
             f'value at {".".join(self.path)} has an invalid value: {value} ({message})'
         )
+
+    @property
+    def depth(self) -> int:
+        """
+        Return the number of components in the path of this context.
+        """
+        return len(self.path)
 
     def _replace_all_type_vars(
         self, type_vars: "Mapping[str, Type]", fields: "DefDataType.Fields"

--- a/python/dazl/values/json.py
+++ b/python/dazl/values/json.py
@@ -42,7 +42,8 @@ class JsonEncoder(CanonicalMapper):
         return obj.contract_id
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return decimal_to_str(d) if d is not None else None
 
     def _ctor_value_to_variant(
         self,

--- a/python/dazl/values/mapper.py
+++ b/python/dazl/values/mapper.py
@@ -14,7 +14,6 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Protocol
 
-
 __all__ = ["ValueMapper"]
 
 

--- a/python/dazl/values/protobuf.py
+++ b/python/dazl/values/protobuf.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, Optional, Type as PyType, TypeVar
 
 from google.protobuf import timestamp_pb2
 from google.protobuf.empty_pb2 import Empty
@@ -222,7 +222,8 @@ class ProtobufEncoder(ValueMapper):
         return "map", msg
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return "numeric", decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return "numeric", decimal_to_str(d) if d is not None else None
 
     def prim_gen_map(
         self, context: "Context", key_type: "Type", value_type: "Type", obj: "Any"
@@ -237,7 +238,7 @@ class ProtobufEncoder(ValueMapper):
         return "gen_map", msg
 
 
-def get_value(obj: "Any", field: str, pb_type: "Type[T]") -> "T":
+def get_value(obj: "Any", field: str, pb_type: "PyType[T]") -> "T":
     return obj if isinstance(obj, pb_type) else getattr(obj, field)
 
 

--- a/python/dazl/values/pysample_encoder.py
+++ b/python/dazl/values/pysample_encoder.py
@@ -4,7 +4,8 @@
 from typing import Any
 
 from ..damlast.daml_lf_1 import DefDataType, Type as DamlType
-from .mapper import Context, ValueMapper, convert
+from .context import Context
+from .mapper import ValueMapper
 
 
 class PythonSampleEncoder(ValueMapper):
@@ -15,7 +16,7 @@ class PythonSampleEncoder(ValueMapper):
         if context.depth <= self.max_depth:
             return "..."
         else:
-            return convert(self, context.append_path(key), item_type, None)
+            return context.append_path(key).convert(item_type, None)
 
     def data_record(
         self, context: "Context", dt: "DefDataType", record: "DefDataType.Fields", obj: "Any"

--- a/python/dazl/values/string.py
+++ b/python/dazl/values/string.py
@@ -110,7 +110,8 @@ class StringMapperBase(ValueMapper):
         )
 
     def prim_numeric(self, context: "Context", nat: int, obj: "Any") -> "Any":
-        return decimal_to_str(to_decimal(obj))
+        d = to_decimal(obj)
+        return decimal_to_str(d) if d is not None else None
 
     def prim_gen_map(
         self, context: "Context", key_type: "Type", value_type: "Type", obj: "Any"


### PR DESCRIPTION
More backports in service of #207.

The only notable difference between this and the release branch contents is the release branch still supports deprecated `ContractId`'s…this needs to be restored too, but can only be done in conjunction with resurrecting the deprecated type system.