### PR TITLE
python: `DeprecationWarning` cleanup

### DIFF
--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -92,7 +92,9 @@ class _PartyClientImpl:
         self._acs = ActiveContractSet(self.invoker, self.parent.lookup)
         self.bots = BotCollection(party)
         self._reader = _PartyClientReaderState()
-        self._writer = _PartyClientWriterState()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self._writer = _PartyClientWriterState()
 
     def connect_in(self, pool: "LedgerNetwork") -> "Future":
         self._config = config = self.resolved_config()

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -316,12 +316,6 @@ class Network:
         """
         self._impl.shutdown()
         if self._main_fut is not None:
-            warnings.warn(
-                "shutdown() in conjunction with start() is deprecated; use aio_run() directly "
-                "and await on the returned coroutine instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             return self._main_fut
         else:
             return None
@@ -343,9 +337,6 @@ class Network:
         """
         Start the coroutine that spawns callbacks for listeners on event streams.
         """
-        warnings.warn(
-            "start() is deprecated; use aio_run() directly", DeprecationWarning, stacklevel=2
-        )
         self._main_fut = ensure_future(self.aio_run(keep_open=False))
 
     def run_until_complete(
@@ -854,8 +845,12 @@ class AIOPartyClient(PartyClient):
         """
         from .. import create
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = create(template_name, arguments)
+
         return self.submit(
-            create(template_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -891,8 +886,12 @@ class AIOPartyClient(PartyClient):
         """
         from .. import exercise
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = exercise(cid, choice_name, arguments)
+
         return self.submit(
-            exercise(cid, choice_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -928,8 +927,12 @@ class AIOPartyClient(PartyClient):
         """
         from .. import exercise_by_key
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = (exercise_by_key(template_name, contract_key, choice_name, arguments),)
+
         return self.submit(
-            exercise_by_key(template_name, contract_key, choice_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -964,8 +967,12 @@ class AIOPartyClient(PartyClient):
         """
         from .. import create_and_exercise
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = create_and_exercise(template_name, arguments, choice_name, choice_arguments)
+
         return self.submit(
-            create_and_exercise(template_name, arguments, choice_name, choice_arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -1473,8 +1480,12 @@ class SimplePartyClient(PartyClient):
         """
         from .. import create
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = create(template_name, arguments)
+
         return self.submit(
-            create(template_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -1507,8 +1518,12 @@ class SimplePartyClient(PartyClient):
         """
         from .. import exercise
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = exercise(cid, choice_name, arguments)
+
         return self.submit(
-            exercise(cid, choice_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -1544,8 +1559,12 @@ class SimplePartyClient(PartyClient):
         """
         from .. import exercise_by_key
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = exercise_by_key(template_name, contract_key, choice_name, arguments)
+
         return self.submit(
-            exercise_by_key(template_name, contract_key, choice_name, arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )
@@ -1580,8 +1599,12 @@ class SimplePartyClient(PartyClient):
         """
         from .. import create_and_exercise
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cmd = create_and_exercise(template_name, arguments, choice_name, choice_arguments)
+
         return self.submit(
-            create_and_exercise(template_name, arguments, choice_name, choice_arguments),
+            cmd,
             workflow_id=workflow_id,
             deduplication_time=deduplication_time,
         )

--- a/python/dazl/ledger/pkgloader_aio.py
+++ b/python/dazl/ledger/pkgloader_aio.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
 from asyncio import ensure_future, gather, get_event_loop, sleep, wait_for
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 import sys
 from typing import AbstractSet, Awaitable, Callable, Dict, Optional, Set, TypeVar
+import warnings
 
 from .. import LOG
 from ..damlast.daml_lf_1 import Archive, Package, PackageRef
@@ -108,9 +108,11 @@ class PackageLoader:
                     )
                     raise
 
-                pkg_id, name = validate_template(
-                    ex.ref, allow_deprecated_identifiers=self._allow_deprecated_identifiers
-                )
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    pkg_id, name = validate_template(
+                        ex.ref, allow_deprecated_identifiers=self._allow_deprecated_identifiers
+                    )
                 if pkg_id == "*":
                     # we don't know what package contains this type, so we have no
                     # choice but to look in all known packages

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -111,9 +111,17 @@ class ContractId(ContractId_):
         :param arguments:
             (optional) A ``dict`` of named values to send as parameters to the choice exercise.
         """
+        warnings.warn(
+            "ContractId.exercise is deprecated; prefer calling dazl.ledger.Connection.exercise or "
+            "dazl.client.PartyClient.submit_exercise, or use dazl.ledger.ExerciseCommand instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from .writing import ExerciseCommand
 
-        return ExerciseCommand(self, choice_name, arguments=arguments)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return ExerciseCommand(self, choice_name, arguments=arguments)
 
     def replace(self, contract_id=None, template_id=None):
         """

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -355,8 +355,12 @@ def grpc_package_sync(package_provider: "PackageProvider", store: "PackageStore"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         all_package_ids = package_provider.get_package_ids()
-        loaded_package_ids = {a.hash for a in store.archives()}
-        expected_package_ids = store.expected_package_ids()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            loaded_package_ids = {a.hash for a in store.archives()}
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            expected_package_ids = store.expected_package_ids()
 
         def should_load(p: str) -> bool:
             # TODO: Filtering by expected package IDs may cause packages to never fully load due to
@@ -377,8 +381,12 @@ def grpc_package_sync(package_provider: "PackageProvider", store: "PackageStore"
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         adr = find_dependencies(metadatas_pb, loaded_package_ids)
-        for package_id, archive_bytes in adr.sorted_archives.items():
-            store.register_all(parse_daml_metadata_pb(package_id, archive_bytes))
+
+    for package_id, archive_bytes in adr.sorted_archives.items():
+        m = parse_daml_metadata_pb(package_id, archive_bytes)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            store.register_all(m)
 
         LOG.debug("grpc_package_sync ended.")
 

--- a/python/dazl/util/asyncio_util.py
+++ b/python/dazl/util/asyncio_util.py
@@ -751,7 +751,9 @@ def get_running_loop() -> Optional[AbstractEventLoop]:
 # noinspection PyDeprecation
 def safe_create_future():
     warnings.warn(
-        "safe_create_future() is deprecated; there is no planned replacement.", DeprecationWarning
+        "safe_create_future() is deprecated; there is no planned replacement.",
+        DeprecationWarning,
+        stacklevel=2,
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -795,7 +797,7 @@ class Signal:
         if self._fut is None:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-            self._fut = safe_create_future()
+                self._fut = safe_create_future()
         return self._fut
 
 

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -2,5 +2,6 @@
 cache_dir=../.cache/pytest
 log_cli = True
 log_cli_level = DEBUG
+junit_family = xunit1
 testpaths =
     tests/unit

--- a/python/tests/unit/test_acs_find_active.py
+++ b/python/tests/unit/test_acs_find_active.py
@@ -5,7 +5,8 @@ from asyncio import ensure_future, wait_for
 
 import pytest
 
-from dazl import AIOPartyClient, async_network, exercise
+from dazl import AIOPartyClient, async_network
+from dazl.ledger import ExerciseCommand
 
 from .dars import Simple
 
@@ -52,6 +53,6 @@ async def async_test_case(client: AIOPartyClient):
         if int(cdata["text"]) <= 3:
             contracts_to_delete.append(cid)
 
-    ensure_future(client.submit([exercise(cid, "Archive") for cid in contracts_to_delete]))
+    ensure_future(client.submit([ExerciseCommand(cid, "Archive") for cid in contracts_to_delete]))
 
     ensure_future(client.submit_exercise(operator_cid, "PublishMany", dict(count=3)))

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from dazl import Party, async_network, create
+from dazl import Party, async_network
 
 from .dars import AllParty as AllPartyDar
 
@@ -27,12 +27,12 @@ async def test_some_party_receives_public_contract(sandbox):
 
         some_client = network.aio_new_party()
         some_client.add_ledger_ready(
-            lambda _: create(PrivateContract, {"someParty": some_client.party})
+            lambda _: some_client.submit_create(PrivateContract, {"someParty": some_client.party})
         )
 
         publisher_client = network.aio_new_party()
         publisher_client.add_ledger_ready(
-            lambda _: create(
+            lambda _: publisher_client.submit_create(
                 PublicContract, {"publisher": publisher_client.party, "allParty": all_party}
             )
         )

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -6,7 +6,8 @@ from decimal import Decimal
 
 import pytest
 
-from dazl import async_network, create
+from dazl import async_network
+from dazl.ledger import CreateCommand, ExerciseCommand
 
 from .dars import AllKindsOf
 
@@ -76,11 +77,11 @@ class AllTypesTestCase:
         self.archive_done = False
 
     def create_one_of_everything(self, _):
-        return create(TEMPLATE, {**SOME_ARGS, "operator": self.operator})
+        return CreateCommand(TEMPLATE, {**SOME_ARGS, "operator": self.operator})
 
     def on_one_of_everything(self, event):
         if event.cdata is not None:
             self.found_instance = event.cdata
-            return event.cid.exercise("Accept")
+            return ExerciseCommand(event.cid, "Accept")
         else:
             self.archive_done = True

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -4,6 +4,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from dazl.client.commands import CommandBuilder, CommandDefaults, CommandPayload, create
 from dazl.damlast.lookup import parse_type_con_name
 from dazl.ledger import CreateCommand, ExerciseCommand
@@ -27,7 +29,8 @@ class TestCommandBuilderTest(TestCase):
     """
 
     def test_single_create_untyped(self):
-        expr = create("Sample:Untyped", {"arg": 1})
+        with pytest.warns(DeprecationWarning):
+            expr = create("Sample:Untyped", {"arg": 1})
 
         expected = [
             CommandPayload(
@@ -39,12 +42,15 @@ class TestCommandBuilderTest(TestCase):
                 commands=[CreateCommand(SOME_TEMPLATE_NAME, dict(arg=1))],
             )
         ]
-        actual = CommandBuilder.coerce(expr).build(DEFAULTS)
+
+        with pytest.warns(DeprecationWarning):
+            actual = CommandBuilder.coerce(expr).build(DEFAULTS)
 
         assert expected == actual
 
     def test_object_create_untyped(self):
-        builder = CommandBuilder()
+        with pytest.warns(DeprecationWarning):
+            builder = CommandBuilder()
         builder.create("Sample:Untyped", {"arg": 1})
 
         expected = [
@@ -62,7 +68,8 @@ class TestCommandBuilderTest(TestCase):
         assert expected == actual
 
     def test_object_atomic_default_false(self):
-        builder = CommandBuilder(atomic_default=False)
+        with pytest.warns(DeprecationWarning):
+            builder = CommandBuilder(atomic_default=False)
         builder.create("Sample:Untyped", {"arg": 1})
         builder.exercise(SOME_CONTRACT_ID, "SomeChoice", {"choiceArg": "value"})
 
@@ -90,7 +97,8 @@ class TestCommandBuilderTest(TestCase):
         assert expected == actual
 
     def test_object_atomic_default_true(self):
-        builder = CommandBuilder(atomic_default=True)
+        with pytest.warns(DeprecationWarning):
+            builder = CommandBuilder(atomic_default=True)
         builder.create("Sample:Untyped", {"arg": 1})
         builder.exercise(SOME_CONTRACT_ID, "SomeChoice", {"choiceArg": "value"})
 

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -12,13 +12,13 @@ from dazl_internal.background_http_server import TestHTTPServer
 
 
 def test_party_config_allows_single_string():
-    config = NetworkConfig.parse_kwargs(parties="Bob", participant_url="http://nowhere/")
+    config = NetworkConfig.parse_kwargs(parties="Bob", url="http://nowhere/")
     assert config.parties[0].party == Party("Bob")
     assert config.parties[0].url == "http://nowhere/"
 
 
 def test_party_config_allows_list():
-    config = NetworkConfig.parse_kwargs(parties=["Bob"], participant_url="http://nowhere/")
+    config = NetworkConfig.parse_kwargs(parties=["Bob"], url="http://nowhere/")
     assert config.parties[0].party == Party("Bob")
     assert config.parties[0].url == "http://nowhere/"
 

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from asyncio import gather
 import uuid
 
 import pytest
 
-from dazl import async_network, create, exercise
+from dazl import async_network
 
 from .dars import PostOffice
 
@@ -19,15 +20,19 @@ async def test_parties_can_be_added_after_run_forever(sandbox):
         party_c_party = str(uuid.uuid4())
 
         @operator_client.ledger_ready()
-        def operator_ready(event):
-            return create("Main:PostmanRole", {"postman": event.party})
+        async def operator_ready(event):
+            await operator_client.submit_create("Main:PostmanRole", {"postman": event.party})
 
         @operator_client.ledger_created("Main:PostmanRole")
-        def operator_role_created(event):
-            return [
-                exercise(event.cid, "InviteParticipant", {"party": party, "address": "whatevs"})
-                for party in (party_a_client.party, party_b_client.party, party_c_party)
-            ]
+        async def operator_role_created(event):
+            await gather(
+                *[
+                    operator_client.submit_exercise(
+                        event.cid, "InviteParticipant", {"party": party, "address": "whatevs"}
+                    )
+                    for party in (party_a_client.party, party_b_client.party, party_c_party)
+                ]
+            )
 
         @party_a_client.ledger_created("Main:InviteAuthorRole")
         async def party_a_accept_invite(_):

--- a/python/tests/unit/test_event_order.py
+++ b/python/tests/unit/test_event_order.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from asyncio import new_event_loop, set_event_loop, sleep
+from asyncio import new_event_loop, set_event_loop
 import random
 import uuid
 
-from dazl import Network, create, exercise
+from dazl import Network
+from dazl.ledger import CreateCommand, ExerciseCommand
 from dazl.prim import to_party
 
 from .dars import Simple as SimpleDar
@@ -59,11 +60,13 @@ class Stage1LedgerInit:
     async def on_ready(self, event):
         await self.network.aio_global().ensure_dar(SimpleDar)
 
-        return create(Simple.OperatorRole, {"operator": event.party})
+        return CreateCommand(Simple.OperatorRole, {"operator": event.party})
 
     @staticmethod
     def on_operator(event):
-        return [exercise(event.cid, "Publish", {"text": n}) for n in range(0, NOTIFICATION_COUNT)]
+        return [
+            ExerciseCommand(event.cid, "Publish", {"text": n}) for n in range(0, NOTIFICATION_COUNT)
+        ]
 
     def on_notification(self, event):
         if self.evt_count == 25:
@@ -72,7 +75,7 @@ class Stage1LedgerInit:
             self.evt_count += 1
             missing_parties = self.user_parties.difference(event.cdata["theObservers"])
             if missing_parties:
-                return exercise(
+                return ExerciseCommand(
                     event.cid, "Share", {"sharingParty": random.choice(list(missing_parties))}
                 )
 

--- a/python/tests/unit/test_flask.py
+++ b/python/tests/unit/test_flask.py
@@ -5,7 +5,8 @@ import json
 from threading import Thread
 from time import sleep
 
-from dazl import LOG, Network, SimplePartyClient, create
+from dazl import LOG, Network, SimplePartyClient
+from dazl.ledger import CreateCommand
 from dazl.protocols.events import ReadyEvent
 
 from .dars import PostOffice
@@ -52,7 +53,7 @@ def create_initial_state(event: "ReadyEvent"):
         event.client.ensure_dar(PostOffice)
 
         LOG.info("DAR uploaded. Creating the initial postman role contract...")
-        return create("Main:PostmanRole", dict(postman=event.party))
+        return CreateCommand("Main:PostmanRole", dict(postman=event.party))
     except:
         LOG.exception("Failed to set up our initial state!")
 

--- a/python/tests/unit/test_pb_serialize.py
+++ b/python/tests/unit/test_pb_serialize.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 import pytest
 
-from dazl import CreateAndExerciseCommand, CreateCommand, ExerciseByKeyCommand, ExerciseCommand
 from dazl._gen.com.daml.ledger.api.v1.commands_pb2 import Command as G_Command
 from dazl._gen.com.daml.ledger.api.v1.value_pb2 import (
     RecordField as G_RecordField,
@@ -14,6 +13,12 @@ from dazl._gen.com.daml.ledger.api.v1.value_pb2 import (
 from dazl.damlast import DarFile
 from dazl.damlast.lookup import MultiPackageLookup
 from dazl.damlast.protocols import SymbolLookup
+from dazl.ledger import (
+    CreateAndExerciseCommand,
+    CreateCommand,
+    ExerciseByKeyCommand,
+    ExerciseCommand,
+)
 from dazl.ledger.grpc.codec_aio import Codec
 from dazl.prim import ContractId, Party
 from dazl.protocols.v1.pb_ser_command import ProtobufSerializer

--- a/python/tests/unit/test_pending.py
+++ b/python/tests/unit/test_pending.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from dazl import async_network, create, exercise
+from dazl import async_network
+from dazl.ledger import CreateCommand, ExerciseCommand
 
 from .dars import Pending
 
@@ -21,10 +22,10 @@ async def test_select_template_retrieves_contracts(sandbox):
         client = network.aio_new_party()
         client.add_ledger_ready(
             lambda _: [
-                create(Counter, {"owner": client.party, "value": 0}),
+                CreateCommand(Counter, {"owner": client.party, "value": 0}),
                 *[
-                    create(AccountRequest, {"owner": client.party})
-                    for i in range(number_of_contracts)
+                    CreateCommand(AccountRequest, {"owner": client.party})
+                    for _ in range(number_of_contracts)
                 ],
             ]
         )
@@ -33,8 +34,8 @@ async def test_select_template_retrieves_contracts(sandbox):
         async def on_account_request(event):
             counter_cid, counter_cdata = await event.acs_find_one(Counter)
             return [
-                exercise(event.cid, "CreateAccount", dict(accountId=counter_cdata["value"])),
-                exercise(counter_cid, "Increment"),
+                ExerciseCommand(event.cid, "CreateAccount", dict(accountId=counter_cdata["value"])),
+                ExerciseCommand(counter_cid, "Increment"),
             ]
 
         await network.aio_run(keep_open=False)

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import ClientSession
 import pytest
 
-from dazl import Network, Party, async_network, create, exercise_by_key
+from dazl import Network, Party, async_network
 
 from .dars import TestServer as TestServerDar
 
@@ -38,8 +38,8 @@ async def test_server_endpoint(sandbox):
         bob_bot.pause()
 
         @bob_bot.ledger_created("TestServer:Person")
-        def bob_sends_a_message(_):
-            return exercise_by_key(
+        async def bob_sends_a_message(_):
+            await bob_client.submit_exercise_by_key(
                 "TestServer:Person",
                 bob,
                 "SayHello",
@@ -47,8 +47,8 @@ async def test_server_endpoint(sandbox):
             )
 
         @carol_client.ledger_created("TestServer:Person")
-        def carol_sends_a_message(_):
-            return exercise_by_key(
+        async def carol_sends_a_message(_):
+            await carol_client.submit_exercise_by_key(
                 "TestServer:Person",
                 carol,
                 "SayHello",
@@ -60,9 +60,8 @@ async def test_server_endpoint(sandbox):
 
 
 def ensure_person_contract(network: Network, party: Party):
-    network.aio_party(party).add_ledger_ready(
-        lambda _: create("TestServer:Person", dict(party=party))
-    )
+    client = network.aio_party(party)
+    client.add_ledger_ready(lambda _: client.submit_create("TestServer:Person", dict(party=party)))
 
 
 async def client_main(

--- a/python/tests/unit/test_service_queue.py
+++ b/python/tests/unit/test_service_queue.py
@@ -4,6 +4,8 @@
 from asyncio import ensure_future, gather, new_event_loop, set_event_loop, sleep
 from unittest import TestCase
 
+import pytest
+
 from dazl.util.asyncio_util import ServiceQueue
 
 
@@ -12,7 +14,8 @@ class TestServiceQueue(TestCase):
         loop = new_event_loop()
         set_event_loop(loop)
 
-        sq = ServiceQueue()
+        with pytest.warns(DeprecationWarning):
+            sq = ServiceQueue()
         expected = list(range(5))
         actual = []
 

--- a/python/tests/unit/test_template_filtering.py
+++ b/python/tests/unit/test_template_filtering.py
@@ -1,6 +1,7 @@
 import pytest
 
-from dazl import async_network, create
+from dazl import async_network
+from dazl.ledger import CreateCommand
 
 from .dars import AllParty, PostOffice
 
@@ -20,11 +21,11 @@ async def test_template_filtering(sandbox):
         network.start()
         await client.submit(
             [
-                create("AllParty:PrivateContract", {"someParty": party}),
-                create("AllParty:PrivateContract", {"someParty": party}),
-                create("AllParty:PrivateContract", {"someParty": party}),
-                create("Main:PostmanRole", {"postman": party}),
-                create("Main:PostmanRole", {"postman": party}),
+                CreateCommand("AllParty:PrivateContract", {"someParty": party}),
+                CreateCommand("AllParty:PrivateContract", {"someParty": party}),
+                CreateCommand("AllParty:PrivateContract", {"someParty": party}),
+                CreateCommand("Main:PostmanRole", {"postman": party}),
+                CreateCommand("Main:PostmanRole", {"postman": party}),
             ]
         )
 


### PR DESCRIPTION
python: Tweaks, mostly to tests to ensure that deprecation warnings are handled appropriately in tests.

The vast majority of these warnings are in core parts of `dazl` where a user has no realistic way of suppressing warnings; until these bits of code are either themselves deprecated or changed to use symbols that will be supported going forward, they're suppressed.