### PR TITLE
python: Backport dazl.util from v7.

### DIFF
--- a/python/dazl/util/__init__.py
+++ b/python/dazl/util/__init__.py
@@ -8,6 +8,6 @@
 Module that exposes general utility functions.
 """
 
-from . import io
+from . import dar, io
 from .io import find_free_port
 from .proc_util import ProcessLogger, kill_process_tree, wait_for_process_port

--- a/python/dazl/util/asyncio_util.py
+++ b/python/dazl/util/asyncio_util.py
@@ -10,6 +10,7 @@ from asyncio import (
     CancelledError,
     Future,
     InvalidStateError,
+    Queue as AQueue,
     ensure_future,
     gather,
     get_event_loop,
@@ -31,14 +32,19 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
+    no_type_check,
 )
+import warnings
 
 from .. import LOG
 from ..prim.datetime import TimeDeltaLike, to_timedelta
 
-T = TypeVar("T", covariant=True)
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
 U = TypeVar("U")
 
 _PENDING = "PENDING"
@@ -121,7 +127,7 @@ def isolated_async(async_fn):
     return invoke
 
 
-def await_then(awaitable: "Awaitable[T]", func: "Callable[[T], U]") -> "Awaitable[U]":
+def await_then(awaitable: "Awaitable[T_co]", func: "Callable[[T_co], U]") -> "Awaitable[U]":
     """
     Call a function on the result of an Awaitable, and then return an Awaitable that is resolved
     with that result.
@@ -143,14 +149,14 @@ def await_then(awaitable: "Awaitable[T]", func: "Callable[[T], U]") -> "Awaitabl
         raise TypeError(f"expected a valid awaitable (got {awaitable} instead)")
     if fut.done():
         if fut.cancelled() or fut.exception() is not None:
-            return fut
+            return fut  # type: ignore
         else:
             try:
                 return completed(func(fut.result()))
             except Exception as ex:
                 fut = get_event_loop().create_future()
                 fut.set_exception(ex)
-                return fut
+                return fut  # type: ignore
     else:
         g = get_event_loop().create_future()
 
@@ -166,7 +172,7 @@ def await_then(awaitable: "Awaitable[T]", func: "Callable[[T], U]") -> "Awaitabl
                     g.set_exception(ex2)
 
         fut.add_done_callback(_propagate)
-        return g
+        return g  # type: ignore
 
 
 @dataclass
@@ -181,9 +187,9 @@ class FailedInvocation:
 
 def execute_in_loop(
     loop: AbstractEventLoop,
-    coro_fn: "Callable[[], Union[Awaitable[T], T]]",
+    coro_fn: "Callable[[], Union[Awaitable[T_co], T_co]]",
     timeout: "Optional[TimeDeltaLike]" = 30.0,
-) -> T:
+) -> T_co:
     """
     Run a coroutine in a target loop. Exceptions thrown by the coroutine are
     propagated to the caller. Must NOT be called from a coroutine on the same
@@ -197,7 +203,7 @@ def execute_in_loop(
     from functools import wraps
     from queue import Queue
 
-    q = Queue()
+    q = Queue()  # type: ignore
 
     def coro_fn_complete(fut):
         LOG.debug("coro_fn_complete: %s", fut)
@@ -340,7 +346,7 @@ class LongRunningAwaitable:
 
     def __init__(self, awaitables: Optional[Iterable[Awaitable[Any]]] = None):
         self._fut = get_event_loop().create_future()
-        self._coros = list()
+        self._coros = []  # type: List[Awaitable[Any]]
         if awaitables is not None:
             self.extend(awaitables)
 
@@ -363,15 +369,25 @@ class LongRunningAwaitable:
 
 
 class ServiceQueue(Generic[T]):
-    """"""
 
+    # noinspection PyDeprecation
     def __init__(self):
-        self._q = []
-        self._service_fut = safe_create_future()
+        warnings.warn(
+            "ServiceQueue is deprecated; there is no planned replacement",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._q = []  # type: Union[List[Tuple[T, Future]], AQueue[Tuple[T, Future]]]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self._service_fut = safe_create_future()
         self._prev_fut = None
 
+    # noinspection PyDeprecation
     def put(self, value: T) -> Awaitable[None]:
-        fut = safe_create_future()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            fut = safe_create_future()
         if isinstance(self._q, list):
             self._q.append((value, fut))
         else:
@@ -384,10 +400,8 @@ class ServiceQueue(Generic[T]):
         more than once has no effect.
         """
         if not self._service_fut.done():
-            from asyncio import Queue
-
-            existing_items = self._q
-            self._q = Queue()
+            existing_items = cast(list, self._q)  # type: List[Tuple[T, Future]]
+            self._q = AQueue()
             for item in existing_items:
                 self._q.put_nowait(item)
             self._service_fut.set_result(None)
@@ -401,13 +415,13 @@ class ServiceQueue(Generic[T]):
         self._q.put_nowait((None, fut))
         return fut
 
-    def abort(self) -> Sequence[T]:
+    def abort(self) -> Sequence[T_co]:
         """
         Gracefully terminate the open iterator as quickly as possible and return all remaining
         elements in the queue.
         """
 
-    async def next(self) -> Optional[T]:
+    async def next(self) -> Optional[T_co]:
         if not self._service_fut.done():
             await self._service_fut
 
@@ -415,7 +429,8 @@ class ServiceQueue(Generic[T]):
             self._prev_fut.set_result(None)
             self._prev_fut = None
 
-        value, fut = await self._q.get()
+        q = cast(AQueue, self._q)  # type: AQueue[Tuple[T_co, Future]]
+        value, fut = await q.get()
         if value is None:
             fut.set_result(None)
             return None
@@ -446,14 +461,14 @@ class ServiceQueue(Generic[T]):
         return repr(self._q)
 
 
-class ContextFreeFuture(Awaitable[T]):
+class ContextFreeFuture(Awaitable[T_co]):
     """
     An awaitable whose loop is defined at the time of either a :meth:`set_result` call or an
     `await`. These futures are more expensive than normal asyncio futures because they are
     thread-safe.
     """
 
-    _result: Optional[T] = None
+    _result: Optional[T_co] = None
     _exception: Optional[Exception] = None
     _log_traceback = False
     _asyncio_future_blocking = False
@@ -478,7 +493,7 @@ class ContextFreeFuture(Awaitable[T]):
         from threading import RLock
 
         self._lock = RLock()
-        self._callbacks = []  # type: List[Callable[[ContextFreeFuture[T]], None]]
+        self._callbacks = []  # type: List[Callable[[ContextFreeFuture[T_co]], None]]
         self._state = _PENDING
         self.__loop = loop  # type: Optional[AbstractEventLoop]
         self._source_traceback = None
@@ -496,7 +511,10 @@ class ContextFreeFuture(Awaitable[T]):
         to invoke :meth:`set_loop` directly.
         """
         if self.__loop is None:
-            self.__loop = get_running_loop()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                # noinspection PyDeprecation
+                self.__loop = get_running_loop()
         return self.__loop
 
     def set_loop(self, loop: AbstractEventLoop) -> None:
@@ -561,9 +579,14 @@ class ContextFreeFuture(Awaitable[T]):
             self._schedule_callbacks()
             self._log_traceback = True
 
-    def add_done_callback(self, fn: "Callable[[ContextFreeFuture[T]], None]", context=None) -> None:
+    def add_done_callback(
+        self, fn: "Callable[[ContextFreeFuture[T_co]], None]", context=None
+    ) -> None:
         if context is not None:
-            LOG.warning("ContextFreeFutures do not support the use of contexts.")
+            # This used to be a warning, but in newer versions of Python a context
+            # is sometimes supplied and nothing seems to particularly go wrong by
+            # simply doing nothing with this information.
+            pass
         with self._lock:
             if self._loop is not None and self._state != _PENDING:
                 self._loop.call_soon_threadsafe(fn, self)
@@ -631,7 +654,7 @@ class ContextFreeFuture(Awaitable[T]):
             self._log_traceback = False
             return self._exception
 
-    def __await__(self) -> Generator[Any, None, T]:
+    def __await__(self) -> Generator[Any, None, T_co]:
         if not self.done():
             self._asyncio_future_blocking = True
             yield self  # This tells Task to wait for completion.
@@ -694,7 +717,7 @@ class DeferredStartTask:
         if context is None:
             self._future.add_done_callback(callback)
         else:
-            self._future.add_done_callback(callback, context=context)
+            self._future.add_done_callback(callback, context=context)  # type: ignore
 
     def __await__(self):
         return self._future.__await__()
@@ -704,7 +727,13 @@ class DeferredStartTask:
         return f"DeferredStartTask({self._name!r}, state={state})"
 
 
+@no_type_check
 def get_running_loop() -> Optional[AbstractEventLoop]:
+    warnings.warn(
+        "get_running_loop() is deprecated, as support for Python 3.6 will be dropped in dazl 8. "
+        "Use Python 3.7+'s asyncio.get_running_loop() instead.",
+        DeprecationWarning,
+    )
     try:
         from asyncio import get_running_loop
 
@@ -719,11 +748,18 @@ def get_running_loop() -> Optional[AbstractEventLoop]:
         return _get_running_loop()
 
 
+# noinspection PyDeprecation
 def safe_create_future():
-    loop = get_running_loop()
+    warnings.warn(
+        "safe_create_future() is deprecated; there is no planned replacement.", DeprecationWarning
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        loop = get_running_loop()
     return loop.create_future() if loop is not None else ContextFreeFuture()
 
 
+@no_type_check
 def named_gather(name: str, *awaitables, return_exceptions=False):
     g = gather(*awaitables, return_exceptions=return_exceptions)
     g.__repr__ = staticmethod(lambda _: f"<Gather {name}>")
@@ -735,8 +771,16 @@ class Signal:
     A simple guard that "wakes" up a coroutine from another coroutine.
     """
 
+    # noinspection PyDeprecation
     def __init__(self):
-        self._fut = safe_create_future()
+        warnings.warn(
+            "Signal is deprecated; there is no planned replacement",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self._fut = safe_create_future()
 
     def notify_all(self) -> None:
         """
@@ -746,8 +790,11 @@ class Signal:
             self._fut.set_result(None)
             self._fut = None
 
+    # noinspection PyDeprecation
     def wait(self) -> "Awaitable[None]":
         if self._fut is None:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
             self._fut = safe_create_future()
         return self._fut
 
@@ -756,7 +803,7 @@ class UnsettableEventLoopPolicy(AbstractEventLoopPolicy):
     def get_event_loop(self) -> AbstractEventLoop:
         raise Exception("Called get_event_loop")
 
-    def set_event_loop(self, loop: AbstractEventLoop) -> None:
+    def set_event_loop(self, loop: Optional[AbstractEventLoop]) -> None:
         raise Exception("Called set_event_loop")
 
     def new_event_loop(self) -> AbstractEventLoop:

--- a/python/dazl/util/config_meta.py
+++ b/python/dazl/util/config_meta.py
@@ -8,7 +8,7 @@ This module contains utilities required by :mod:`dazl.client.config`.
 from argparse import _ActionsContainer
 from dataclasses import Field, dataclass, field, fields
 import logging
-from typing import Any, Callable, FrozenSet, Optional, Sequence, Tuple
+from typing import Any, Callable, FrozenSet, Optional, Sequence, Tuple, no_type_check
 
 from ..prim import Party
 
@@ -17,14 +17,14 @@ def config_field(
     description: str,
     param_type: "Optional[ConfigParameterType]" = None,
     *,
-    default_value: Any = None,
+    default_value: "Optional[Any]" = None,
     long_alias: Optional[str] = None,
     short_alias: Optional[str] = None,
     deprecated_alias: Optional[str] = None,
     environment_variable: Optional[str] = None
 ) -> Field:
     return field(
-        default=default_value,
+        default=default_value,  # type: ignore
         metadata={
             "dazl.config": ConfigParameter(
                 description=description,
@@ -41,6 +41,7 @@ def config_field(
     )
 
 
+@no_type_check
 def config_fields(class_or_instance: Any) -> "Sequence[Tuple[Field, ConfigParameter]]":
     return [(fld, fld.metadata.get("dazl.config")) for fld in fields(class_or_instance)]
 

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from io import BytesIO
+from typing import TYPE_CHECKING, AbstractSet, Collection, Mapping, Optional, Sequence
+import warnings
+
+from ..damlast.daml_lf_1 import PackageRef
+from ..damlast.parse import parse_archive
+from ..damlast.pkgfile import Dar, DarFile as _DarFile
+
+if TYPE_CHECKING:
+    from ..model.types_store import PackageProvider, PackageStore
+
+
+def get_archives(contents: bytes) -> "Mapping[PackageRef, bytes]":
+    """
+    Attempt to parse the specified contents as either a DALF or a DAR, and return a mapping of
+    package IDs to DALF bytes.
+    This class is deprecated as it assumes and expose use of a :class:`PackageStore` and
+
+    :class:`Type`, all of which are deprecated.
+
+    :param contents: A byte array to attempt to parse.
+    :return: Return a mapping from package ID to byte contents.
+    """
+    warnings.warn(
+        "get_archives is deprecated. For DAR parsing, use dazl.damlast.DarFile instead. "
+        "There is no replacement for DALF parsing.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    if contents[0:4] == b"PK\03\04":
+        with BytesIO(contents) as buf:
+            with _DarFile(buf) as dar:
+                # noinspection PyProtectedMember
+                return {name: dar._zip.read(name) for name in dar._dalf_names()}
+
+    raise Exception(
+        "get_archives(...) only works on DAR files, and is additionally deprecated. "
+        "Use dazl.damlast.DarFile instead."
+    )
+
+
+class DarFile(_DarFile):
+    """
+    Provides access to the contents of a .dar file.
+    """
+
+    def __init__(self, dar: "Dar"):
+        super().__init__(dar)
+        warnings.warn(
+            "dazl.util.dar.DarFile is deprecated; please use dazl.damlast.DarFile instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    def read_metadata(self) -> "PackageStore":
+        warnings.warn(
+            "read_metadata is deprecated. For DAR parsing, use dazl.damlast.DarFile instead. "
+            "There is no replacement for DALF parsing.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # noinspection PyProtectedMember
+        from ..model.types_store import PackageStore
+        from ..protocols.v1.pb_parse_metadata import _parse_daml_metadata_pb
+
+        store = PackageStore.empty()
+
+        for archive in self.archives():
+            store.register_all(_parse_daml_metadata_pb(archive))
+        return store
+
+    def get_archives(self) -> "Mapping[PackageRef, bytes]":
+        """
+        Return a mapping from package ID to byte contents.
+        """
+        warnings.warn(
+            "get_archives is deprecated; there is no replacement.", DeprecationWarning, stacklevel=2
+        )
+        return {a.hash: a.payload for a in self._pb_archives()}
+
+    def get_dalf_names(self) -> "Sequence[PackageRef]":
+        warnings.warn(
+            "get_dalf_names is deprecated; there is no replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return list(self._dalf_names())
+
+    def get_manifest(self) -> "Optional[Mapping[str, str]]":
+        """
+        Return the contents of the manifest of this DAR.
+        """
+        warnings.warn(
+            "get_manifest() is deprecated; use manifest() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.manifest()
+
+    def get_sdk_version(self) -> "Optional[str]":
+        """
+        Return the SDK version used to compile this dar (if this information is available).
+
+        This method is deprecated; use dazl.damlast..DarFile
+        """
+        warnings.warn(
+            "get_sdk_version() is deprecated; use sdk_versions() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.sdk_version()
+
+    def get_package_ids(self) -> "AbstractSet[PackageRef]":
+        """
+        Return the set of package IDs from this DAR.
+        """
+        warnings.warn(
+            "get_package_ids() is deprecated; please use package_ids() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.package_ids()
+
+    def get_package_provider(self) -> "PackageProvider":
+        warnings.warn(
+            "get_package_provider() is deprecated; use the methods of the "
+            "dazl.damlast.PackageProvider protocol as implemented on DarFile directly.",
+            DeprecationWarning,
+        )
+        from ..model.types_store import MemoryPackageProvider
+
+        return MemoryPackageProvider(self.get_archives())
+
+
+def parse_dalf(contents: bytes) -> "PackageStore":
+    warnings.warn(
+        "parse_dalf is deprecated, as PackageStore and Type are deprecated.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # noinspection PyProtectedMember
+    from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import Archive
+    from ..protocols.v1.pb_parse_metadata import _parse_daml_metadata_pb
+
+    a = Archive()
+    a.ParseFromString(contents)
+    return _parse_daml_metadata_pb(parse_archive(a.hash, a.payload))
+
+
+def get_dar_package_ids(dar: "Dar") -> "Collection[PackageRef]":
+    warnings.warn(
+        "dazl.util.dar.get_dar_package_ids is deprecated; "
+        "please use dazl.damlast.get_dar_package_ids instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # This is a local import to get around circular dependencies; also the replacement function
+    # is the same name as our own
+    from ..damlast.pkgfile import get_dar_package_ids
+
+    return get_dar_package_ids(dar)

--- a/python/dazl/util/dar_repo.py
+++ b/python/dazl/util/dar_repo.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from contextlib import ExitStack
+from os import PathLike, fspath
+from pathlib import Path
+import time
+from typing import List, Sequence, Union
+import warnings
+
+from .. import LOG
+
+
+class LocalDarRepository:
+    def __init__(self):
+        warnings.warn(
+            "LocalDarRepository is deprecated; use PackageLookup instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._context = ExitStack()
+        self._dar_paths = []  # type: List[Path]
+        self._files = set()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            from ..model.types_store import PackageStore
+
+            self.store = PackageStore.empty()
+
+    def _add_source(self, path: Path) -> None:
+        ext = path.suffix.lower()
+
+        if ext == ".daml":
+            LOG.error("Reading metadata directly from a DAML file is not supported.")
+            raise ValueError("Unsupported extension: .daml")
+
+        elif ext == ".dalf":
+            LOG.error("Reading metadata directly from a DALF file is not supported.")
+            raise ValueError("Unsupported extension: .dalf")
+
+        elif ext == ".dar":
+            dar_parse_start_time = time.time()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+
+                from ..util.dar import DarFile
+
+                dar = self._context.enter_context(DarFile(path))
+            dar_package = dar.read_metadata()
+            self._dar_paths.append(path)
+            self.store.register_all(dar_package)
+            dar_parse_end_time = time.time()
+            LOG.debug("Parsed a dar in %s seconds.", dar_parse_end_time - dar_parse_start_time)
+
+        else:
+            LOG.error("Unknown extension: %s", ext)
+            raise ValueError(f"Unknown extension: {ext}")
+
+    def add_source(self, *files: Union[str, PathLike, Path]) -> None:
+        """
+        Add a source file (either a .daml file, .dalf file, or a .dar file).
+
+        Attempts to add the same file more than once will be ignored.
+
+        :param files: Files to add to the archive.
+        """
+        for file in files:
+            path = Path(fspath(file)).resolve(strict=True)
+            if path not in self._files:
+                self._files.add(path)
+                self._add_source(path)
+
+    def get_daml_archives(self) -> Sequence[Path]:
+        return self._dar_paths
+
+    def __enter__(self):
+        """
+        Does nothing.
+        """
+        self._context.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Delete all managed resources in the reverse order that they were created.
+        """
+        self._context.__exit__(exc_type, exc_val, exc_tb)

--- a/python/dazl/util/path_util.py
+++ b/python/dazl/util/path_util.py
@@ -1,18 +1,16 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-from os import PathLike
+from os import PathLike, fspath
 from pathlib import Path
 from typing import Union
+import warnings
+
+__all__ = ["pathify"]
 
 
 def pathify(path: "Union[str, Path, PathLike]") -> Path:
     """
     Convert an object that could be a :class:`Path` into a :class:`Path`.
     """
-    if isinstance(path, Path):
-        return path
-    elif isinstance(path, PathLike):
-        return Path(path)
-    else:
-        raise ValueError(f"path must be a str or Path (got {path!r} instead)")
+    warnings.warn("pathify is deprecated; use os.fspath instead", DeprecationWarning, stacklevel=2)
+    return Path(fspath(path))

--- a/python/dazl/util/prim_types.py
+++ b/python/dazl/util/prim_types.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+The :mod:`dazl.util.prim_types` module contains functions for converting arbitrary objects and
+on-wire formats to/from canonical Python types.
+"""
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Mapping, Optional, Tuple, Union, overload
+import warnings
+
+from ..prim.datetime import DATETIME_ISO8601_Z_FORMAT, TimeDeltaLike as TimeDeltaConvertible
+
+warnings.warn(
+    "dazl.util.prim_types is deprecated; use dazl.prim instead.", DeprecationWarning, stacklevel=2
+)
+
+__all__ = [
+    "to_boolean",
+    "to_str",
+    "to_int",
+    "to_date",
+    "to_datetime",
+    "to_decimal",
+    "to_ledger_api_decimal",
+    "to_timedelta",
+    "PrimitiveTypeConverter",
+    "decode_variant_dict",
+    "standard_format",
+    "nano_format",
+    "unflatten_dotted_keys",
+    "DEFAULT_TYPE_CONVERTER",
+    "DATETIME_ISO8601_Z_FORMAT",
+    "frozendict",
+    "to_hashable",
+]
+
+
+@overload
+def to_boolean(obj: "Union[bool, str]") -> bool:
+    ...
+
+
+@overload
+def to_boolean(obj: None) -> None:
+    ...
+
+
+def to_boolean(obj):
+    from ..prim import to_bool
+
+    warnings.warn(
+        "dazl.util.prim_types.to_boolean is deprecated; use dazl.prim.to_bool instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_bool(obj) if obj is not None else None
+
+
+def to_str(obj: "Optional[Any]") -> "Optional[str]":
+    from ..prim import to_str
+
+    warnings.warn(
+        "dazl.util.prim_types.to_str is deprecated; use dazl.prim.to_str instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_str(obj) if obj is not None else None
+
+
+def to_int(obj: Any) -> "Optional[int]":
+    from ..prim import to_int
+
+    warnings.warn(
+        "dazl.util.prim_types.to_int is deprecated; use dazl.prim.to_int instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_int(obj) if obj is not None else None
+
+
+def to_date(obj: "Optional[Any]") -> "Optional[date]":
+    from ..prim import to_date
+
+    warnings.warn(
+        "dazl.util.prim_types.to_date is deprecated; use dazl.prim.to_date instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_date(obj) if obj is not None else None
+
+
+def to_datetime(obj: "Optional[Any]") -> "Optional[datetime]":
+    from ..prim import to_datetime
+
+    warnings.warn(
+        "dazl.util.prim_types.to_datetime is deprecated; use dazl.prim.to_datetime instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_datetime(obj) if obj is not None else None
+
+
+def to_decimal(obj: "Optional[Any]") -> "Optional[Decimal]":
+    from ..prim import to_decimal
+
+    warnings.warn(
+        "dazl.util.prim_types.to_decimal is deprecated; use dazl.prim.to_decimal instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_decimal(obj) if obj is not None else None
+
+
+def to_ledger_api_decimal(obj: "Decimal") -> str:
+    from ..prim import decimal_to_str
+
+    warnings.warn(
+        "dazl.util.prim_types.to_ledger_api_decimal is deprecated; use dazl.prim.decimal_to_str instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return decimal_to_str(obj)
+
+
+def to_timedelta(obj: TimeDeltaConvertible) -> "timedelta":
+    from ..prim import to_timedelta
+
+    warnings.warn(
+        "dazl.util.prim_types.to_timedelta is deprecated; use dazl.prim.to_timedelta instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_timedelta(obj)
+
+
+class PrimitiveTypeConverter:
+    to_boolean = staticmethod(to_boolean)
+    to_str = staticmethod(to_str)
+    to_int = staticmethod(to_int)
+    to_decimal = staticmethod(to_decimal)
+    to_date = staticmethod(to_date)
+    to_datetime = staticmethod(to_datetime)
+    to_timedelta = staticmethod(to_timedelta)
+
+
+def decode_variant_dict(obj: "Any") -> "Tuple[str, Any]":
+    from ..prim import to_variant
+
+    warnings.warn(
+        "dazl.util.prim_types.decode_variant_dict is deprecated; use dazl.prim.to_variant instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_variant(obj)
+
+
+def standard_format(fmt, value):
+    from ..prim.datetime import _parse
+
+    warnings.warn(
+        "dazl.util.prim_types.nano_format is deprecated; there is no replacement.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _parse(fmt, value)
+
+
+def nano_format(value):
+    from ..prim.datetime import _parse_nano_format
+
+    warnings.warn(
+        "dazl.util.prim_types.nano_format is deprecated; there is no replacement.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _parse_nano_format(value)
+
+
+def unflatten_dotted_keys(m: "Mapping[str, Any]"):
+    from ..prim import to_record
+
+    warnings.warn(
+        "dazl.util.prim_types.unflatten_dotted_keys is deprecated; use dazl.prim.to_record instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_record(m) if m is not None else None
+
+
+DEFAULT_TYPE_CONVERTER = PrimitiveTypeConverter()
+
+
+def frozendict(*args, **kwargs):
+    from ..prim.map import FrozenDict
+
+    warnings.warn(
+        "dazl.util.prim_types.frozendict is deprecated; use dazl.prim.map.FrozenDict instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return FrozenDict(*args, **kwargs)
+
+
+def to_hashable(*args, **kwargs):
+    from ..prim.map import to_hashable
+
+    warnings.warn(
+        "dazl.util.prim_types.to_hashable is deprecated; use dazl.prim.map.to_hashable instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return to_hashable(*args, **kwargs)

--- a/python/dazl/util/tools.py
+++ b/python/dazl/util/tools.py
@@ -17,11 +17,14 @@ from typing import (
     TypeVar,
     Union,
 )
+import warnings
 
 T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
-E = TypeVar("E", bound=Exception)
+
+
+__all__ = ["boundary_iter", "flatten", "as_list", "get_matches"]
 
 
 def boundary_iter(obj: Iterable[T]) -> Generator[Tuple[bool, T], None, None]:
@@ -50,11 +53,11 @@ def boundary_iter(obj: Iterable[T]) -> Generator[Tuple[bool, T], None, None]:
         try:
             entry = next(gen)
             if prev_entry is not None:
-                yield (False, prev_entry)
+                yield False, prev_entry
             prev_entry = entry
         except StopIteration:
             if prev_entry is not None:
-                yield (True, prev_entry)
+                yield True, prev_entry
             break
 
 
@@ -86,8 +89,14 @@ def as_list(obj: "Union[None, T, Collection[Union[None, T]]]") -> "List[T]":
         return [obj]
 
 
+def __key_error(key: str) -> Exception:
+    return KeyError(key)
+
+
 def get_matches(
-    mapping: "Mapping[K, V]", key: "K", exc_class: "Optional[Callable[[K], E]]" = KeyError
+    mapping: "Mapping[str, V]",
+    key: "str",
+    exc_class: "Optional[Callable[[str], Exception]]" = __key_error,
 ) -> "Collection[V]":
     """
     Return the value (as a singleton collection) associated with a key. If the key is equal to the
@@ -110,6 +119,7 @@ def get_matches(
         * A collection of one if a match is found for the supplied key;
         * All values of the mapping if the key is `""*""`.
     """
+    warnings.warn("get_matches is deprecated; there is no replacement.", DeprecationWarning)
     if key == "*":
         return tuple(mapping.values())
 


### PR DESCRIPTION
Type fixes and more resurrection of dead code in `dazl.util`.

This code will still be removed as part of dazl v8, but will remain in dazl v7.5.