### PR TITLE
python: Make sure that mypy is run as part of the build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ jobs:
           name: Python format checks
           command: make python-format-test
       - run:
+          name: Python typechecks
+          command: make python-typecheck
+      - run:
           name: Python unit tests
           command: make python-unit-test
       - run:

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -10,6 +10,9 @@ ignore_missing_imports = True
 [mypy-google.protobuf.pyext.*]
 ignore_missing_imports = True
 
+[mypy-grpc._cython.*]
+ignore_missing_imports = True
+
 [mypy-grpc.aio.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
I thought I had already merged this in but apparently not; make sure that `mypy` is run as part of the build.

`dazl` is finally now 100% happy with `mypy`, so this is to make sure it stays that way.