### PR TITLE
python: Add sphinxcontrib-trio to the docs.

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
-    "sphinx.ext.viewcode",
+    "sphinxcontrib_trio",
     "sphinx.ext.githubpages",
 ]
 
@@ -199,4 +199,4 @@ def setup(sphinx):
         DAMLLexer = None
 
     if DAMLLexer is not None:
-        sphinx.add_lexer("daml", DAMLLexer())
+        sphinx.add_lexer("daml", DAMLLexer)

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -60,13 +60,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3.0"
+version = "21.1.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 category = "dev"
@@ -74,7 +74,7 @@ description = "Internationalization utilities"
 name = "babel"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9.0"
+version = "2.9.1"
 
 [package.dependencies]
 pytz = ">=2015.7"
@@ -111,7 +111,7 @@ description = "Extensible memoizing collections and decorators"
 name = "cachetools"
 optional = true
 python-versions = "~=3.5"
-version = "4.2.1"
+version = "4.2.2"
 
 [[package]]
 category = "main"
@@ -188,7 +188,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
-version = "1.29.0"
+version = "1.30.0"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -224,13 +224,13 @@ description = "HTTP/2-based RPC framework"
 name = "grpcio"
 optional = false
 python-versions = "*"
-version = "1.37.0"
+version = "1.37.1"
 
 [package.dependencies]
 six = ">=1.5.2"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.37.0)"]
+protobuf = ["grpcio-tools (>=1.37.1)"]
 
 [[package]]
 category = "dev"
@@ -238,10 +238,10 @@ description = "Protobuf code generator for gRPC"
 name = "grpcio-tools"
 optional = false
 python-versions = "*"
-version = "1.37.0"
+version = "1.37.1"
 
 [package.dependencies]
-grpcio = ">=1.37.0"
+grpcio = ">=1.37.1"
 protobuf = ">=3.5.0.post1,<4.0dev"
 setuptools = "*"
 
@@ -498,7 +498,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.8.1"
+version = "2.9.0"
 
 [[package]]
 category = "dev"
@@ -627,7 +627,7 @@ description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
+version = "1.16.0"
 
 [[package]]
 category = "dev"
@@ -757,6 +757,17 @@ test = ["pytest"]
 
 [[package]]
 category = "dev"
+description = "Make Sphinx better at documenting Python functions and methods"
+name = "sphinxcontrib-trio"
+optional = false
+python-versions = "*"
+version = "1.1.2"
+
+[package.dependencies]
+sphinx = ">=1.7"
+
+[[package]]
+category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
@@ -785,7 +796,7 @@ description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4.3"
+version = "3.10.0.0"
 
 [[package]]
 category = "dev"
@@ -825,7 +836,7 @@ description = "Filesystem events monitoring"
 name = "watchdog"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.3"
+version = "2.1.0"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)", "argh (>=0.24.1)"]
@@ -894,7 +905,7 @@ pygments = ["pygments"]
 server = ["aiohttp"]
 
 [metadata]
-content-hash = "5a73fd44ed037444a47bc8e1eb3aaccd550e3dfb2ec0b62718d34e8a1f826409"
+content-hash = "92d55f633de9286b42fddeb8c54c8bc4a9eeea3712d16acbba36c54a87af865a"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -954,19 +965,19 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    {file = "attrs-21.1.0-py2.py3-none-any.whl", hash = "sha256:8ee1e5f5a1afc5b19bdfae4fdf0c35ed324074bdce3500c939842c8f818645d9"},
+    {file = "attrs-21.1.0.tar.gz", hash = "sha256:3901be1cb7c2a780f14668691474d9252c070a756be0a9ead98cfeabfa11aeb8"},
 ]
 babel = [
-    {file = "Babel-2.9.0-py2.py3-none-any.whl", hash = "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5"},
-    {file = "Babel-2.9.0.tar.gz", hash = "sha256:da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"},
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 cachetools = [
-    {file = "cachetools-4.2.1-py3-none-any.whl", hash = "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2"},
-    {file = "cachetools-4.2.1.tar.gz", hash = "sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9"},
+    {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
+    {file = "cachetools-4.2.2.tar.gz", hash = "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -997,116 +1008,118 @@ flask = [
     {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
 ]
 google-auth = [
-    {file = "google-auth-1.29.0.tar.gz", hash = "sha256:010f011c4e27d3d5eb01106fba6aac39d164842dfcd8709955c4638f5b11ccf8"},
-    {file = "google_auth-1.29.0-py2.py3-none-any.whl", hash = "sha256:f30a672a64d91cc2e3137765d088c5deec26416246f7a9e956eaf69a8d7ed49c"},
+    {file = "google-auth-1.30.0.tar.gz", hash = "sha256:9ad25fba07f46a628ad4d0ca09f38dcb262830df2ac95b217f9b0129c9e42206"},
+    {file = "google_auth-1.30.0-py2.py3-none-any.whl", hash = "sha256:588bdb03a41ecb4978472b847881e5518b5d9ec6153d3d679aa127a55e13b39f"},
 ]
 grpc-stubs = [
     {file = "grpc-stubs-1.24.6.tar.gz", hash = "sha256:98f307afcb180676ce3181262d01a7f1b0773b4c4c92724a761030ba2c44ff6b"},
     {file = "grpc_stubs-1.24.6-py3-none-any.whl", hash = "sha256:d22e3a9febde16252bfa30c807a0f7b7090bef2b83b87cf9e0e8a97b4b489a19"},
 ]
 grpcio = [
-    {file = "grpcio-1.37.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:8a0517e7a6784439a3730e50597bd64debf776692adea3c18f869a36454952e1"},
-    {file = "grpcio-1.37.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:96ca74522bcd979856d359fcca3128f760c69885d264dc22044fd1a468e0eb68"},
-    {file = "grpcio-1.37.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:3da2b0b8afe3ef34c9e2f90329b1f170fc50db5c4d0bbe986946caa659e5ed17"},
-    {file = "grpcio-1.37.0-cp27-cp27m-win32.whl", hash = "sha256:0634cd805c6725ab71bebaf3370da0e5d32339c26eb1b6ad0f73d64224e19ddf"},
-    {file = "grpcio-1.37.0-cp27-cp27m-win_amd64.whl", hash = "sha256:fe14c86c58190463f6e714637bba366874ca1e518ff1f82723d90765e6e39288"},
-    {file = "grpcio-1.37.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:14d7a15030a3f72cfd16dde8018d9f0e29e3f52cb566506dc942220b69b65de8"},
-    {file = "grpcio-1.37.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:9d389f4e008edbd91082baff37507bbf4b25afd6c239c8070071f8936466a374"},
-    {file = "grpcio-1.37.0-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:a8b0914e6ac8987b8f59fcfb79519c5ce8df279b19d1c88bda2fc6e147821217"},
-    {file = "grpcio-1.37.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:aaf44d496fe53ca1414677cab73b7935d01006f0b8ab4a32ab18704643a80ab5"},
-    {file = "grpcio-1.37.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:fb6588a47d096cdaa0815d108b714d3e273361bfe03bc47725ddb1fdeaa56061"},
-    {file = "grpcio-1.37.0-cp35-cp35m-manylinux2014_i686.whl", hash = "sha256:9b872b6c8ab618caa9bdee871c51021c7cc4890c141e7ee7bb6b923174bb299a"},
-    {file = "grpcio-1.37.0-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:810d488804291f22cb696692cfddf75b12bbc9d34beca0159d99103286ac0091"},
-    {file = "grpcio-1.37.0-cp35-cp35m-win32.whl", hash = "sha256:55fbdb9a2f81b28bd15af5c6e6669a2c8bb0bdb2add74c8818f9593a7428a164"},
-    {file = "grpcio-1.37.0-cp35-cp35m-win_amd64.whl", hash = "sha256:fa6cfecbafbab8c4a229c42787b02cf58d0f128ad43c27b89c4df603b66d7f3c"},
-    {file = "grpcio-1.37.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:b36eeb8a29f214f876ddda563990267a8b35d0a6da587edfa97effa4cdf6e5bd"},
-    {file = "grpcio-1.37.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:a89b5d2f64d588b46a8b77c04ada4c68ee1cfd0b7a148ff9108d72eefdc9b363"},
-    {file = "grpcio-1.37.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e0169f550dc9ba88da0bb60b8198437d9bd0e8600d600e3569cd3ba7d2ce0bc7"},
-    {file = "grpcio-1.37.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:4408b2732fdf93f735ecb059193219528981d27483feaa822970226d5c66c143"},
-    {file = "grpcio-1.37.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:5784d1e4877345efb6655f6851809441478769558565d8291a54e1bd3f19548b"},
-    {file = "grpcio-1.37.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:96e3d85eb63d144656611eef4683f5b4003e1deec93bc2d6cbc5cf330f275a7e"},
-    {file = "grpcio-1.37.0-cp36-cp36m-win32.whl", hash = "sha256:e1a5322d63346afdda8ad7ff8cf9933a0ab029546395eae31af7cd27ef75e47b"},
-    {file = "grpcio-1.37.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5e11b7176e7c14675868b7c46b7aa2da0b184cf7c189348f3ad7c98829de07be"},
-    {file = "grpcio-1.37.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:6c2798eaef4eebcf3f9d62b49652bc1110787c684861605d20fec842580f6cee"},
-    {file = "grpcio-1.37.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:3e541240650f9173b4891f3e252234976199e487b9bd771e4f082403db50130d"},
-    {file = "grpcio-1.37.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b4f3ddfed733264c4f6431302e5fbafdd9c03f166b98b04d16a058fae3101a5d"},
-    {file = "grpcio-1.37.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:f16e40ea37600fe21b51651617867c46d26dcb3f25a5912b7e61c7199b3f5a9f"},
-    {file = "grpcio-1.37.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b897b825fb464c940001a2cc1d631f418f5b071ccff64647148dbf99c775b98b"},
-    {file = "grpcio-1.37.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:5e598af1d64ece6a91797b2dcacaf2d537ffb1c0075ecd184c62976068ce1f09"},
-    {file = "grpcio-1.37.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:1a167d39b1db6e1b29653d69938ff79936602e95863db897ff9eeab81366b304"},
-    {file = "grpcio-1.37.0-cp37-cp37m-win32.whl", hash = "sha256:c4f71341c20327bda9f8c28c35d1475af335bb27e591e7f6409d493b49e06223"},
-    {file = "grpcio-1.37.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e86acc1462bc796df672568492d24c6b4e7692e3f58b873d56b215dc65553ae1"},
-    {file = "grpcio-1.37.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:28f94700775ceca8820fa2c141501ec713e821de7362b966f8d7bf4d8e1eb93a"},
-    {file = "grpcio-1.37.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:ca5c96c61289c001b9bcd607dcc1df3060eb8cc13088baf8a6e13268e4879a1f"},
-    {file = "grpcio-1.37.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:06cae65dc4557a445748092a61f2adb425ee472088a7e39826369f1f0ae9ffea"},
-    {file = "grpcio-1.37.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6986d58240addd69e001e2e0e97c4b198370dd575162ab4bb1e3ea3816103e75"},
-    {file = "grpcio-1.37.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:606f0bbfac3860cb6f23f8ebabb974c14db8797317a86d6df063b132f64318f9"},
-    {file = "grpcio-1.37.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:1c611a4d137a40f8a6803933dd77ab43f04cc54c27fb0e07483fd37b70e7dae6"},
-    {file = "grpcio-1.37.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3acfb47d930daec7127a7bc27a7e9c1c276d5e4ae3d2b04a4c7a33432712c811"},
-    {file = "grpcio-1.37.0-cp38-cp38-win32.whl", hash = "sha256:575b49cbdd7286df9f77451709060a4a311a9c8767e89cf4e28d3b3200893de4"},
-    {file = "grpcio-1.37.0-cp38-cp38-win_amd64.whl", hash = "sha256:04582b260ff0c953011819b1964e875139a7a43adb84621d3ab57f66d0f3d04e"},
-    {file = "grpcio-1.37.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:00f0acc463d9e6b1e74e71ce516c8cabd053619d08dd81765eb573492811de54"},
-    {file = "grpcio-1.37.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:4eb3907fda03eda8bdb7d666f5371b6500a9054f355a547961da1ee231d2d6aa"},
-    {file = "grpcio-1.37.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:3eecf543aa66f7d8304f82854132df6116476279a8e3ba0665c5d93f1ef622de"},
-    {file = "grpcio-1.37.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:91f91388e6f72a5d15161124458ad62387470f3a0a16b488db169232f79dd4d2"},
-    {file = "grpcio-1.37.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:efb928f1a3fd5889b9045c323077d2696937cf9cdb7d2e60b90caa7da5bd1ce9"},
-    {file = "grpcio-1.37.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:93d990885d392f564ef95a97e0d6936cb09ee404418e8c986835a4d1786b882d"},
-    {file = "grpcio-1.37.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ebbb2796ec138cb56373f328f5046ccb9e591046cd8aaccbb8af5bfc397d8b53"},
-    {file = "grpcio-1.37.0-cp39-cp39-win32.whl", hash = "sha256:adfef1a3994220bd39e5e2dd57714ca94c4c38c9015f2812a0b09b39f86ddbe0"},
-    {file = "grpcio-1.37.0-cp39-cp39-win_amd64.whl", hash = "sha256:df142d51d7de3f8d13aaa78f7ddc7d74088226f92ec5aae8d98d8ae5d328f74b"},
-    {file = "grpcio-1.37.0.tar.gz", hash = "sha256:b3ce16aa91569760fdabd77ca901b2288152eb16941d28edd9a3a75a0c4a8a85"},
+    {file = "grpcio-1.37.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:0d64b5995e17eb9f086e82e6a4edadd1295827b593be71b516e7a442067784b5"},
+    {file = "grpcio-1.37.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:6f44b8244bafcbea63daff222ae1b27d048b9d8fd47eb3d11e61ee092078e766"},
+    {file = "grpcio-1.37.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:37e265b72e69ef8e33efca8d1123bdc349ae3eabb92563e76adfce209c9df51a"},
+    {file = "grpcio-1.37.1-cp27-cp27m-win32.whl", hash = "sha256:ee0537fe2423307b885ba44e6789249e6d7624247cb38a20b9f38f4b40f5ab03"},
+    {file = "grpcio-1.37.1-cp27-cp27m-win_amd64.whl", hash = "sha256:1de472a3c2a3d89d4d400d8179f2777ec99f7da0e87c0c1f196226141816d621"},
+    {file = "grpcio-1.37.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:99a627471275f93d400399b55e4c1d798602ff79d693e7def0a0b276912bff7e"},
+    {file = "grpcio-1.37.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:e7da0319003d150611b30cd864e0474a283324b3db9107107aa3ef9a71c53130"},
+    {file = "grpcio-1.37.1-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:22b0cc3531d3c405fae9a8519004a0e62ecbd1f005b55b3622098a4881d36b96"},
+    {file = "grpcio-1.37.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:f6a73167fce4a41e5c0b34ceaad1048a14e9eeb4fc324da49da0537c199efab7"},
+    {file = "grpcio-1.37.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:fa279b99878bae9b804c09e023f2b47de79d0b5e813ab85ddf28673784d610f0"},
+    {file = "grpcio-1.37.1-cp35-cp35m-manylinux2014_i686.whl", hash = "sha256:9674fffd1f599aec7389a61d48c1a8c8aaba69591609895911c6d8386d86dd45"},
+    {file = "grpcio-1.37.1-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:80c3c9d24ecd236571d3c86657243431a8bafef022dcce83f9f2aeb6eecb96b9"},
+    {file = "grpcio-1.37.1-cp35-cp35m-win32.whl", hash = "sha256:e236d0580f7e69a35c420ce60f960b294e9dc973b8c31499fa476eb4d4ba4088"},
+    {file = "grpcio-1.37.1-cp35-cp35m-win_amd64.whl", hash = "sha256:30ba9712547c9497a438bfeb2c7f393fa983df1609e1c81243d4b0d1b1bfefbf"},
+    {file = "grpcio-1.37.1-cp36-cp36m-linux_armv7l.whl", hash = "sha256:ad03ff6b15f3481f3c999d5d22b5c56295dffc49b8e2cbdbc04c7bf358d3034e"},
+    {file = "grpcio-1.37.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:728292f5ccb849f30774c0805ef5c39452b3a5f4d193ac499ae5b78d268ff64b"},
+    {file = "grpcio-1.37.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:5dabaac759a98bcfd979d22874dcd7ccf8779678a2fe841d355dd93fee143974"},
+    {file = "grpcio-1.37.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f933dd10948a5e5ed4258a1581e45aec1bb84069e62368084eb2dcf4cce51e78"},
+    {file = "grpcio-1.37.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:67b482c810d05d9317e29b82900864ab888b9f842701906ba54c3eb176cd8eab"},
+    {file = "grpcio-1.37.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:494cce1709f7cd63c2610c25b41f886048f1d993511ddb23f766b77ac142ba78"},
+    {file = "grpcio-1.37.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:264f6d9a922f5124f79f50b1880349fd16c657a9b4fdf0f29fca939d40584f7f"},
+    {file = "grpcio-1.37.1-cp36-cp36m-win32.whl", hash = "sha256:e3e0fb7d32f163699cef5132b060e3f613dc914408164eb3e3ac69095861ea04"},
+    {file = "grpcio-1.37.1-cp36-cp36m-win_amd64.whl", hash = "sha256:640f49187105fb6c2b1b7acea06df3b0ccf5fe33a075c73b8a741013bc5cc802"},
+    {file = "grpcio-1.37.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:f1287ae8a3bef97fd702dac95967aaf52031a6dceb2bd30da165f16e3b617293"},
+    {file = "grpcio-1.37.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:30807f3979ebb3872588fa166876a2a24febe17e0db5950d5bedd67320d11b8c"},
+    {file = "grpcio-1.37.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:23666be3ed366f647f09c9caf89c48ca0daa12be8fe4786e5a368a6cd69de1f6"},
+    {file = "grpcio-1.37.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:8f5a16f8b650efddd5ff3f750cca5b45c045923be13e79cdd1b886332307f46a"},
+    {file = "grpcio-1.37.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e72d8df53624098d8b1fe01c961888d61f90d7c0aa8116d76db80a535da9b445"},
+    {file = "grpcio-1.37.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:4850c96d3a22d941b0d6af4dccbc739caec7f367b783aad049c843b28b458ff0"},
+    {file = "grpcio-1.37.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:4493365334baaa3d775f5e4a91d9a844ac676560232223405a0964dfddb31924"},
+    {file = "grpcio-1.37.1-cp37-cp37m-win32.whl", hash = "sha256:34d6f626062e7ef47ab30ff8976825c58fa8846ccd8c645b57291ccc74b9d413"},
+    {file = "grpcio-1.37.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4c0503b5ef6fcabc52c296d750a095ef29fd707d0f85322e95e5c261b3a684f9"},
+    {file = "grpcio-1.37.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:ac4174b1cf4daea0653fcfee7676bb04a8a43644e9ddf1913834d1542a9c697b"},
+    {file = "grpcio-1.37.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d232802ba15b465000263bc17171f9863173b7669bdd72dbdffdfcc0f6e637dc"},
+    {file = "grpcio-1.37.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c87599137f6022ed5079b0df47da83134b9810d4b00999b87edfc901347f26a9"},
+    {file = "grpcio-1.37.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:609297d3d5d32f47e04bf7dc61c7756df50bc37dec4dfd63e996388eba42fb3b"},
+    {file = "grpcio-1.37.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:025fa7dffb0cf724070cfcbe2ff600a18b0cf84642ede5c92f2717162e2a8c95"},
+    {file = "grpcio-1.37.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0b8817acef140cb9a3543208c13282d3bf4bb0103e930ddbb779677604085ada"},
+    {file = "grpcio-1.37.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a1cd40eac72d3c914eea73f8f7730ddbd86061098a8ce712d1ce108e9d87d449"},
+    {file = "grpcio-1.37.1-cp38-cp38-win32.whl", hash = "sha256:d7ae05ded17c4697ef80784dc89cad3025db0d90c5a8a0ada47a8d0749617d58"},
+    {file = "grpcio-1.37.1-cp38-cp38-win_amd64.whl", hash = "sha256:b948a00764fee55cf111e0bf3d987167557152abf879f2c13bd2f278a6247ded"},
+    {file = "grpcio-1.37.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:8d3cdca5cfd6761a8824bc8acc8ac7bc37ad5ef75899308ca0458cf7952ce12d"},
+    {file = "grpcio-1.37.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:9364f35949c3cff5470b583a03ccfd927b71cbe1ab7583a6529d5d67ed76e91e"},
+    {file = "grpcio-1.37.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:1aab01ee3e4b88ed6419f0b25ff21c83deb6c823c6fb77e655def0796526e3a3"},
+    {file = "grpcio-1.37.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:74aad86c7c1b9163d01c3d9e75861e9b09c65e0947592ca315c30353a0f6c4d1"},
+    {file = "grpcio-1.37.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3ee1bef5f5e4208998cdef44933db3c30c52a7ebde424cfc4186404ffded1d35"},
+    {file = "grpcio-1.37.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:7533d2c9698dd3038fcf3dd0df243b76a9e0db8008f8575c305e20a3593189eb"},
+    {file = "grpcio-1.37.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b7cc965538da06c9e9cf0e01bae91f274c75baf224ca6a734717c0f003ddf1f2"},
+    {file = "grpcio-1.37.1-cp39-cp39-win32.whl", hash = "sha256:6ad11c1ea337720a42fc31959bd44a38b8837e3ae25bdab681e2e1a28096b02a"},
+    {file = "grpcio-1.37.1-cp39-cp39-win_amd64.whl", hash = "sha256:7b2a2cf3621f94b123a9d7a68e4a8d948b29520136f096927f7c9653f24c8fca"},
+    {file = "grpcio-1.37.1.tar.gz", hash = "sha256:df8305806311d3fe913d4f7eb3ef28e2072159ea12f95baab5d447f1380a71e3"},
 ]
 grpcio-tools = [
-    {file = "grpcio-tools-1.37.0.tar.gz", hash = "sha256:3ec510c1b6bfc32effc639acf9a055e72dab7a7b6757bf72f2132790d6a7cf1c"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:4018d6c6ebe68020172753675463a958f3bc579ed4ee24dfe8f12076beea7011"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:3409fde6793cb9273e3515733d19b94baed70adeb65c7dc78cf992490fc947c5"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:c2ae27b64e7a113b57b7effc79afcb8dc1bde175d0fd69bfa496447aae18c125"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27m-win32.whl", hash = "sha256:df290c1dcf504c74b25a320202aa8d7b9e3c18f2db19b18613a2e8513970b17f"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27m-win_amd64.whl", hash = "sha256:2fc318becc701d4f1a6ba200cdf44c1485a1eb8eef506064585092b0d43eef82"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:d5087058710468e2054049b24e31a88bfba4c244a0f1f4cc32b5439bb265d9e7"},
-    {file = "grpcio_tools-1.37.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:e7c87cb0a90d1f2cfd9cb0afa936663d639da97d67ad72102f30827709202d94"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:557dcb595f359795955c13c77d4ce6761b9502a8cd6dd9814d05a1fd882994aa"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:501af4e929bbb6ab0c98b02a504963d80eff653b031e97d64e9d42a0e4b7e79f"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:99def9a3a5c78f502a6416f72ced3e6b511276614cec9bdbfa580bdada84ccaf"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-manylinux2014_i686.whl", hash = "sha256:3f9c05dac8a3466f73b794c99c7e1a7dc1238c2d907f3c344682018f0a018dac"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:c53457000e033281955894ed3de0a2efdec3a8d68b7f4ee3b03e66c18a270a2a"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-win32.whl", hash = "sha256:888b74dedebf8a00e8ab178acf0c7c844afa3fc69966fea9cb6239ccdf6bf319"},
-    {file = "grpcio_tools-1.37.0-cp35-cp35m-win_amd64.whl", hash = "sha256:450c15eea7159951b0cdbc9d6703e1f7fa7cc7a3d851d7ec43a2c6e2023e7655"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:92fd9db40762c45f15ebcd2e264a1c0b2e281c12fd0a70977629c9efc8d1d8b3"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:731b21a74b456539c505386f5d60369a1ddf72a65dc9bf7747f18a52ad39089a"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:206fa2aa48d8887941e7407a5a90e4a76d45e8aee99d23af27ae7dfd3b410d64"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:b684ddabdc81bb73583dadebce7a5807a1e7b3f55d52e615618f8d502fe5cadd"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:265e19db587be9f2f8d2b99fd69a14e65d2cd419f23cd0ac381c9615ae2ee958"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:8a1573c8788aa43a886ece51bbc2e3a1bad575df101b06e173f82359a864cd10"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-win32.whl", hash = "sha256:806411475a6d66384901b78bf2c9f9957890a3499c8ebee7127bc9938091775d"},
-    {file = "grpcio_tools-1.37.0-cp36-cp36m-win_amd64.whl", hash = "sha256:ccdb1b5076f0a07b8876d7811003e3ddbb16b91eb547bcb4285cccaa24c0539c"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:c6f1fa84ef5a040f5e4940f66cfff3f071b89ac40b1c7998924668993eba98d5"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:dd33af18e69e05ba3f80877db94d49baf4cf3695e4a22ca44739ea4036090fcc"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b9d4350874eb98ea56067b670b72d0f8ebe85513cfc4b4821125e1a8daf64e9c"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:44a3808fbce1ce5184ee3443ecdbfad8aa1c0ddec1dd61bf4211fbcd4eb76416"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f477ca35024fc8cd6da68e3f9a4a7fcb3b65b307ccd9c822735ffdf1131c250d"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:545f0b4ec1f4c19e241de19e68d428f866334ae642cedeb77e07d5146e464816"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:d5e174c6c2a32ec925f4cd94330339a5aceea1963f22bbcde9a02fde4b6b6b0f"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-win32.whl", hash = "sha256:de1f83271686296ec1f96ac2ba9b0a9f302e867cf42dab300ea372190c80b3d6"},
-    {file = "grpcio_tools-1.37.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5e1098bf352eb72e69a132abd5ab1bd569e27a51e7daa858b7fbe4e85e07c941"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:52e24726e9d64350d60e47d0d07a02d0daa5edc0b46a360ca88a5e44dfa7a037"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:ff3be2289c6d2b52667d26ad749ca36a2953f124536b231c99fc4f2ab9e51ef6"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:350327f66b259632556d8d68f4c00d5d3628473ee58442920782594c821bf548"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f86f05a47a65b84635a6402a4114b29a7dfc9bbd92049d301fed052100832a33"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0f06956775853d214af4878c82b571ad5ae4baf866234299cc544d2f6d863b29"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:055b2044f8724e5ae02c927fe58880ef39fc5bdf546b9126d90cae5fb4661879"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ae34e6219194afbae65033cc416182b3473f9d0595733757861e8f5832091713"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-win32.whl", hash = "sha256:a32de26574d91d88bd6fdbf94766e67883364c5f38f205c734ffa24608be17bd"},
-    {file = "grpcio_tools-1.37.0-cp38-cp38-win_amd64.whl", hash = "sha256:480a2e98e386e737c54056baffeab09c7d400a050df9fda585c30b0e1b3595cc"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:b48e64b706ef3abe8feb4acc6aeaa12588fdc1a2d65477ebbaa7a443089b5f08"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:374d7444d71bdebb3a879ff4bc52e0470ad5b77be9a8c6c5896793aef245e179"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:be352ff2360bcc691c036bfa2c13e99e560e3d619dc93b113c735906d9a88c4b"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:07d400f5d22131d4d8e77cc80a923e669cc6ff08cfe8848eefcc1b26078c9847"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d1a91ccad1edb71bf9b5dfc2f48253041510e44190a0cd324b5728cebc4203cf"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:92d373659a1dd405a1b945a7594dcc3e173fb983ea6dd489a3f008ce7759c5b9"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:83e9f3da8f8b3580f074e3ffa900d7317b6dbdbea641af2d1d49c63b37521117"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-win32.whl", hash = "sha256:841ebb76cb0588cfe1b3c71205b011aadaa179e09593c890715a0d670b570ab7"},
-    {file = "grpcio_tools-1.37.0-cp39-cp39-win_amd64.whl", hash = "sha256:bde7358fc84fcb1b227d6cd53cfd40179851df9a3bbf650d492a180baa1e4986"},
+    {file = "grpcio-tools-1.37.1.tar.gz", hash = "sha256:d775fb07cc6561174d6c86d11727a156c4ade969f7bf5edf623ffe2a428bee4e"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:a1e8eaa1e381689b71000578856391723f17445861e74df9efad9aa75e94b1ee"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:09c6afaa35b268063fbc5e1c5a698c5d52e82fc9e58484217c9f231ae97fcc23"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:2056acc3e8b715e8e7fac343d44ed0e05f294cdf3775d488c7c42159ed6acb4b"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27m-win32.whl", hash = "sha256:ebb2f445cb236f61ea98536da5344fc60c77e6543a048ebef412c25622f36436"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27m-win_amd64.whl", hash = "sha256:cba726ebd6198ed5fab03a54ab86212ce45299e00a3c56f65db74081d240cb1c"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:930181a99d8cf7a05d1b46a658d0f54d6d3359ce1ee100bc1689ab8ada13fe9e"},
+    {file = "grpcio_tools-1.37.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:974677ac643cbd37ecfcd67ac1e33a7182e24bc5b67372a05ec887b230366d5f"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:090e73ab4cf648a82c82069c7f8d95d0d2973fbf7101b263c78dd68b3176fcc9"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:ccac333076ad354cdb3bb108d67d0a75d5a93b13eaf81323daff0aa050a40bb3"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:cab777c7cd107d4a03ec528b660c6443f13fd26bfa14e56b13820420b8423aff"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-manylinux2014_i686.whl", hash = "sha256:939402ec6011c527bfa37c63189c0f1f69e585c95b6ca01de1222d81d70838a0"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:36a8559fc0475bae6eb2eb18637b1c8ae5d8914cb43d58c3674fe476f534445b"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-win32.whl", hash = "sha256:a5165e6ef456ac14aa631afdeb70fbd154fd3eec0e658bacd1e4c60c4fd73ddb"},
+    {file = "grpcio_tools-1.37.1-cp35-cp35m-win_amd64.whl", hash = "sha256:35b2d64ee1cb80074f98dcb6fbc688a35f2d54b01fb2f4cc4727f8e79ef03356"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-linux_armv7l.whl", hash = "sha256:f75d4493a9efea530037cb0b92fecef6d3d712b67b5279fe145399ece632487f"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:878568d44562171f78fda9a048d589955edfc49860b6239ae280395b420bfc66"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:fd77c94cac4fb925f4d0ee709fb64a54726abe9066ef0181a62b96ca56977033"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7ce4f0363038fff2e76ab0930633542c52ea8249be91c4922b4d60f2d9c7c798"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:cd603a84ee6778ddaf44ac502c507bbaff31c0c886c1e5243fed85ef8cc93e3b"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:9d1debe310b5b865c3385b2d3764fe369daf9f046d43f257452de4b5d33b78e9"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:b6d31d6ead93209981caafe4961279d064ee4befc2b667fc1de88992f32071b3"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-win32.whl", hash = "sha256:a464378a9274b99bc683f50e9a494d7c3a326e7f627589981078976d708d8f21"},
+    {file = "grpcio_tools-1.37.1-cp36-cp36m-win_amd64.whl", hash = "sha256:a2fdc548a51bfd10b2ad83c6d811c9618614523c079d09bf85213641d2ba3302"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:2a478a074e454fc4d833468597158e03d1cee12dae7106fc93465e646ee7bb8a"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:2dff4eb17b42e3e81e9c68994c84691ade057b132e830545fed8619dd043ad01"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b8bcfca91cc0f76f897735028e3ef0a1c358c3edfdc3f48b36e4f46f3c97efbd"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:b59c264a4a5c4b0d0e5674f92b887c4bee2a18189ef6e47598c97f4602d22c9b"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:69e7ab498be6511cf832bf8679394471bb76e684ada6540f57a00030f3ab4d6f"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:2d43f9537a8f2f78f0def659e95bdd2aedde8672b99f29e9692a6aadea7aaed3"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7c9db39e17a19131e28af4d19099d71525a907b51535e0a6214bb2092b24f63b"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-win32.whl", hash = "sha256:e71cd8efa06fb1acb55ce3fa256da2d8a0421b279e1a2068acd40c157d2651c5"},
+    {file = "grpcio_tools-1.37.1-cp37-cp37m-win_amd64.whl", hash = "sha256:dfe7f4d1e17dd64ec6aa732418c2f676371a817eb07b9e50e0b71c09ff71ded7"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:7a5367532edea169ea5dee0a2290e81d41ed3352e61dbd2c5b3a6ccbd97dace2"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:b3324cc1e72f88f32a2bed7a2f73f5d4fef00899036e821dea5d98c6f64325bc"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:36a40a3591a9cdb1ee44ce055ec8006743ee686a8989f31f88439c3231a7ee2d"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:442c68f9239eab84d3a64f27dfb70c56a0fdb4b6eec56bdd42cb615aad9b3f18"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:6e2e8415cd975e1d86387ce0e62e4820886cbab7115df0ed8354946535e8ab1b"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:d29777e2e82446ae95427755a87ecacd29baaf8081a61ffaf034fbf8064bec56"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0cf44026497f874c8cd0007e724b84950d0f7f70276f9f858c84fddfd06ee946"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-win32.whl", hash = "sha256:78130149ffa40fcf06097788a948c0e52d5ccf848c385306ca4c6d64d9869cf1"},
+    {file = "grpcio_tools-1.37.1-cp38-cp38-win_amd64.whl", hash = "sha256:5ac5043886f9a3f742d18e5d25aef3e951811e780a48b76a53d86955f3e50a12"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:cce6bb815241a5ab5d8e70cc137cf9d6005ce9bf73ae23d8364f64fe4b6a8043"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:78db6525af7228d1d64e4531be8036b54497100c20af4b1bdad8d0ee07a7c7cb"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:46e90c20faebff5332ff604fe202104740fd20968e183a12399a3a58135d1f3d"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:216aa4284c8cc9c491bf8311a10192f9f9b49a7e57463abe1ca7b757fd232f8b"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9ac5fd7eb16a8bc175ef9a4313cf039d64eae48acb9513ca82c3f6fb9483d0bf"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:8e5e7e2ce74e7145ba59495c1cc3357fa0c62f85e77ed7d5c09dc5be194a8a43"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:6a7cd8c81d22d9420c712fa383fb8a4c4f55326037222f0f5095382a8d4d4e1a"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-win32.whl", hash = "sha256:98fcd8d1a7b347f835c1b1d104931a4522cec2c08fc0eafb13a8e7a325a62fed"},
+    {file = "grpcio_tools-1.37.1-cp39-cp39-win_amd64.whl", hash = "sha256:63d701170d5dd64b5eaeb291c75de9320b447bfea8df3a21ebb5fa954b792aae"},
 ]
 html2text = [
     {file = "html2text-2020.1.16-py3-none-any.whl", hash = "sha256:c7c629882da0cf377d66f073329ccf34a12ed2adf0169b9285ae4e63ef54c82b"},
@@ -1326,8 +1339,8 @@ pydash = [
     {file = "pydash-5.0.0.tar.gz", hash = "sha256:845262df83b5411742e5f7f7dbfa5ed4d0ddac6d7d0a13c4375c6a3c40d4e8f4"},
 ]
 pygments = [
-    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
-    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pympler = [
     {file = "Pympler-0.9.tar.gz", hash = "sha256:f2cbe7df622117af890249f2dea884eb702108a12d729d264b7c5983a6e06e47"},
@@ -1408,8 +1421,8 @@ semver = [
     {file = "semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"},
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
@@ -1446,6 +1459,10 @@ sphinxcontrib-qthelp = [
 sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
     {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
+]
+sphinxcontrib-trio = [
+    {file = "sphinxcontrib-trio-1.1.2.tar.gz", hash = "sha256:9f1ba9c1d5965b534e85258d8b677dd94e9b1a9a2e918b85ccd42590596b47c0"},
+    {file = "sphinxcontrib_trio-1.1.2-py3-none-any.whl", hash = "sha256:1b849be08a147ef4113e35c191a51c5792613a9a54697b497cd91656d906a232"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
@@ -1488,9 +1505,9 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 unify = [
     {file = "unify-0.5.tar.gz", hash = "sha256:8ddce812b2457212b7598fe574c9e6eb3ad69710f445391338270c7f8a71723c"},
@@ -1503,23 +1520,23 @@ urllib3 = [
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 watchdog = [
-    {file = "watchdog-2.0.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9fe3ea15f9020aa7f129f700341850ee768730c67e89d8256c224c4f26c86670"},
-    {file = "watchdog-2.0.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0ba2c2526dc81a241e3b0f018a447a5ca634fa1f01fc5fa2a07c87ee04d730a7"},
-    {file = "watchdog-2.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a679d03f52a9e3ea3efb77b459e9eba05c7c687f48e4d17ce20bc0e36f867d9a"},
-    {file = "watchdog-2.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1583ee70d78226d897cbc85cfd5b88108340450e0214a704a4919443434d3c32"},
-    {file = "watchdog-2.0.3-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b8727f84a3c7dd21138d92186181d015af45168e0af895ffdc553a28019494ef"},
-    {file = "watchdog-2.0.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:51ad0342ecb4733796e94980f2430b2333e12ead973d3e18f5514cd77a24fa85"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7fea9428ab2cd577d7dc571036b2450361802c43d7a546e72eead95c21239c9a"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_armv7l.whl", hash = "sha256:819d7e77594aa3108f9ad9e896b003914ec778fdf9827d9f940ca5e6db5416ce"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_i686.whl", hash = "sha256:be4c578fa148a9cbc64451a3af26c4ee55d59c33f5438bcffc1956092df0888b"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_ppc64.whl", hash = "sha256:4607156004c36c1cbd8b693b9516a3463646159299404e007cc292f51934c930"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:3bf9132a6c609ca9fa96df3e8309acaee930b1faf46212d7c296f2bce03f5264"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_s390x.whl", hash = "sha256:a06e595e05cc31a882031367e0f6c2b19160b1d7e881857c16121e3cda32494d"},
-    {file = "watchdog-2.0.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8e82707878e3defc46e8a4d861cde0c89561fba8a91b3609742213fa9d07fc16"},
-    {file = "watchdog-2.0.3-py3-none-win32.whl", hash = "sha256:b565838318e134e41d78f056194dff6bbd7b85fef67f9ee6f01168146bf04048"},
-    {file = "watchdog-2.0.3-py3-none-win_amd64.whl", hash = "sha256:6b760cf207bf4d533155853904047e75eb3a2d629bfd320c3f4f8d07abbc38d5"},
-    {file = "watchdog-2.0.3-py3-none-win_ia64.whl", hash = "sha256:c678b51fb89c76816004c8234ac827977c23912c3826e263adbfb5dbe161e8dc"},
-    {file = "watchdog-2.0.3.tar.gz", hash = "sha256:4288d3a984324db492e57aa169666238a2578f0af5a081685526608fb9f6bd61"},
+    {file = "watchdog-2.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af1d42ac65bf3f851d787e723a950d9c878c4ef0ff3381a2196d36b0c4b6d39c"},
+    {file = "watchdog-2.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8a75022cacbd0ad66ab8a9059322a76a43164ea020b373cbc28ddbacf9410b14"},
+    {file = "watchdog-2.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37bf90ef22b666fb0b5c1ea4375c9cbf43f1ff72489a91bf6f0370ba13e09b2a"},
+    {file = "watchdog-2.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:66193c811498ff539d0312091bdcbd98cce03b5425b8fa918c80f21a278e8358"},
+    {file = "watchdog-2.1.0-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5472ee2d23eaedf16c4b5088897cd9f50cd502074f508011180466d678cdf62a"},
+    {file = "watchdog-2.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a079aceede99b83a4cf4089f6e2243c864f368b60f4cce7bf46286f3cfcc8947"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:da1ca0845bbc92606b08a08988d8dbcba514a16c209be29d211b13cf0d5be2fd"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:5a62491c035646130c290a4cb773d7de103ac0202ac8305404bdb7db17ab5c3f"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_i686.whl", hash = "sha256:8c8ff287308a2ba5148aa450d742198d838636b65de52edd3eccfa4c86bf8004"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:05544fdd1cdc00b5231fb564f17428c5d502756419008cb8045be5b297eac21c"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8ab111b71fba4f8f77baa39d42bf923d085f64869396497518c43297fe1ec4e7"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:06ee7b77a8169f9828f8d24fc3d3d99b2216e1d2f7085b5913022a55161da758"},
+    {file = "watchdog-2.1.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c2d37a9df96d8f9ea560c0824f179168d8501f3e614b5e9f2168b38fe6ef3c12"},
+    {file = "watchdog-2.1.0-py3-none-win32.whl", hash = "sha256:6c6fa079abddea664f7ecda0a02636ca276f095bd26f474c23b3f968f1e938ec"},
+    {file = "watchdog-2.1.0-py3-none-win_amd64.whl", hash = "sha256:80afa2b32aac3abc7fb6ced508fc612997a0c8fb0f497217d54c524ff52e9e3a"},
+    {file = "watchdog-2.1.0-py3-none-win_ia64.whl", hash = "sha256:b8fb08629f52d3e0a060b93d711824f2b06fb8e0d09ad453f2a93d0c97d6b1ec"},
+    {file = "watchdog-2.1.0.tar.gz", hash = "sha256:55316efab52f659b8b7b59730680bfb27ac003522f24c44f6bcd60c4e3736ccd"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,6 +41,7 @@ pytest-subtests = "^0.2.1"
 setuptools = "==40.8.0"
 sphinx = "*"
 sphinx-markdown-builder = "^0.5.1"
+sphinxcontrib-trio = "^1.1.2"
 watchdog = "*"
 
 [tool.poetry.extras]


### PR DESCRIPTION
* Add the `sphinxcontrib_trio` plugin (https://sphinxcontrib-trio.readthedocs.io/en/latest/) as it does a much better rendering job on async methods, of which `dazl` has many.
* Drop the `sphinx.ext.viewcode` plugin, because the source links will be increasingly less helpful as the docs start to lean more heavily on rst files that live outside the code, and typing rules sometimes move to dedicated .pyi files.
* Fix a little warning around lexers and Sphinx—it prefers classes over instances.