### PR TITLE
meta: Fix the release script to include a leading 'v' in tag names.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -39,5 +39,5 @@ echo "Git SHA: ${git_sha}"
 echo "Files: $@"
 echo "Flags: ${gh_flags}"
 
-gh release create "${root_version}" ${gh_flags} -t "dazl v${root_version}" $@
+gh release create "v${root_version}" ${gh_flags} -t "dazl v${root_version}" $@
 poetry publish


### PR DESCRIPTION
meta: Fix the release script to include a leading 'v' in tag names.

Releases v7.5.0 through v7.5.3 have had their tags retroactively updated to fix the previously broken script that was in use for those four releases.