### PR TITLE
python: Backport dazl.damlast type fixes from v7.

### DIFF
--- a/python/dazl/damlast/builtins.py
+++ b/python/dazl/damlast/builtins.py
@@ -37,6 +37,7 @@ class Concat(Builtin):
             return xxs.cons.front[0]
         if xxs.nil is not None:
             return Expr(nil=Expr.Nil(xxs.nil.type.prim.args[0]))
+        return None
 
 
 @builtins.add
@@ -59,6 +60,9 @@ class AppendText(Builtin):
     def evaluate(self, _: "Sequence[Type]", args: "Sequence[Any]") -> "Any":
         return args[0] + args[1]
 
-    def simplify(self, _: "Sequence[Type]", args: "Sequence[Expr]") -> "Expr":
+    def simplify(self, _: "Sequence[Type]", args: "Sequence[Expr]") -> "Optional[Expr]":
         if args[0].prim_lit is not None and args[1].prim_lit is not None:
-            return Expr(prim_lit=PrimLit(text=args[0].prim_lit.text + args[1].prim_lit.text))
+            return Expr(
+                prim_lit=PrimLit(text=(args[0].prim_lit.text or "") + (args[1].prim_lit.text or ""))
+            )
+        return None

--- a/python/dazl/damlast/compat.py
+++ b/python/dazl/damlast/compat.py
@@ -23,11 +23,6 @@ if TYPE_CHECKING:
         from ..model.types import Type as DeprecatedType, TypeReference as DeprecatedTypeReference
 
 
-__all__ = ["parse_template"]
-
-warnings.warn("dazl.damlast.compat is deprecated", DeprecationWarning)
-
-
 def parse_template(
     template_id: "Union[str, DeprecatedType, TypeConName]",
 ) -> "Tuple[TypeConName, DeprecatedTypeReference]":

--- a/python/dazl/damlast/eval_scope.py
+++ b/python/dazl/damlast/eval_scope.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from types import MappingProxyType
+from typing import Collection, Mapping, Optional
+import warnings
+
+from .daml_lf_1 import Expr, Type, ValName
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from ..model.types_store import PackageStore
+
+
+warnings.warn(
+    "dazl.damlast.eval_scope is deprecated; there is no replacement.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class EvaluationScope:
+    def __init__(
+        self,
+        store: "PackageStore",
+        bindings: "Mapping[str, Expr]",
+        blocked_value_refs: "Collection[ValName]" = (),
+        depth: int = 0,
+    ):
+        warnings.warn(
+            "EvaluationScope is deprecated; there is no replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.store = store
+        self.depth = depth
+        self._vars = MappingProxyType(dict(bindings))
+        self._blocked_value_refs = frozenset(blocked_value_refs)
+
+    def without(self, var_name: str) -> "EvaluationScope":
+        """
+        Return a child scope with the specified variable name _unbound_.
+
+        :param var_name:
+        :return:
+        """
+        new_bindings = dict(self._vars)
+        del new_bindings[var_name]
+        return EvaluationScope(self.store, new_bindings, self._blocked_value_refs, self.depth + 1)
+
+    def without_value(self, value_ref) -> "EvaluationScope":
+        """
+        Return a child scope where the value corresponding to the specified value reference will
+        NOT be returned. (This is used to handle breaking otherwise recursive calls.)
+
+        :param value_ref: The value to withhold.
+        """
+        values = set(self._blocked_value_refs)
+        values.discard(value_ref)
+
+        return EvaluationScope(self.store, self._vars, frozenset(values), self.depth + 1)
+
+    def child_scope(self, new_bindings: "Mapping[str, Expr]") -> "EvaluationScope":
+        bindings = dict(self._vars)
+        bindings.update(new_bindings)
+        return EvaluationScope(self.store, bindings, self._blocked_value_refs, self.depth + 1)
+
+    def get_bound(self, var_name) -> "Expr":
+        return self._vars[var_name]
+
+    def resolve_type(self, type_ref) -> "Type":
+        pass
+
+    def resolve_value(self, value_ref) -> "Optional[Expr]":
+        if value_ref in self._blocked_value_refs:
+            return None
+        else:
+            return self.store.resolve_value_reference(value_ref)

--- a/python/dazl/damlast/expand.py
+++ b/python/dazl/damlast/expand.py
@@ -175,7 +175,7 @@ class SimplifyVisitor(RewriteVisitor):
             if builtin is not None:
                 type_args = app.fun.ty_app.types
                 new_args = [self.visit_expr(arg) for arg in app.args]
-                result = builtin().simplify(type_args, new_args)
+                result = builtin.simplify(type_args, new_args)
                 if result is not None:
                     return result
 

--- a/python/dazl/damlast/parse.py
+++ b/python/dazl/damlast/parse.py
@@ -14,6 +14,7 @@ in turn contain templates, data types, and values.
 
 import sys
 import time
+from typing import Optional
 
 from .._gen.com.daml.daml_lf_dev.daml_lf_pb2 import ArchivePayload
 from .daml_lf_1 import Archive, PackageRef
@@ -34,7 +35,9 @@ def parse_archive(package_id: "PackageRef", archive_bytes: bytes) -> "Archive":
     return Archive(package_id, package)
 
 
-def parse_archive_payload(package_id: "PackageRef", archive_bytes: bytes) -> "ArchivePayload":
+def parse_archive_payload(
+    package_id: "Optional[PackageRef]", archive_bytes: bytes
+) -> "ArchivePayload":
     """
     Convert ``bytes`` into a :class:`G.ArchivePayload`.
 
@@ -55,7 +58,7 @@ def parse_archive_payload(package_id: "PackageRef", archive_bytes: bytes) -> "Ar
         archive_payload.ParseFromString(archive_bytes)
     except DecodeError:
         # noinspection PyPackageRequirements
-        from google.protobuf.internal import api_implementation
+        from google.protobuf.internal import api_implementation  # type: ignore
 
         if api_implementation.Type() == "cpp":
             LOG.error("Failed to decode metadata. This may be due to bugs in the native Protobuf")

--- a/python/dazl/damlast/protocols.py
+++ b/python/dazl/damlast/protocols.py
@@ -4,6 +4,11 @@
 import sys
 from typing import TYPE_CHECKING, AbstractSet, Any, Collection
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
+
 if TYPE_CHECKING:
     from .daml_lf_1 import (
         Archive,
@@ -14,13 +19,6 @@ if TYPE_CHECKING:
         PackageRef,
         TypeConName,
     )
-
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable
-
 
 __all__ = ["PackageProvider", "SymbolLookup"]
 

--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -4,14 +4,12 @@
 from typing import TYPE_CHECKING, Callable, Optional, no_type_check
 import warnings
 
+from ..util.typing import safe_cast
 from ._base import T
 from .daml_lf_1 import PrimType, Type
 
 if TYPE_CHECKING:
     from ..model.types import Type as OldType
-
-
-__all__ = ["var", "match_prim_type", "get_old_type"]
 
 
 def var(var_: str) -> "Type":
@@ -90,8 +88,7 @@ def match_prim_type(
 
 def get_old_type(daml_type: "Type") -> "OldType":
     warnings.warn(
-        "dazl.model.types.Type and get_old_type are deprecated; "
-        "use the types defined in dazl.damlast.daml_lf_1 instead.",
+        "get_old_type is deprecated; use the types of dazl.damlast.daml_lf_1 instead",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -99,7 +96,7 @@ def get_old_type(daml_type: "Type") -> "OldType":
         warnings.simplefilter("ignore", DeprecationWarning)
         from ..model.types import UnsupportedType
 
-        return daml_type.Sum_match(
+        return safe_cast(Type, daml_type).Sum_match(
             _old_type_var,
             _old_type_con,
             _old_type_prim,

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -34,14 +34,13 @@ def var(var: str) -> "Type":
 def values_by_module(
     store: "PackageStore",
 ) -> "Mapping[ModuleRef, Mapping[Sequence[str], Union[Expr, OldType]]]":
-    from collections import defaultdict
+    warnings.warn(
+        "dazl.damlast.util.values_by_module is deprecated; there is no replacement.",
+        DeprecationWarning,
+    )
+    from ..pretty.render_python import values_by_module  # type: ignore
 
-    d = defaultdict(defaultdict)
-    for vn, vv in store._value_types.items():
-        d[vn.module][vn.name] = vv
-    for vn, vv in store._data_types.items():
-        d[vn.module][vn.name] = vv
-    return d
+    return values_by_module(store)  # type: ignore
 
 
 # noinspection PyShadowingBuiltins
@@ -76,11 +75,9 @@ def pack_arrow_type(types: "Sequence[Type]") -> "Optional[Type]":
     if not types:
         return None
 
-    from .daml_types import Arrow
-
     t = types[-1]
     for type in reversed(types[0:-1]):
-        t = Arrow(type, t)
+        t = arrow_type(type, t)
     return t
 
 
@@ -131,7 +128,7 @@ def package_ref(obj: "Union[ModuleRef, _Name, TypeReference]") -> "PackageRef":
     """
     from ..model.types import TypeReference
 
-    # TODO: Rewrite for dazl 8.0.0 when the internal structure of a ModuleRef is changed.
+    # TODO: Rewrite for dazl 7.0.0 when the internal structure of a ModuleRef is changed.
     if isinstance(obj, ModuleRef):
         # noinspection PyProtectedMember
         return obj._package_id
@@ -151,7 +148,7 @@ def module_name(obj: "Union[ModuleRef, _Name, TypeReference]") -> "DottedName":
     """
     from ..model.types import TypeReference
 
-    # TODO: Rewrite for dazl 8.0.0 when the internal structure of ModuleRefs and _Name are changed.
+    # TODO: Rewrite for dazl 7.0.0 when the internal structure of ModuleRefs and _Name are changed.
     if isinstance(obj, ModuleRef):
         # noinspection PyProtectedMember
         return obj._module_name
@@ -171,7 +168,7 @@ def module_ref(obj: "Union[_Name, TypeReference]") -> "ModuleRef":
     """
     from ..model.types import TypeReference
 
-    # TODO: Rewrite for dazl 8.0.0 when the internal structure of ModuleRefs and _Name are changed.
+    # TODO: Rewrite for dazl 7.0.0 when the internal structure of ModuleRefs and _Name are changed.
     if isinstance(obj, _Name):
         # noinspection PyProtectedMember
         return obj._module
@@ -189,10 +186,10 @@ def package_local_name(obj: "Union[_Name, TypeReference]") -> str:
     """
     from ..model.types import TypeReference
 
+    # TODO: Rewrite for dazl 7.0.0 when the internal structure of a ModuleRef is changed.
     if isinstance(obj, TypeReference):
         obj = obj.con
 
-    # TODO: Rewrite for dazl 8.0.0 when the internal structure of a ModuleRef is changed.
     if isinstance(obj, _Name):
         # noinspection PyProtectedMember
         return f'{obj._module._module_name}:{".".join(obj._name)}'
@@ -205,12 +202,9 @@ def module_local_name(obj: "Union[_Name, TypeReference]") -> str:
     Return the name of a DAML object, assuming that the referent exists in the same module as the
     target (i.e., in the same package and in the same module).
     """
+    # TODO: Rewrite for dazl 7.0.0 when the internal structure of ModuleRefs and _Name are changed.
     from ..model.types import TypeReference
 
-    if isinstance(obj, TypeReference):
-        obj = obj.con
-
-    # TODO: Rewrite for dazl 8.0.0 when the internal structure of ModuleRefs and _Name are changed.
     if isinstance(obj, _Name):
         # noinspection PyProtectedMember
         return ".".join(obj._name)

--- a/python/dazl/damlast/visitor.py
+++ b/python/dazl/damlast/visitor.py
@@ -288,8 +288,7 @@ class IdentityVisitor(ExprVisitor[Expr], IdentityTypeVisitor):
         )
 
     def visit_expr_enum_con(self, enum_con: "Expr.EnumCon") -> "Expr":
-        new_type_con = self.visit_type_con(enum_con.tycon).con
-        return Expr(enum_con=Expr.EnumCon(tycon=new_type_con, enum_con=enum_con.enum_con))
+        return Expr(enum_con=Expr.EnumCon(tycon=enum_con.tycon, enum_con=enum_con.enum_con))
 
     def visit_expr_struct_con(self, struct_con: "Expr.StructCon") -> "Expr":
         new_fields = tuple(
@@ -373,7 +372,7 @@ class IdentityVisitor(ExprVisitor[Expr], IdentityTypeVisitor):
 
     def visit_expr_from_any(self, from_any: "Expr.FromAny") -> "Expr":
         return Expr(
-            from_any=Expr.ToAny(
+            from_any=Expr.FromAny(
                 type=self.visit_type(from_any.type), expr=self.visit_expr(from_any.expr)
             )
         )

--- a/python/dazl/model/lookup.py
+++ b/python/dazl/model/lookup.py
@@ -5,7 +5,7 @@
 This module has been relocated to ``dazl.damlast.lookup``.
 """
 
-from typing import TYPE_CHECKING, Any, Iterator, Tuple, Union
+from typing import Iterator, Tuple
 import warnings
 
 from ..damlast.daml_lf_1 import PackageRef
@@ -13,10 +13,10 @@ from ..damlast.lookup import validate_template as _validate_template
 
 __all__ = ["validate_template", "template_reverse_globs"]
 
-if TYPE_CHECKING:
-    from ..damlast.daml_lf_1 import PackageRef
 warnings.warn(
-    "dazl.model.lookup is deprecated; use dazl.damlast.lookup instead.", DeprecationWarning
+    "dazl.model.lookup is deprecated; use dazl.damlast.lookup instead.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 

--- a/python/dazl/server/management.py
+++ b/python/dazl/server/management.py
@@ -7,6 +7,7 @@ Endpoints for managing parties/bots connected via a dazl client.
 
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Collection, NoReturn, Optional, Sequence
+import warnings
 
 from ..client import Bot, _NetworkImpl
 from ..client.bots import SourceLocation


### PR DESCRIPTION
This is basically the last of the backports of type fixes from the v7 branch; `master` still doesn't 100% pass `mypy`'s muster yet, but the remaining breaks are largely due to code that only exists on `master`: the new v8 API!