### PR TITLE
python: Add some test utilities.

### DIFF
--- a/python/dazl/ledger/errors.py
+++ b/python/dazl/ledger/errors.py
@@ -58,7 +58,7 @@ def _rewrite_exceptions(fn: Fn) -> Fn:
     # to handling all Exceptions until this code is modified to handle this case.
     try:
         # noinspection PyProtectedMember
-        from grpc._cython.cygrpc import UsageError
+        from grpc._cython.cygrpc import UsageError  # type: ignore
     except ImportError:
         # noinspection PyPep8Naming
         UsageError = Exception
@@ -73,7 +73,7 @@ def _rewrite_exceptions(fn: Fn) -> Fn:
             else:
                 raise
 
-    return _rewrite_exception
+    return _rewrite_exception  # type: ignore
 
 
 class ExceptionTranslator:

--- a/python/dazl/testing/__init__.py
+++ b/python/dazl/testing/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .connect import connect_with_new_party
+
+__all__ = ["connect_with_new_party"]

--- a/python/dazl/testing/connect.py
+++ b/python/dazl/testing/connect.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from asyncio import gather
+from os import PathLike
+import sys
+from typing import BinaryIO, Callable, Collection, List, Optional, Sequence, Union
+
+from .. import connect
+from ..ledger.aio import Connection
+from ..prim import Party
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+__all__ = ["connect_with_new_party"]
+
+
+NameGenFn = Callable[[int], Optional[str]]
+
+
+def connect_with_new_party(
+    *,
+    party_count=1,
+    url=None,
+    read_as=None,
+    act_as=None,
+    admin=False,
+    ledger_id=None,
+    dar=None,
+    identifier_hint=None,
+    display_name=None,
+) -> "ConnectWithNewParty":
+    """
+    A helper function for connecting to a ledger as a brand new party. This isn't normally useful
+    outside of tests, where having creating new parties for each test helps keep test data isolated.
+
+    Like the :func:`dazl.ledger.connect` function, all parameters are optional, and if unspecified,
+    get their default values from the environment.
+
+    This function can NOT be used with ledgers that require authentication since it has no way to
+    ask a token granter for an appropriate token for the newly allocated party.
+
+    :param url:
+        The URL of the ledger to connect to. This ledger MUST NOT require authentication!
+    :type url: str
+    :param read_as:
+        Extra parties to for which read-as access should be granted.
+    :type read_as: str or Collection[str]
+    :param act_as:
+        Extra parties to for which act-as access should be granted. The created party is added to
+        this list.
+    :type read_as: str or Collection[str]
+    :param admin:
+        ``True`` if the created connection should have "admin" rights; otherwise ``False``. Note
+        that in order to allocate parties, an initial connection with admin rights is ALWAYS
+        created, and the value of this call only affects the returned connection.
+    :type admin: bool
+    :param ledger_id:
+        The ledger ID to connect to. As with the ``connect`` api, if the target is the gRPC Ledger
+        API, then supplying this field is optional, and with an HTTP JSON API server, this field
+        must be supplied.
+    :type ledger_id: str
+    :param dar:
+        A path to a file, the contents of the file (as ``bytes``), or a byte buffer that point to a
+        DAR that should also be uploaded.
+    :type dar: str or bytes or PathLike or BinaryIO
+    :param party_count:
+        The number of parties (and connections) to create.
+    :type party_count: int
+    :param identifier_hint:
+        A hint to the backing participant. Note that the Daml ledger is free to ignore this
+        hint entirely. If `party_count` is greater than 1, then
+    :type identifier_hint: str
+    :param display_name:
+        A human-readable name that corresponds to the allocated ``Party``.
+    :return:
+        An asynchronous context manager that returns one or more :class:`ConnectionWithParty`
+        objects.
+    """
+    if party_count < 0:
+        raise ValueError("party_count must be a positive number")
+
+    contents = None  # type: Optional[bytes]
+    if dar is not None:
+        if isinstance(dar, bytes):
+            contents = dar
+        elif isinstance(dar, (str, PathLike)):
+            with open(dar, "rb") as buf:
+                contents = buf.read()
+        else:
+            contents = dar.read()
+
+    return ConnectWithNewParty(
+        party_count=party_count,
+        url=url,
+        read_as=read_as,
+        act_as=as_party_collection(act_as),
+        admin=admin,
+        ledger_id=ledger_id,
+        dar=contents,
+        identifier_hint_fn=convert_to_fn(identifier_hint, party_count=party_count),
+        display_name_fn=convert_to_fn(display_name, party_count=party_count),
+    )
+
+
+class ConnectionWithParty:
+    # We're cheating here; we declare the types of our fields as properties in the typing file,
+    # but really they're just plain attributes
+    # noinspection PyPropertyAccess
+    def __init__(self, connection, party):
+        self.connection = connection
+        self.party = party
+
+    def __getitem__(self, item: Literal[0]) -> "ConnectionWithParty":
+        return self
+
+    def __len__(self) -> Literal[1]:
+        return 1
+
+
+def as_party_collection(p: Union[None, Party, Collection[Party]]) -> Collection[Party]:
+    if not p:
+        return []
+    elif isinstance(p, str):
+        return [Party(o) for o in p.split(",")]
+    else:
+        return p
+
+
+def convert_to_fn(party_or_fn: Union[None, str, NameGenFn], *, party_count: int = 1) -> NameGenFn:
+    if party_or_fn is None:
+        return lambda _: None
+    if isinstance(party_or_fn, str):
+        if party_count == 1:
+            return lambda _: party_or_fn
+        else:
+            return lambda i: f"{party_or_fn}{i:03}"
+    else:
+        return party_or_fn
+
+
+class ConnectWithNewParty:
+    def __init__(
+        self,
+        *,
+        url: Optional[str],
+        read_as: Union[Party, Collection[Party]],
+        act_as: Collection[Party],
+        admin: Optional[bool],
+        ledger_id: str,
+        dar: Optional[bytes],
+        party_count: int,
+        identifier_hint_fn: NameGenFn,
+        display_name_fn: NameGenFn,
+    ):
+        self.url = url
+        self.read_as = read_as
+        self.act_as = act_as
+        self.admin = admin
+        self.ledger_id = ledger_id
+        self.dar = dar
+        self.party_count = party_count
+        self.identifier_hint_fn = identifier_hint_fn
+        self.display_name_fn = display_name_fn
+        self.connections = []  # type: List[Connection]
+
+    async def __aenter__(self) -> "Sequence[ConnectionWithParty]":
+        # Party allocation and package uploading require "admin" access, so we disregard the given
+        # user parameters to allocate parties
+        async with connect(url=self.url, admin=True, ledger_id=self.ledger_id) as conn:
+            party_infos = await gather(
+                *(
+                    conn.allocate_party(
+                        identifier_hint=self.identifier_hint_fn(i),
+                        display_name=self.display_name_fn(i),
+                    )
+                    for i in range(self.party_count)
+                )
+            )
+
+            if self.dar is not None:
+                await conn.upload_package(self.dar)
+
+        ret = []
+        for party_info in party_infos:
+            party_conn = connect(
+                url=self.url,
+                read_as=self.read_as,
+                act_as=[party_info.party, *self.act_as],
+                admin=self.admin,
+                ledger_id=self.ledger_id,
+            )
+            await party_conn.open()
+            ret.append(ConnectionWithParty(party_conn, party_info.party))
+        if len(ret) == 1:
+            return ret[0]
+        else:
+            return tuple(ret)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await gather(*(conn.close() for conn in self.connections))

--- a/python/dazl/testing/connect.pyi
+++ b/python/dazl/testing/connect.pyi
@@ -1,0 +1,103 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence as Seq
+from os import PathLike
+import sys
+from typing import (
+    AsyncContextManager,
+    BinaryIO,
+    Callable,
+    Collection,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
+
+from ..ledger.aio import Connection
+from ..prim import Party
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+__all__ = ["connect_with_new_party"]
+NameGenFn = Callable[[int], Optional[str]]
+@overload
+def connect_with_new_party(
+    *,
+    party_count: Literal[1] = 1,
+    url: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    identifier_hint: Union[None, str, NameGenFn] = None,
+    display_name: Union[None, str, NameGenFn] = None
+) -> AsyncContextManager[ConnectionWithParty]: ...
+@overload
+def connect_with_new_party(
+    *,
+    party_count: Literal[2],
+    url: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    identifier_hint: Union[None, str, NameGenFn] = None,
+    display_name: Union[None, str, NameGenFn] = None
+) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty]]: ...
+@overload
+def connect_with_new_party(
+    *,
+    party_count: Literal[3],
+    url: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    identifier_hint: Union[None, str, NameGenFn] = None,
+    display_name: Union[None, str, NameGenFn] = None
+) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty, ConnectionWithParty]]: ...
+@overload
+def connect_with_new_party(
+    *,
+    party_count: Literal[4],
+    url: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    identifier_hint: Union[None, str, NameGenFn] = None,
+    display_name: Union[None, str, NameGenFn] = None
+) -> AsyncContextManager[
+    Tuple[ConnectionWithParty, ConnectionWithParty, ConnectionWithParty, ConnectionWithParty]
+]: ...
+@overload
+def connect_with_new_party(
+    *,
+    party_count: int,
+    url: Optional[str] = None,
+    read_as: Union[None, Party, Collection[Party]] = None,
+    act_as: Union[None, Party, Collection[Party]] = None,
+    admin: Optional[bool] = False,
+    ledger_id: Optional[str] = None,
+    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    identifier_hint: Union[None, str, NameGenFn] = None,
+    display_name: Union[None, str, NameGenFn] = None
+) -> AsyncContextManager[Sequence[ConnectionWithParty]]: ...
+
+class ConnectionWithParty(Seq["ConnectionWithParty"]):
+    def __init__(self, connection: Connection, party: Party): ...
+    @property
+    def connection(self) -> Connection: ...
+    @property
+    def party(self) -> Party: ...
+    def __getitem__(self, item): ...
+    def __len__(self) -> Literal[1]: ...

--- a/python/tests/unit/test_ledgerutil_acs_close.py
+++ b/python/tests/unit/test_ledgerutil_acs_close.py
@@ -1,33 +1,28 @@
 from typing import Optional
 
-from dazl import connect
 from dazl.ledger.errors import ConnectionClosedError
 from dazl.ledgerutil.acs import RUNNING, Snapshot, snapshots
+from dazl.testing import connect_with_new_party
 import pytest
 from tests.unit.dars import PostOffice
 
 
 @pytest.mark.asyncio
 async def test_acs(sandbox):
-    # we need a sandbox that we can close, so we create our own
-    async with connect(url=sandbox, admin=True) as conn:
-        await conn.upload_package(PostOffice.read_bytes())
-        party = (await conn.allocate_party()).party
-
-    async with connect(url=sandbox, act_as=party) as conn:
-        await conn.create("Main:PostmanRole", {"postman": party})
+    async with connect_with_new_party(url=sandbox, dar=PostOffice) as p:
+        await p.connection.create("Main:PostmanRole", {"postman": p.party})
         snapshot = None  # type: Optional[Snapshot]
         snapshot_loop_count = 0
 
         with pytest.raises(ConnectionClosedError):
-            async for state, s in snapshots(conn, "Main:PostmanRole"):
+            async for state, s in snapshots(p.connection, "Main:PostmanRole"):
                 # once we get one snapshot successfully, remember that we did, and kill our connection
                 if state == RUNNING:
                     snapshot_loop_count += 1
                     snapshot = s
 
                     # ok so now we got the snapshot; kill the connection
-                    await conn.close()
+                    await p.connection.close()
 
         # we should have only run the loop once
         assert snapshot_loop_count == 1

--- a/python/tests/unit/test_protocol_ledgerapi.py
+++ b/python/tests/unit/test_protocol_ledgerapi.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from dazl import connect
+from dazl.testing import connect_with_new_party
 import pytest
 
 from .dars import PostOffice
@@ -12,19 +12,13 @@ from .dars import PostOffice
 @pytest.mark.asyncio
 async def test_protocol_ledger_api(sandbox):
     # first, administrative stuff--upload the DAR and allocate two parties that we'll use later
-    async with connect(url=sandbox, admin=True) as conn:
-        await conn.upload_package(PostOffice.read_bytes())
-        postman = (await conn.allocate_party()).party
-        participant = (await conn.allocate_party()).party
-
-    async with connect(url=sandbox, act_as=postman) as conn:
-        event = await conn.create("Main:PostmanRole", {"postman": postman})
-        result = await conn.exercise(
-            event.contract_id, "InviteParticipant", {"party": participant, "address": "Somewhere!"}
+    async with connect_with_new_party(url=sandbox, dar=PostOffice, party_count=2) as (postman, p1):
+        event = await postman.connection.create("Main:PostmanRole", {"postman": postman.party})
+        result = await postman.connection.exercise(
+            event.contract_id, "InviteParticipant", {"party": p1.party, "address": "Somewhere!"}
         )
         logging.info("Result of inviting a participant: %s", result)
 
-    async with connect(url=sandbox, act_as=participant) as conn:
         # Stream results for Main:InviteAuthorRole, and then Main:InviteReceiverRole. Then break the
         # stream once we find the first contract.
         #
@@ -32,15 +26,15 @@ async def test_protocol_ledger_api(sandbox):
         # postman inviting participants may not yet have been observed by the clients. Instead, use
         # stream() since it remains open until explicitly closed. We break the never-ending iterator
         # as soon as we see one of each contract.
-        async with conn.stream("Main:InviteAuthorRole") as query:
+        async with p1.connection.stream("Main:InviteAuthorRole") as query:
             async for event in query:
-                result = await conn.exercise(event.contract_id, "AcceptInviteAuthorRole")
+                result = await p1.connection.exercise(event.contract_id, "AcceptInviteAuthorRole")
                 logging.info("The result of AcceptInviteAuthorRole: %s", result)
                 break
 
-        async with conn.stream("Main:InviteReceiverRole") as query:
+        async with p1.connection.stream("Main:InviteReceiverRole") as query:
             async for event in query:
-                result = await conn.exercise(event.contract_id, "AcceptInviteReceiverRole")
+                result = await p1.connection.exercise(event.contract_id, "AcceptInviteReceiverRole")
                 logging.info("The result of AcceptInviteReceiverRole: %s", result)
                 break
 


### PR DESCRIPTION
In trying to fix another bug, I realized how verbose the code around writing tests was, and set out to try to reduce it.

The total amount of code is higher than I would have liked, but that's mostly because of Python 3.6 support; it could have been a lot less if I could have used `contextlib.asynccontextmanager` and `contextlib.AsyncExitStack`, but unfortunately those were introduced in Python 3.7. 