### PR TITLE
python: Documentation updates, Command submission changes

### DIFF
--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -29,7 +29,7 @@ from uuid import uuid4
 import warnings
 
 from .. import LOG
-from ..ledger import Command
+from ..ledger import Command, CreateEvent, ExerciseResponse
 from ..prim import Party
 from ..protocols.events import BaseEvent
 from ..util.asyncio_util import LongRunningAwaitable, Signal, completed, failed, propagate
@@ -519,6 +519,8 @@ def wrap_as_command_submission(
                     ret = cmd_fut.result()
                     if ret is None:
                         fut.set_result(None)
+                    elif isinstance(ret, (CreateEvent, ExerciseResponse)):
+                        fut.set_result(ret)
                     elif isinstance(ret, (CommandBuilder, Command, list, tuple)):
                         propagate(ensure_future(submit_fn(ret)), fut)
                     elif inspect.isawaitable(ret):

--- a/python/dazl/ledger/grpc/conn_aio.py
+++ b/python/dazl/ledger/grpc/conn_aio.py
@@ -25,6 +25,7 @@ from ..._gen.com.daml.ledger.api.v1.admin.package_management_service_pb2_grpc im
 )
 from ..._gen.com.daml.ledger.api.v1.admin.party_management_service_pb2 import (
     AllocatePartyRequest as G_AllocatePartyRequest,
+    ListKnownPartiesRequest as G_ListKnownPartiesRequest,
 )
 from ..._gen.com.daml.ledger.api.v1.admin.party_management_service_pb2_grpc import (
     PartyManagementServiceStub,
@@ -165,8 +166,8 @@ class Connection:
 
     async def create(
         self,
-        template_id: Union[str, TypeConName],
-        payload: ContractData,
+        __template_id: Union[str, TypeConName],
+        __payload: ContractData,
         *,
         workflow_id: Optional[str] = None,
         command_id: Optional[str] = None,
@@ -174,14 +175,28 @@ class Connection:
         """
         Create a contract for a given template.
 
-        :param template_id: The template of the contract to be created.
-        :param payload: Template arguments for the contract to be created.
-        :param workflow_id: An optional workflow ID.
-        :param command_id: An optional command ID. If unspecified, a random one will be created.
+        :param __template_id:
+            The template of the contract to be created.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __payload:
+            Template arguments for the contract to be created.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The :class:`CreateEvent` that represents the contract that was successfully created.
         """
         stub = CommandServiceStub(self.channel)
 
-        commands = [G_Command(create=await self._codec.encode_create_command(template_id, payload))]
+        commands = [
+            G_Command(create=await self._codec.encode_create_command(__template_id, __payload))
+        ]
         request = G_SubmitAndWaitRequest(
             commands=G_Commands(
                 ledger_id=self._config.access.ledger_id,
@@ -200,9 +215,9 @@ class Connection:
 
     async def exercise(
         self,
-        contract_id: ContractId,
-        choice_name: str,
-        argument: Optional[ContractData] = None,
+        __contract_id: ContractId,
+        __choice_name: str,
+        __argument: Optional[ContractData] = None,
         *,
         workflow_id: Optional[str] = None,
         command_id: Optional[str] = None,
@@ -210,19 +225,35 @@ class Connection:
         """
         Exercise a choice on a contract identified by its contract ID.
 
-        :param contract_id: The contract ID of the contract to exercise.
-        :param choice_name: The name of the choice to exercise.
-        :param argument: The choice arguments. Can be omitted for choices that take no argument.
-        :param workflow_id: An optional workflow ID.
-        :param command_id: An optional command ID. If unspecified, a random one will be created.
-        :return: A response
+        :param __contract_id:
+            The contract ID of the contract to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __choice_name:
+            The name of the choice to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __argument:
+            The choice arguments. Can be omitted for choices that take no argument.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The return value of the choice, together with a list of events that occurred as a result
+            of exercising the choice.
         """
         stub = CommandServiceStub(self.channel)
 
         commands = [
             G_Command(
                 exercise=await self._codec.encode_exercise_command(
-                    contract_id, choice_name, argument
+                    __contract_id, __choice_name, __argument
                 )
             )
         ]
@@ -233,20 +264,52 @@ class Connection:
 
     async def create_and_exercise(
         self,
-        template_id: Union[str, TypeConName],
-        payload: ContractData,
-        choice_name: str,
-        argument: Optional[ContractData] = None,
+        __template_id: Union[str, TypeConName],
+        __payload: ContractData,
+        __choice_name: str,
+        __argument: Optional[ContractData] = None,
         *,
         workflow_id: Optional[str] = None,
         command_id: Optional[str] = None,
     ) -> ExerciseResponse:
+        """
+        Exercise a choice on a newly-created contract, in a single transaction.
+
+        :param __template_id:
+            The template of the contract to be created (positional argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __payload:
+            Template arguments for the contract to be created (positional argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __choice_name:
+            The name of the choice to exercise (positional argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __argument:
+            The choice arguments. Can be omitted for choices that take no argument (positional
+            argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The return value of the choice, together with a list of events that occurred as a result
+            of exercising the choice.
+        """
         stub = CommandServiceStub(self.channel)
 
         commands = [
             G_Command(
                 createAndExercise=await self._codec.encode_create_and_exercise_command(
-                    template_id, payload, choice_name, argument
+                    __template_id, __payload, __choice_name, __argument
                 )
             )
         ]
@@ -257,20 +320,51 @@ class Connection:
 
     async def exercise_by_key(
         self,
-        template_id: Union[str, TypeConName],
-        choice_name: str,
-        key: Any,
-        argument: Optional[ContractData] = None,
+        __template_id: Union[str, TypeConName],
+        __choice_name: str,
+        __key: Any,
+        __argument: Optional[ContractData] = None,
         *,
         workflow_id: Optional[str] = None,
         command_id: Optional[str] = None,
     ) -> "ExerciseResponse":
+        """
+        Exercise a choice on a contract identified by its contract key.
+
+        :param __template_id:
+            The template of the contract to be created (positional argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __choice_name:
+            The name of the choice to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __key:
+            The key of the contract to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __argument:
+            The choice arguments. Can be omitted for choices that take no argument.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The return value of the choice, together with a list of events that occurred as a result
+            of exercising the choice.
+        """
         stub = CommandServiceStub(self.channel)
 
         commands = [
             G_Command(
                 exerciseByKey=await self._codec.encode_exercise_by_key_command(
-                    template_id, choice_name, key, argument
+                    __template_id, __choice_name, __key, __argument
                 )
             )
         ]
@@ -279,12 +373,66 @@ class Connection:
 
         return await self._codec.decode_exercise_response(response.transaction)
 
-    async def archive(self, contract_id: ContractId) -> ArchiveEvent:
-        await self.exercise(contract_id, "Archive")
-        return ArchiveEvent(contract_id)
+    async def archive(
+        self,
+        __contract_id: ContractId,
+        *,
+        workflow_id: Optional[str] = None,
+        command_id: Optional[str] = None,
+    ) -> ArchiveEvent:
+        """
+        Archive a choice on a contract identified by its contract ID.
 
-    async def archive_by_key(self, template_id: str, key: Any) -> ArchiveEvent:
-        response = await self.exercise_by_key(template_id, "Archive", key)
+        :param __contract_id:
+            The contract ID of the contract to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The return value of the choice, together with a list of events that occurred as a result
+            of exercising the choice.
+        """
+        await self.exercise(
+            __contract_id, "Archive", workflow_id=workflow_id, command_id=command_id
+        )
+        return ArchiveEvent(__contract_id)
+
+    async def archive_by_key(
+        self,
+        __template_id: str,
+        __key: Any,
+        *,
+        workflow_id: Optional[str] = None,
+        command_id: Optional[str] = None,
+    ) -> ArchiveEvent:
+        """
+        Exercise a choice on a contract identified by its contract key.
+
+        :param __template_id:
+            The template of the contract to be created (positional argument only).
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param __key:
+            The key of the contract to exercise.
+
+            Note that future versions of dazl reserve the right to rename this parameter name at any
+            time; it should be passed in as a positional parameter and never by name.
+        :param workflow_id:
+            An optional workflow ID.
+        :param command_id:
+            An optional command ID. If unspecified, a random one will be created.
+        :return:
+            The return value of the choice, together with a list of events that occurred as a result
+            of exercising the choice.
+        """
+        response = await self.exercise_by_key(
+            __template_id, "Archive", __key, workflow_id=workflow_id, command_id=command_id
+        )
         return next(iter(event for event in response.events if isinstance(event, ArchiveEvent)))
 
     def _ensure_act_as(self) -> Party:
@@ -428,7 +576,8 @@ class Connection:
 
     async def list_known_parties(self) -> Sequence[PartyInfo]:
         stub = PartyManagementServiceStub(self.channel)
-        response = await stub.ListKnownParties()
+        request = G_ListKnownPartiesRequest()
+        response = await stub.ListKnownParties(request)
         return [Codec.decode_party_info(pd) for pd in response.party_details]
 
     # endregion

--- a/python/dazl/ledger/pkgloader_aio.py
+++ b/python/dazl/ledger/pkgloader_aio.py
@@ -34,10 +34,10 @@ class PackageService(Protocol):
     """
 
     async def get_package(self, package_id: "PackageRef") -> bytes:
-        raise NotImplementedError("SyncPackageService.package_bytes requires an implementation")
+        raise NotImplementedError("PackageService.get_package requires an implementation")
 
     async def list_package_ids(self) -> "AbstractSet[PackageRef]":
-        raise NotImplementedError("SyncPackageService.package_ids requires an implementation")
+        raise NotImplementedError("PackageService.list_package_ids requires an implementation")
 
 
 class PackageLoader:

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -12,6 +12,10 @@ import threading
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from .. import LOG
+from .._gen.com.daml.ledger.api.v1.transaction_pb2 import (
+    Transaction as G_Transaction,
+    TransactionTree as G_TransactionTree,
+)
 from ..damlast.lookup import MultiPackageLookup
 from ..prim import Party
 from ..scheduler import Invoker
@@ -103,12 +107,34 @@ class LedgerClient:
         """
         Submit a command to the ledger.
 
-        The coroutine returns when the implementation has accepted the command for processing, but
-        not necessarily committed to the ledger.
+        The coroutine returns when the implementation has accepted the command and a transaction
+        has been added to the ledger. Nothing is returned.
 
         :param command_payload: Payload of data to submit asynchronously.
         """
         raise NotImplementedError("commands must be implemented")
+
+    async def commands_transaction(self, __1: "CommandPayload") -> G_Transaction:
+        """
+        Submit a command to the ledger and retrieve the resulting transaction.
+
+        The coroutine returns when the implementation has accepted the command and a transaction
+        has been added to the ledger. The transaction is returned.
+
+        :param __1: Payload of data to submit asynchronously.
+        """
+        raise NotImplementedError("commands_transaction must be implemented")
+
+    async def commands_transaction_tree(self, __1: "CommandPayload") -> G_TransactionTree:
+        """
+        Submit a command to the ledger and retrieve the resulting transaction tree.
+
+        The coroutine returns when the implementation has accepted the command and a transaction
+        has been added to the ledger. The transaction tree is returned.
+
+        :param __1: Payload of data to submit asynchronously.
+        """
+        raise NotImplementedError("commands_transaction_tree must be implemented")
 
     async def active_contracts(self, contract_filter: "ContractFilter") -> "Sequence[BaseEvent]":
         """

--- a/python/tests/unit/test_acs_find_active.py
+++ b/python/tests/unit/test_acs_find_active.py
@@ -35,11 +35,11 @@ async def test_acs_find_active_retrieves_contracts(sandbox):
 async def async_test_case(client: AIOPartyClient):
     await client.ready()
 
-    ensure_future(client.submit_create(OperatorRole, {"operator": client.party}))
+    ensure_future(client.create(OperatorRole, {"operator": client.party}))
 
     operator_cid, _ = await client.find_one(OperatorRole)
 
-    ensure_future(client.submit_exercise(operator_cid, "PublishMany", dict(count=5)))
+    ensure_future(client.exercise(operator_cid, "PublishMany", dict(count=5)))
 
     # this should actually be a no-op; we're just making sure that calls to ready() that are
     # "too late" are not treated strangely
@@ -55,4 +55,4 @@ async def async_test_case(client: AIOPartyClient):
 
     ensure_future(client.submit([ExerciseCommand(cid, "Archive") for cid in contracts_to_delete]))
 
-    ensure_future(client.submit_exercise(operator_cid, "PublishMany", dict(count=3)))
+    ensure_future(client.exercise(operator_cid, "PublishMany", dict(count=3)))

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -27,12 +27,12 @@ async def test_some_party_receives_public_contract(sandbox):
 
         some_client = network.aio_new_party()
         some_client.add_ledger_ready(
-            lambda _: some_client.submit_create(PrivateContract, {"someParty": some_client.party})
+            lambda _: some_client.create(PrivateContract, {"someParty": some_client.party})
         )
 
         publisher_client = network.aio_new_party()
         publisher_client.add_ledger_ready(
-            lambda _: publisher_client.submit_create(
+            lambda _: publisher_client.create(
                 PublicContract, {"publisher": publisher_client.party, "allParty": all_party}
             )
         )

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -65,7 +65,7 @@ async def test_maps(sandbox):
 
         network.start()
 
-        await client.submit_create(
+        await client.create(
             "AllKindsOf:MappyContract", {"operator": client.party, "value": {"Map_internal": []}}
         )
 

--- a/python/tests/unit/test_autoload_explicit_packages.py
+++ b/python/tests/unit/test_autoload_explicit_packages.py
@@ -44,7 +44,7 @@ async def test_autoload_explicit_packages(sandbox):
     # this call should nonetheless succeed because dazl fetches packages that it sees
     # it's missed
     logging.info("Submitting the create...")
-    await client.submit_create(fqtn, {"operator": client.party})
+    await client.create(fqtn, {"operator": client.party})
 
     network.shutdown()
     await fut

--- a/python/tests/unit/test_complicated_types.py
+++ b/python/tests/unit/test_complicated_types.py
@@ -24,7 +24,7 @@ async def test_complicated_types(sandbox):
     async with async_network(url=sandbox, dars=ComplicatedDar) as network:
         party_client = network.aio_new_party()
         party_client.add_ledger_ready(
-            lambda _: party_client.submit_create(
+            lambda _: party_client.create(
                 Complicated.OperatorRole, {"operator": party_client.party}
             )
         )

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -19,7 +19,7 @@ async def test_record_dotted_fields_submit(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create(
+        await client.create(
             "DottedFields:American",
             {
                 "person": client.party,
@@ -45,7 +45,7 @@ async def test_variant_dotted_fields_submit(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create(
+        await client.create(
             "DottedFields:Person",
             {
                 "person": client.party,

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -21,13 +21,13 @@ async def test_parties_can_be_added_after_run_forever(sandbox):
 
         @operator_client.ledger_ready()
         async def operator_ready(event):
-            await operator_client.submit_create("Main:PostmanRole", {"postman": event.party})
+            await operator_client.create("Main:PostmanRole", {"postman": event.party})
 
         @operator_client.ledger_created("Main:PostmanRole")
         async def operator_role_created(event):
             await gather(
                 *[
-                    operator_client.submit_exercise(
+                    operator_client.exercise(
                         event.cid, "InviteParticipant", {"party": party, "address": "whatevs"}
                     )
                     for party in (party_a_client.party, party_b_client.party, party_c_party)
@@ -43,6 +43,6 @@ async def test_parties_can_be_added_after_run_forever(sandbox):
                 network.shutdown()
 
             cid, cdata = await party_c.find_one("Main:InviteAuthorRole")
-            party_c.submit_exercise(cid, "AcceptInviteAuthorRole")
+            party_c.exercise(cid, "AcceptInviteAuthorRole")
 
         network.start()

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -16,7 +16,7 @@ async def test_map_support(sandbox):
         network.start()
 
         await client.ready()
-        await client.submit_create(
+        await client.create(
             "MapSupport:Sample",
             {"party": client.party, "mappings": {"65": "A", "97": "a"}, "text": None},
         )
@@ -33,7 +33,7 @@ async def test_complicated_map_support(sandbox):
         client = network.aio_new_party()
 
         await client.ready()
-        await client.submit_create(
+        await client.create(
             "MapSupport:ComplicatedSample",
             {
                 "party": "Test",

--- a/python/tests/unit/test_select.py
+++ b/python/tests/unit/test_select.py
@@ -19,7 +19,7 @@ async def test_select_star_retrieves_contracts(sandbox):
 
         network.start()
 
-        await client.submit_create(OperatorRole, {"operator": client.party})
+        await client.create(OperatorRole, {"operator": client.party})
 
         data = client.find_active("*")
 
@@ -45,7 +45,7 @@ async def test_select_template_retrieves_contracts(sandbox):
 
         network.start()
 
-        await client.submit_create(OperatorRole, {"operator": client.party})
+        await client.create(OperatorRole, {"operator": client.party})
 
         data = client.find_active(OperatorRole)
 
@@ -59,7 +59,7 @@ async def test_select_unknown_template_retrieves_empty_set(sandbox):
 
         network.start()
 
-        await client.submit_create(OperatorRole, {"operator": client.party})
+        await client.create(OperatorRole, {"operator": client.party})
 
         with pytest.warns(UnknownTemplateWarning):
             data = client.find_active("NonExistentModule:NonExistentTemplate")
@@ -82,11 +82,9 @@ async def test_select_operates_on_acs_before_event_handlers(sandbox):
 
     async with async_network(url=sandbox, dars=Simple) as network:
         client = network.aio_new_party()
-        client.add_ledger_ready(
-            lambda e: client.submit_create(OperatorRole, {"operator": client.party})
-        )
+        client.add_ledger_ready(lambda e: client.create(OperatorRole, {"operator": client.party}))
         client.add_ledger_created(
-            OperatorRole, lambda e: client.submit_exercise(e.cid, "PublishMany", dict(count=3))
+            OperatorRole, lambda e: client.exercise(e.cid, "PublishMany", dict(count=3))
         )
         client.add_ledger_created(OperatorNotification, on_notification_contract)
 
@@ -110,15 +108,11 @@ async def test_select_reflects_archive_events(sandbox):
 
     async with async_network(url=sandbox, dars=Simple) as network:
         client = network.aio_new_party()
-        client.add_ledger_ready(
-            lambda e: client.submit_create(OperatorRole, {"operator": client.party})
-        )
+        client.add_ledger_ready(lambda e: client.create(OperatorRole, {"operator": client.party}))
         client.add_ledger_created(
-            OperatorRole, lambda e: client.submit_exercise(e.cid, "PublishMany", dict(count=3))
+            OperatorRole, lambda e: client.exercise(e.cid, "PublishMany", dict(count=3))
         )
-        client.add_ledger_created(
-            OperatorNotification, lambda e: client.submit_exercise(e.cid, "Archive")
-        )
+        client.add_ledger_created(OperatorNotification, lambda e: client.exercise(e.cid, "Archive"))
         client.add_ledger_created(OperatorNotification, on_notification_contract)
 
         network.start()

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -39,7 +39,7 @@ async def test_server_endpoint(sandbox):
 
         @bob_bot.ledger_created("TestServer:Person")
         async def bob_sends_a_message(_):
-            await bob_client.submit_exercise_by_key(
+            await bob_client.exercise_by_key(
                 "TestServer:Person",
                 bob,
                 "SayHello",
@@ -48,7 +48,7 @@ async def test_server_endpoint(sandbox):
 
         @carol_client.ledger_created("TestServer:Person")
         async def carol_sends_a_message(_):
-            await carol_client.submit_exercise_by_key(
+            await carol_client.exercise_by_key(
                 "TestServer:Person",
                 carol,
                 "SayHello",
@@ -61,7 +61,7 @@ async def test_server_endpoint(sandbox):
 
 def ensure_person_contract(network: Network, party: Party):
     client = network.aio_party(party)
-    client.add_ledger_ready(lambda _: client.submit_create("TestServer:Person", dict(party=party)))
+    client.add_ledger_ready(lambda _: client.create("TestServer:Person", dict(party=party)))
 
 
 async def client_main(

--- a/python/tests/unit/test_simple_client_api.py
+++ b/python/tests/unit/test_simple_client_api.py
@@ -16,7 +16,7 @@ def test_simple_client_api(sandbox):
     with simple_client(url=sandbox, party=party) as client:
         client.ready()
         logging.info("Submitting...")
-        client.submit_create("Main:PostmanRole", {"postman": party})
+        client.create("Main:PostmanRole", {"postman": party})
         logging.info("getting contracts")
         contracts = client.find_active("*")
         logging.info("got the contracts")

--- a/python/tests/unit/test_static_dump.py
+++ b/python/tests/unit/test_static_dump.py
@@ -28,6 +28,6 @@ async def test_static_dump_and_tail(sandbox):
         await client.ready()
 
         for i in range(0, 5):
-            await client.submit_create("Main:PostmanRole", {"postman": client.party})
+            await client.create("Main:PostmanRole", {"postman": client.party})
 
     assert len(seen_contracts) == 5

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -15,11 +15,11 @@ def test_threadsafe_methods(sandbox):
 
     with simple_client(url=sandbox, party=party) as client:
         client.ready()
-        client.submit_create(OperatorRole, {"operator": party})
+        client.create(OperatorRole, {"operator": party})
 
         operator_cid, _ = client.find_one(OperatorRole)
 
-        client.submit_exercise(operator_cid, "PublishMany", dict(count=5))
+        client.exercise(operator_cid, "PublishMany", dict(count=5))
 
         notifications = client.find_nonempty(OperatorNotification, {"operator": party}, min_count=5)
         contracts_to_delete = []
@@ -29,6 +29,6 @@ def test_threadsafe_methods(sandbox):
 
         client.submit([exercise(cid, "Archive") for cid in contracts_to_delete])
 
-        client.submit_exercise(operator_cid, "PublishMany", dict(count=3))
+        client.exercise(operator_cid, "PublishMany", dict(count=3))
 
         print(client.find_active("*"))

--- a/python/tests/unit/test_write_cancel.py
+++ b/python/tests/unit/test_write_cancel.py
@@ -4,6 +4,8 @@
 """
 Tests to ensure that cancelled command submissions behave correctly.
 """
+from asyncio import ensure_future
+
 import pytest
 
 from dazl import async_network

--- a/python/tests/unit/test_write_cancel.py.orig
+++ b/python/tests/unit/test_write_cancel.py.orig
@@ -22,11 +22,16 @@ async def test_cancelled_write(sandbox):
         # Submit a command, but _immediately_ cancel it. Because there are no awaits, this code
         # cannot have possibly been interrupted by the coroutine responsible for scheduling a write
         # to the server, so the command should be cancelled.
+<<<<<<< HEAD
+        fut = client.submit_create("Pending:Counter", {"owner": client.party, "value": 66})
+        fut.cancel()
+=======
         fut = client.create("Pending:Counter", {"owner": client.party, "value": 66})
         ensure_future(fut).cancel()
+>>>>>>> 4cdf603 (more)
 
         # Immediately afterwards, schedule another command submission; this time, we wait for it.
-        fut = client.create("Pending:Counter", {"owner": client.party, "value": 7})
+        fut = client.submit_create("Pending:Counter", {"owner": client.party, "value": 7})
         await fut
 
         data = client.find_active("Pending:Counter")


### PR DESCRIPTION
python: Some documentation updates, but the main course is actually adding support for returning results from exercise commands!

In writing documentation around changes on the write-side, I realized that it would be possible to expose `ExerciseResponse` results for the old API as well as the new one—it also helps make the two APIs more consistent with each other, along with better illustrating why some of these names have been changed.