### PR TITLE
meta: Minor fixes to the CircleCI setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           path: target/test-results
   blackduck:
     docker:
-      - image: rappdw/docker-java-python
+      - image: cimg/python:3.6.13-browsers
     steps:
       - checkout
 
@@ -70,8 +70,7 @@ jobs:
       - run:
           name: Run Blackduck Detect
           command: |
-            cp /home/circleci/.jq/bin/jq /usr/local/bin
-            bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_dazl master --logging.level.com.synopsys.integration=DEBUG --detect.python.python3=true
+            bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_dazl master --logging.level.com.synopsys.integration=DEBUG
           working_directory: python
           
 workflows:

--- a/.circleci/install-daml
+++ b/.circleci/install-daml
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-set -euo pipefail
+set -xeuo pipefail
 
-version=1.12.0
+version=1.13.1
 
 function install {
     if ! link ; then

--- a/.circleci/install-jq
+++ b/.circleci/install-jq
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-set -euo pipefail
+set -xeuo pipefail
 
 bin_dir="$HOME/.jq/bin"
 


### PR DESCRIPTION
* Use the CircleCI base image instead of the older Java/Python image for Blackduck scans.
* Drop an unneeded copy of `jq` in the Blackduck run.
* Drop `--detect.python.python3=true` from Blackduck runs; it's currently configured to fail on warnings and now that Python 2 is unsupported, Synopsys has deprecated that flag.
* Add `set -x` to the various installers that run in CircleCI, because why not.