### PR TITLE
meta: Make Daml files render a little prettier in GitHub.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.daml linguist-language=Haskell


### PR DESCRIPTION
Render Daml files as Haskell files, because it's better than no syntax highlighting at all.