### PR TITLE
python: Backport deserializing backwards-compatible ContractId's

### DIFF
--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -5,7 +5,7 @@
 This module has been relocated to ``dazl.client``, ``dazl.damlast``, ``dazl.protocols``, or
 ``dazl.query``.
 """
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar, Union
 import warnings
 
 from ..client.errors import ConfigurationError, DazlPartyMissingError, UnknownTemplateWarning
@@ -15,12 +15,16 @@ from ..client.state import (
     ContractsHistoricalState,
     ContractsState,
 )
+from ..damlast.daml_lf_1 import TypeConName
 from ..damlast.pkgfile import Dar
-from ..prim import ContractData, ContractId, DazlError, DazlWarning, Party
+from ..prim import ContractData, ContractId as ContractId_, DazlError, DazlWarning, Party
 from ..prim.errors import DazlImportError
 from ..protocols.errors import ConnectionTimeoutError, UserTerminateRequest
 from ..query import ContractMatch
 from ..util.proc_util import ProcessDiedException
+
+if TYPE_CHECKING:
+    from .types import Type, TypeReference
 
 T = TypeVar("T")
 
@@ -45,6 +49,95 @@ __all__ = [
     "UnknownTemplateWarning",
     "UserTerminateRequest",
 ]
+
+
+class ContractId(ContractId_):
+    __slots__ = ("_value_type_deprecated",)
+    _value_type_deprecated: "TypeReference"
+
+    def __init__(self, contract_id: str, template_id: "Union[str, Type, TypeConName]"):
+        warnings.warn(
+            "dazl.model.core.ContractId is deprecated; use dazl.prim.ContractId instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from ..damlast.compat import parse_template
+
+        if not isinstance(contract_id, str):
+            raise ValueError("contract_id must be a string")
+
+        value = contract_id
+        value_type, value_type_deprecated = parse_template(template_id)
+
+        super().__init__(value_type, value)
+        object.__setattr__(self, "_value_type_deprecated", value_type_deprecated)
+
+    @property
+    def contract_id(self) -> str:
+        """
+        Get the raw contract ID value (for example, ``"#4:1"``).
+        """
+        warnings.warn(
+            "ContractId.contract_id is deprecated; use ContractId.value instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.value
+
+    @property
+    def template_id(self) -> "TypeReference":
+        """
+        Get the type of template that is pointed to by this :class:`ContractId` as a
+        :class:`TypeReference`. Note that usage of :class:`Type` and :class:`TypeReference` are
+        deprecated, and :meth:`value_type` should be used instead.
+
+        As of dazl 7.3.0, the :class:`TemplateId` is always normalized to a :class:`TypeReference`,
+        regardless of what the :class:`ContractId` was constructed with.
+        """
+        warnings.warn(
+            "ContractId.template_id is deprecated; use ContractId.value_type instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value_type_deprecated
+
+    def exercise(self, choice_name, arguments=None):
+        """
+        Create an :class:`ExerciseCommand` that represents the result of exercising a choice on this
+        contract with the specified choice.
+
+        :param choice_name:
+            The name of the choice to exercise.
+        :param arguments:
+            (optional) A ``dict`` of named values to send as parameters to the choice exercise.
+        """
+        from .writing import ExerciseCommand
+
+        return ExerciseCommand(self, choice_name, arguments=arguments)
+
+    def replace(self, contract_id=None, template_id=None):
+        """
+        Return a new :class:`ContractId` instance replacing specified fields with values.
+        """
+        warnings.warn(
+            "ContractId.replace is deprecated; simply construct a ContractId with the desired "
+            "values instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return ContractId(
+                contract_id if contract_id is not None else self.value,
+                template_id if template_id is not None else self.value_type,
+            )
+
+    def for_json(self):
+        """
+        Return the JSON representation of this contract. This is currently just the contract ID
+        string itself.
+        """
+        return self.value
 
 
 class CommandTimeoutError(DazlError):

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -230,10 +230,19 @@ class Context:
         """
         Convert a contract ID string to a :class:`ContractId`.
         """
-        if isinstance(contract_id, ContractId):
-            return contract_id
-        elif isinstance(contract_id, str):
-            return ContractId(element_type.con.tycon, contract_id)
+        with warnings.catch_warnings():
+            # TODO: Drop this and switch to new-style ContractIds
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from ..model.core import ContractId as DeprecatedContractId
+
+            if isinstance(contract_id, DeprecatedContractId):
+                return contract_id
+            elif isinstance(contract_id, ContractId):
+                # convert new-style ContractId instances to deprecated subclasses; for now, this is
+                # still the canonical form of a ContractId until the deprecated version is dropped
+                return DeprecatedContractId(contract_id.value, element_type.con.tycon)
+            else:
+                return DeprecatedContractId(contract_id, element_type.con.tycon)
 
     def resolve_data_type(self, con: "Type.Con") -> "DefDataType":
         """


### PR DESCRIPTION
Backport deserializing ContractId's into a backwards-compatible representation.

This restores the "old" `ContractId`'s on `master`; they were originally slated for removal in v8, and although is still planned, `master` is morphing into dazl v7.5 (per #207).