### PR TITLE
python: Backport dazl.protocols from v7.

### DIFF
--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -527,8 +527,8 @@ class _PartyClientImpl:
         LOG.info("Writer loop for party %s is starting...", self.party)
         ledger_fut = ensure_future(self._pool.ledger())
 
-        client = self._client_fut.result()  # type: LedgerClient
-        metadata = ledger_fut.result()  # type: LedgerMetadata
+        client = await self._client_fut  # type: LedgerClient
+        metadata = await ledger_fut  # type: LedgerMetadata
         validator = ValidateSerializer(self.parent.lookup)
 
         self._writer.pending_commands.start()

--- a/python/dazl/client/pkg_loader.py
+++ b/python/dazl/client/pkg_loader.py
@@ -8,6 +8,7 @@ from ..ledger.pkgloader_aio_compat import PackageLoader, SyncPackageService
 warnings.warn(
     "dazl.client.pkg_loader is deprecated; use dazl.protocols.pkgloader_aio instead.",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = ["SyncPackageService", "PackageLoader"]

--- a/python/dazl/ledger/pkgloader_aio_compat.py
+++ b/python/dazl/ledger/pkgloader_aio_compat.py
@@ -10,7 +10,7 @@ from asyncio import get_event_loop
 from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import timedelta
 import sys
-from typing import AbstractSet
+from typing import AbstractSet, Optional
 import warnings
 
 from ..damlast.daml_lf_1 import PackageRef
@@ -60,8 +60,8 @@ class PackageLoader(NewPackageLoader):
     def __init__(
         self,
         package_lookup: "MultiPackageLookup",
-        conn: "SyncPackageService" = None,
-        timeout: "timedelta" = DEFAULT_TIMEOUT,
+        conn: "Optional[SyncPackageService]" = None,
+        timeout: "Optional[timedelta]" = DEFAULT_TIMEOUT,
     ):
         warnings.warn(
             "dazl.client.pkg_loader.PackageLoader has moved to "
@@ -70,7 +70,12 @@ class PackageLoader(NewPackageLoader):
             stacklevel=2,
         )
         executor = ThreadPoolExecutor(3)
-        super().__init__(package_lookup, PackageServiceWrapper(conn, executor), timeout, executor)
+        super().__init__(
+            package_lookup,
+            PackageServiceWrapper(conn, executor) if conn is not None else None,
+            timeout,
+            executor,
+        )
 
 
 class PackageServiceWrapper:

--- a/python/dazl/protocols/events.py
+++ b/python/dazl/protocols/events.py
@@ -218,7 +218,7 @@ class ContractExercisedEvent(ContractEvent):
     Event raised when dazl automation detects a contract exercised.
     """
 
-    contract_creating_event_id: str
+    contract_creating_event_id: None
     choice: str
     choice_args: Any
     acting_parties: Sequence[str]

--- a/python/dazl/protocols/oauth.py
+++ b/python/dazl/protocols/oauth.py
@@ -8,6 +8,9 @@ if TYPE_CHECKING:
     from ..client._conn_settings import OAuthSettings
 
 
+__all__ = ["oauth_flow"]
+
+
 async def oauth_flow(settings: "OAuthSettings") -> "OAuthSettings":
     """
     Implementation of an OAuth flow that ensures that a token is provided.
@@ -33,6 +36,9 @@ async def oauth_flow(settings: "OAuthSettings") -> "OAuthSettings":
             "grant_type": "client_credentials",
         }
 
+        if settings.token_uri is None:
+            raise ValueError("missing a token URI")
+        response = None
         try:
             response = requests.post(
                 settings.token_uri,

--- a/python/dazl/protocols/v0/__init__.py
+++ b/python/dazl/protocols/v0/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+warnings.warn("dazl.protocols.v0 is deprecated", DeprecationWarning, stacklevel=2)

--- a/python/dazl/protocols/v0/json_ser_command.py
+++ b/python/dazl/protocols/v0/json_ser_command.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Methods for serializing domain objects and other things into basic primitive
+types over the wire on the REST interface using JSON.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+import warnings
+
+from ...damlast.daml_lf_1 import TypeConName
+from ...model.writing import AbstractSerializer
+from ...prim import ContractId, JSONEncoder
+from ...values.json import JsonEncoder
+
+if TYPE_CHECKING:
+    from ...model.writing import CommandPayload
+
+__all__ = ["LedgerJSONEncoder", "to_api_datetime", "JsonSerializer"]
+
+
+class LedgerJSONEncoder(JSONEncoder):
+    """
+    Convert some known Ledger API primitive types into their appropriate JSON
+    representations.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "dazl.protocols.v0.json_ser_command.LedgerJSONEncoder is deprecated; "
+            "use dazl.prim.JSONEncoder instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+
+def to_api_datetime(obj):
+    """
+    Converts the object to an ISO8601 datetime string.
+
+    :param obj:
+        A datetime. If the datetime is "naive" (no timezone information), it is
+        assumed to refer to UTC. If the datetime has timezone information, the
+        datetime will be converted to UTC before serializing.
+    :return: An ISO8601 string that represents the time in UTC.
+    """
+    from ...prim import datetime_to_str
+
+    warnings.warn(
+        "dazl.protocols.v0.json_ser_command.to_api_datetime is deprecated; "
+        "use dazl.prim.datetime_to_str instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return datetime_to_str(obj) if isinstance(obj, datetime) else obj
+
+
+class JsonSerializer(AbstractSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "dazl.protocols.v0.json_ser_command.JsonSerializer is deprecated; "
+            "there is no replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    mapper = JsonEncoder()
+
+    def serialize_command_request(self, command_payload: "CommandPayload") -> dict:
+        commands = [self.serialize_command(command) for command in command_payload.commands]
+        return dict(
+            businessIntent=command_payload.command_id,
+            commands=commands,
+            application=command_payload.application_id,
+        )
+
+    def serialize_create_command(self, template_name: "TypeConName", template_args: "Any") -> "Any":
+        # the package_id in ModuleRef is a convenient place to
+        # stash legacy template IDs in the REST endpoint
+        return {"create": {"template": str(template_name), "arguments": template_args}}
+
+    def serialize_exercise_command(
+        self, contract_id: ContractId, choice_name: str, choice_args: "Any"
+    ) -> "Any":
+        return {
+            "exercise": {
+                "contract": contract_id.value,
+                "choice": choice_name,
+                "arguments": choice_args,
+            }
+        }

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -7,6 +7,7 @@ Support for the gRPC-based Ledger API.
 from asyncio import gather
 from datetime import datetime
 from threading import Event
+from time import sleep
 from typing import TYPE_CHECKING, AbstractSet, Iterable, Mapping, Optional, Sequence
 import warnings
 
@@ -20,15 +21,54 @@ from grpc import (
 )
 
 from ... import LOG
-from ..._gen.com.daml.ledger.api.v1.transaction_service_pb2 import GetTransactionTreesResponse
+from ..._gen.com.daml.ledger.api.v1.active_contracts_service_pb2_grpc import (
+    ActiveContractsServiceStub as G_ActiveContractsServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.admin.package_management_service_pb2 import (
+    UploadDarFileRequest as G_UploadDarFileRequest,
+)
+from ..._gen.com.daml.ledger.api.v1.admin.package_management_service_pb2_grpc import (
+    PackageManagementServiceStub as G_PackageManagementServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.command_service_pb2_grpc import (
+    CommandServiceStub as G_CommandServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.ledger_identity_service_pb2 import (
+    GetLedgerIdentityRequest as G_GetLedgerIdentityRequest,
+)
+from ..._gen.com.daml.ledger.api.v1.ledger_identity_service_pb2_grpc import (
+    LedgerIdentityServiceStub as G_LedgerIdentityServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.package_service_pb2 import (
+    GetPackageRequest as G_GetPackageRequest,
+    ListPackagesRequest as G_ListPackagesRequest,
+)
+from ..._gen.com.daml.ledger.api.v1.package_service_pb2_grpc import (
+    PackageServiceStub as G_PackageServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.testing.time_service_pb2 import (
+    GetTimeRequest as G_GetTimeRequest,
+    SetTimeRequest as G_SetTimeRequest,
+)
+from ..._gen.com.daml.ledger.api.v1.testing.time_service_pb2_grpc import (
+    TimeServiceStub as G_TimeServiceStub,
+)
+from ..._gen.com.daml.ledger.api.v1.transaction_service_pb2 import (
+    GetLedgerEndRequest as G_GetLedgerEndRequest,
+    GetTransactionTreesResponse as G_GetTransactionTreesResponse,
+)
+from ..._gen.com.daml.ledger.api.v1.transaction_service_pb2_grpc import (
+    TransactionServiceStub as G_TransactionServiceStub,
+)
 from ...damlast.daml_lf_1 import PackageRef
 from ...damlast.parse import parse_archive_payload
-from ...prim import Party, to_party
-from ...protocols.errors import ConnectionTimeoutError, UserTerminateRequest
+from ...ledger.pkgloader_aio_compat import PackageLoader
+from ...prim import Party, datetime_to_timestamp, to_party
 from ...scheduler import Invoker, RunLevel
 from ...util.io import read_file_bytes
 from ...util.typing import safe_cast
 from .._base import LedgerClient, LedgerConnectionOptions, _LedgerConnection
+from ..errors import ConnectionTimeoutError, UserTerminateRequest
 from .pb_parse_event import (
     BaseEventDeserializationContext,
     serialize_acs_request,
@@ -48,6 +88,19 @@ with warnings.catch_warnings():
         from ...model.types_store import PackageProvider, PackageStore
 
 
+__all__ = [
+    "GRPCv1LedgerClient",
+    "grpc_set_time",
+    "grpc_upload_package",
+    "grpc_detect_ledger_id",
+    "grpc_main_thread",
+    "GRPCPackageProvider",
+    "grpc_package_sync",
+    "grpc_create_channel",
+    "GRPCv1Connection",
+]
+
+
 class GRPCv1LedgerClient(LedgerClient):
     def __init__(self, connection: "GRPCv1Connection", ledger: "LedgerMetadata", party: Party):
         self.connection = safe_cast(GRPCv1Connection, connection)
@@ -57,7 +110,7 @@ class GRPCv1LedgerClient(LedgerClient):
     async def commands(self, commands: "CommandPayload") -> None:
         serializer = self.ledger.serializer
         request = serializer.serialize_command_request(commands)
-        return await self.connection.invoker.run_in_executor(
+        await self.connection.invoker.run_in_executor(
             lambda: self.connection.command_service.SubmitAndWait(request)
         )
 
@@ -81,12 +134,12 @@ class GRPCv1LedgerClient(LedgerClient):
             # Consume a stream of events from the Active Contract Set service and store these results fully
             # in memory; return the full set of events as well as a set of package IDs that need to be
             # available in order to fully understand the contents of the Active Contract Set service.
-            acs_stream = list(acs_stream)
+            acs_responses = list(acs_stream)
 
         with LOG.info_timed("ACS find all required packages"):
             pkg_refs = {
                 create_evt.template_id.package_id
-                for acs_response_pb in acs_stream
+                for acs_response_pb in acs_responses
                 for create_evt in acs_response_pb.active_contracts
             }
 
@@ -100,7 +153,7 @@ class GRPCv1LedgerClient(LedgerClient):
             # packages that contained templates might have references to other packages that are
             # also required to understand the individual fields in a template.
             return await self.ledger.package_loader.do_with_retry(
-                lambda: to_acs_events(context, acs_stream)
+                lambda: to_acs_events(context, acs_responses)
             )
 
     async def events(self, transaction_filter: "TransactionFilter") -> "Sequence[BaseEvent]":
@@ -119,7 +172,7 @@ class GRPCv1LedgerClient(LedgerClient):
             lambda: self.connection.transaction_service.GetTransactions(request)
         )
 
-        tt_stream = None  # type: Optional[Iterable[GetTransactionTreesResponse]]
+        tt_stream = None  # type: Optional[Iterable[G_GetTransactionTreesResponse]]
         if transaction_filter.templates is None:
             # Filtering by package must disable the ability to handle exercise nodes; we may want to
             # consider dropping client-side support for exercise events anyway because they are not
@@ -137,22 +190,18 @@ class GRPCv1LedgerClient(LedgerClient):
         )
 
     async def events_end(self) -> str:
-        from . import model as G
-
-        request = G.GetLedgerEndRequest(ledger_id=self.ledger.ledger_id)
+        request = G_GetLedgerEndRequest(ledger_id=self.ledger.ledger_id)
         return await self.connection.invoker.run_in_executor(
             lambda: self.connection.transaction_service.GetLedgerEnd(request).offset.absolute
         )
 
 
 def grpc_set_time(connection: "GRPCv1Connection", ledger_id: str, new_datetime: datetime) -> None:
-    from . import model as G
-
-    request = G.GetTimeRequest(ledger_id=ledger_id)
+    request = G_GetTimeRequest(ledger_id=ledger_id)
     response = connection.time_service.GetTime(request)
     ts = next(iter(response))
 
-    request = G.SetTimeRequest(
+    request = G_SetTimeRequest(
         ledger_id=ledger_id,
         current_time=ts.current_time,
         new_time=datetime_to_timestamp(new_datetime),
@@ -162,9 +211,7 @@ def grpc_set_time(connection: "GRPCv1Connection", ledger_id: str, new_datetime: 
 
 
 def grpc_upload_package(connection: "GRPCv1Connection", dar_contents: bytes) -> None:
-    from . import model as G
-
-    request = G.UploadDarFileRequest(dar_file=dar_contents)
+    request = G_UploadDarFileRequest(dar_file=dar_contents)
     connection.package_management_service.UploadDarFile(request)
 
 
@@ -181,10 +228,6 @@ def grpc_detect_ledger_id(connection: "GRPCv1Connection") -> str:
     a ledger ID has been successfully retrieved, or the timeout is reached (in which case an
     exception is thrown).
     """
-    from time import sleep
-
-    from . import model as G
-
     LOG.debug("Starting a monitor thread for connection: %s", connection)
 
     start_time = datetime.utcnow()
@@ -198,7 +241,7 @@ def grpc_detect_ledger_id(connection: "GRPCv1Connection") -> str:
 
         try:
             response = connection.ledger_identity_service.GetLedgerIdentity(
-                G.GetLedgerIdentityRequest()
+                G_GetLedgerIdentityRequest()
             )
         except RpcError as ex:
             details_str = ex.details()
@@ -220,14 +263,14 @@ def grpc_detect_ledger_id(connection: "GRPCv1Connection") -> str:
     )
 
 
+# noinspection PyDeprecation
 def grpc_main_thread(connection: "GRPCv1Connection", ledger_id: str) -> "Iterable[LedgerMetadata]":
     from ...client.ledger import LedgerMetadata
-    from ...ledger.pkgloader_aio_compat import PackageLoader
     from .pb_ser_command import ProtobufSerializer
 
     LOG.info("grpc_main_thread...")
-    with warnings.catch_warnings():
 
+    with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         from ...model.types_store import PackageStore
 
@@ -274,16 +317,12 @@ class GRPCPackageProvider:
         self.ledger_id = ledger_id
 
     def package_ids(self) -> "AbstractSet[PackageRef]":
-        from . import model as G
-
-        request = G.ListPackagesRequest(ledger_id=self.ledger_id)
+        request = G_ListPackagesRequest(ledger_id=self.ledger_id)
         response = self.connection.package_service.ListPackages(request)
         return frozenset(response.package_ids)
 
     def package_bytes(self, package_id: "PackageRef") -> bytes:
-        from . import model as G
-
-        request = G.GetPackageRequest(ledger_id=self.ledger_id, package_id=package_id)
+        request = G_GetPackageRequest(ledger_id=self.ledger_id, package_id=package_id)
         package_info = self.connection.package_service.GetPackage(request)
         return package_info.archive_payload
 
@@ -294,9 +333,12 @@ class GRPCPackageProvider:
         return self.package_bytes(package_id)
 
     def get_all_packages(self) -> "Mapping[PackageRef, bytes]":
-        return {pkg_id: self.fetch_package(pkg_id) for pkg_id in self.get_package_ids()}
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return {pkg_id: self.fetch_package(pkg_id) for pkg_id in self.get_package_ids()}
 
 
+# noinspection PyDeprecation
 def grpc_package_sync(package_provider: "PackageProvider", store: "PackageStore") -> "None":
     warnings.warn(
         "grpc_package_sync is deprecated; there is no replacement", DeprecationWarning, stacklevel=2
@@ -414,17 +456,15 @@ class GRPCv1Connection(_LedgerConnection):
         context_path: "Optional[str]",
     ):
         super(GRPCv1Connection, self).__init__(invoker, options, settings, context_path)
-        from . import model as G
-
         self._closed = Event()
         self._channel = grpc_create_channel(settings)
-        self.active_contract_set_service = G.ActiveContractsServiceStub(self._channel)
-        self.command_service = G.CommandServiceStub(self._channel)
-        self.transaction_service = G.TransactionServiceStub(self._channel)
-        self.package_service = G.PackageServiceStub(self._channel)
-        self.package_management_service = G.PackageManagementServiceStub(self._channel)
-        self.ledger_identity_service = G.LedgerIdentityServiceStub(self._channel)
-        self.time_service = G.TimeServiceStub(self._channel)
+        self.active_contract_set_service = G_ActiveContractsServiceStub(self._channel)
+        self.command_service = G_CommandServiceStub(self._channel)
+        self.transaction_service = G_TransactionServiceStub(self._channel)
+        self.package_service = G_PackageServiceStub(self._channel)
+        self.package_management_service = G_PackageManagementServiceStub(self._channel)
+        self.ledger_identity_service = G_LedgerIdentityServiceStub(self._channel)
+        self.time_service = G_TimeServiceStub(self._channel)
 
     def close(self):
         try:

--- a/python/dazl/protocols/v1/model/__init__.py
+++ b/python/dazl/protocols/v1/model/__init__.py
@@ -1,6 +1,14 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
+warnings.warn(
+    "dazl.protocols.v1.model is deprecated; use the types in dazl._gen instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from ...._gen.com.daml.daml_lf_dev.daml_lf_1_pb2 import (
     DefDataType,
     DefTemplate,


### PR DESCRIPTION
Backport of the typing fixes from the `dazl.protocols` package from the release branch onto `master`.

Also fixes some subtle bugs in the new dazl v8 API, as some of this code is shared between the old and new worlds.