### PR TITLE
python: Some more refactors ahead of reintroducing dazl.model.types/types_store

### DIFF
--- a/python/dazl/client/_network_client_impl.py
+++ b/python/dazl/client/_network_client_impl.py
@@ -562,7 +562,14 @@ class _NetworkRunner:
         # Raise the 'init' event.
         init_futs = []
         if first_offset is None:
-            evt = InitEvent(None, None, None, metadata.ledger_id, self._network_impl.lookup)
+            evt = InitEvent(
+                None,
+                None,
+                None,
+                metadata.ledger_id,
+                self._network_impl.lookup,
+                metadata._store,
+            )
             init_futs.append(ensure_future(self._network_impl.emit_event(evt)))
         for party_impl in party_impls:
             init_futs.append(ensure_future(party_impl.initialize(None, metadata)))
@@ -585,6 +592,7 @@ class _NetworkRunner:
                 None,
                 metadata.ledger_id,
                 self._network_impl.lookup,
+                metadata._store,
                 offset,
             )
             ready_futs.append(ensure_future(self._network_impl.emit_event(evt)))

--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -141,7 +141,14 @@ class _PartyClientImpl:
         :param metadata:
             Information about the connected ledger.
         """
-        evt = InitEvent(self, self.party, current_time, metadata.ledger_id, self.parent.lookup)
+        evt = InitEvent(
+            self,
+            self.party,
+            current_time,
+            metadata.ledger_id,
+            self.parent.lookup,
+            metadata._store,
+        )
         return self.emit_event(evt)
 
     def ready(self) -> Awaitable[None]:
@@ -173,7 +180,9 @@ class _PartyClientImpl:
         """
         return self.bots.notify(data)
 
-    async def emit_ready(self, metadata: LedgerMetadata, time: datetime, offset: str) -> None:
+    async def emit_ready(
+        self, metadata: LedgerMetadata, time: "Optional[datetime]", offset: str
+    ) -> None:
         """
         Emit a ready event specific to this client. This may also emit initial create events and
         initial package added events.
@@ -189,13 +198,13 @@ class _PartyClientImpl:
             have been processed.
         """
         ready_event = ReadyEvent(
-            self, self.party, time, metadata.ledger_id, self.parent.lookup, offset
+            self, self.party, time, metadata.ledger_id, self.parent.lookup, metadata._store, offset
         )
         self._known_packages.update(self.parent.lookup.package_ids())
         await self.emit_event(ready_event)
 
         pkg_event = PackagesAddedEvent(
-            self, self.party, time, metadata.ledger_id, self.parent.lookup, True
+            self, self.party, time, metadata.ledger_id, self.parent.lookup, metadata._store, True
         )
         await self.emit_event(pkg_event)
 
@@ -338,6 +347,7 @@ class _PartyClientImpl:
                     None,
                     metadata.ledger_id,
                     self.parent.lookup,
+                    metadata._store,
                     False,
                 )
                 self._known_packages.update(all_packages)

--- a/python/dazl/client/events.py
+++ b/python/dazl/client/events.py
@@ -3,12 +3,7 @@
 from typing import Any, Callable, Collection, Iterator, TypeVar
 import warnings
 
-from ..damlast.lookup import (
-    matching_normalizations,
-    normalize,
-    parse_type_con_name,
-    validate_template,
-)
+from ..damlast.lookup import matching_normalizations, normalize, validate_template
 from ..protocols.events import (
     BaseEvent,
     ContractArchiveEvent,
@@ -22,7 +17,7 @@ from ..protocols.events import (
     TransactionStartEvent,
 )
 
-__all__ = ["EventKey", "template_reverse_globs"]
+__all__ = ["EventKey", "_template_reverse_globs"]
 
 T = TypeVar("T")
 
@@ -63,19 +58,10 @@ def create_dispatch(
     return handle
 
 
-def template_reverse_globs(primary_only: bool, package_id: str, type_name: str) -> "Iterator[str]":
+def _template_reverse_globs(primary_only: bool, package_id: str, type_name: str) -> "Iterator[str]":
     """
     Return an iterator over strings that glob to a specified type.
     """
-    warnings.warn(
-        "template_reverse_globs is deprecated; use either "
-        "dazl.damlast.lookup.matching_normalizations (for template_reverse_globs(False, ...)) or "
-        "dazl.damlast.lookup.normalize(for template_reverse_globs(True, ...)). "
-        "Note that the new functions do NOT support periods as a delimiter between "
-        "module names and entity names; you MUST use a colon.",
-        DeprecationWarning,
-    )
-
     # support deprecated type identifiers for usages of this old API to preserve backwards
     # compatibility
     use_deprecated_form = False
@@ -193,4 +179,4 @@ class EventKey:
         m, t = validate_template(template)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            return tuple(f"{prefix}/{g}" for g in template_reverse_globs(primary_only, m, t))
+            return tuple(f"{prefix}/{g}" for g in _template_reverse_globs(primary_only, m, t))

--- a/python/dazl/client/ledger.py
+++ b/python/dazl/client/ledger.py
@@ -5,10 +5,13 @@
 Types that describe the behavior of the ledger itself.
 """
 from dataclasses import dataclass
+from typing import Any
+import warnings
 
-from dazl.ledger.pkgloader_aio import PackageLoader
-
+from ..ledger.pkgloader_aio import PackageLoader
 from ..protocols.serializers import Serializer
+
+__all__ = ["LedgerMetadata"]
 
 
 @dataclass(init=False, frozen=True)
@@ -21,9 +24,24 @@ class LedgerMetadata:
     package_loader: "PackageLoader"
     serializer: "Serializer"
     protocol_version: str
+    _store: Any
 
-    def __init__(self, ledger_id, package_loader, serializer, protocol_version):
+    def __init__(self, ledger_id, package_loader, serializer, protocol_version, store):
         object.__setattr__(self, "ledger_id", ledger_id)
         object.__setattr__(self, "package_loader", package_loader)
         object.__setattr__(self, "serializer", serializer)
         object.__setattr__(self, "protocol_version", protocol_version)
+        object.__setattr__(self, "_store", store)
+
+    @property
+    def store(self) -> "Any":
+        if self._store is None:
+            raise Exception("eager_package_fetch is disabled, which disables the PackageStore")
+
+        warnings.warn(
+            "PackageStore is deprecated; use SymbolLookup "
+            "(accessible from Network.lookup) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._store

--- a/python/dazl/model/lookup.py
+++ b/python/dazl/model/lookup.py
@@ -5,8 +5,43 @@
 This module has been relocated to ``dazl.client.events`` or ``dazl.damlast.lookup``.
 """
 
-# noinspection PyDeprecation
-from ..client.events import template_reverse_globs
-from ..damlast.lookup import validate_template
+from typing import TYPE_CHECKING, Any, Iterator, Tuple, Union
+import warnings
 
 __all__ = ["validate_template", "template_reverse_globs"]
+
+if TYPE_CHECKING:
+    from ..damlast.daml_lf_1 import PackageRef
+
+
+def validate_template(template: "Any") -> "Tuple[Union[str, PackageRef], str]":
+    from ..damlast.lookup import validate_template as validate_template_new
+
+    warnings.warn(
+        "validate_template is deprecated; use dazl.damlast.lookup.validate_template",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    if template == "*" or template is None:
+        return "*", "*"
+
+    return validate_template_new(template)
+
+
+def template_reverse_globs(primary_only: bool, package_id: str, type_name: str) -> "Iterator[str]":
+    """
+    Return an iterator over strings that glob to a specified type.
+    """
+    # noinspection PyProtectedMember
+    from ..client.events import _template_reverse_globs
+
+    warnings.warn(
+        "template_reverse_globs is deprecated; use either "
+        "dazl.damlast.lookup.matching_normalizations (for template_reverse_globs(False, ...)) or "
+        "dazl.damlast.lookup.normalize(for template_reverse_globs(True, ...)). "
+        "Note that the new functions do NOT support periods as a delimiter between "
+        "module names and entity names; you MUST use a colon.",
+        DeprecationWarning,
+    )
+    return _template_reverse_globs(primary_only, package_id, type_name)

--- a/python/dazl/protocols/events.py
+++ b/python/dazl/protocols/events.py
@@ -68,15 +68,20 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BaseEvent",
-    "ContractArchiveEvent",
-    "ContractCreateEvent",
-    "ContractExercisedEvent",
     "InitEvent",
     "OffsetEvent",
-    "PackagesAddedEvent",
     "ReadyEvent",
-    "TransactionEndEvent",
+    "ActiveContractSetEvent",
+    "BaseTransactionEvent",
     "TransactionStartEvent",
+    "TransactionEndEvent",
+    "ContractEvent",
+    "ContractCreateEvent",
+    "ContractExercisedEvent",
+    "ContractArchiveEvent",
+    "PackagesAddedEvent",
+    "ContractFilter",
+    "TransactionFilter",
 ]
 
 
@@ -91,6 +96,9 @@ class BaseEvent:
     time: "Optional[datetime]"
     ledger_id: str
     lookup: "SymbolLookup"
+
+    # TODO: Replace with PackageStore
+    package_store: "Any"
 
     def acs_find_active(self, template: "Union[str, TypeConName]", match=None):
         return self.client.find_active(template, match)

--- a/python/tests/unit/test_damlast_lookup_normalizations.py
+++ b/python/tests/unit/test_damlast_lookup_normalizations.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from dazl.client.events import template_reverse_globs
 from dazl.damlast.lookup import matching_normalizations, normalize
+from dazl.model.lookup import template_reverse_globs
 
 
 def test_non_primary_simple_unknown_module():


### PR DESCRIPTION
Some more refactors ahead of reintroducing `dazl.model.types` and `dazl.model.types_store` from the v7 release branch back on master.

In particular this reintroduces the deprecated `BaseEvent.store` and `LedgerMetadata.store` properties, but populates them with `object()` instead of an instance of `dazl.model.types_store.PackageStore`, as well as bringing back some of the code that supports deprecated type identifiers.