### PR TITLE
python: Fix a potential typing bug with time service calls.

### DIFF
--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -224,16 +224,16 @@ class GRPCv1LedgerClient(LedgerClient):
 
 
 def grpc_set_time(connection: "GRPCv1Connection", ledger_id: str, new_datetime: datetime) -> None:
-    request = G_GetTimeRequest(ledger_id=ledger_id)
-    response = connection.time_service.GetTime(request)
-    ts = next(iter(response))
+    get_request = G_GetTimeRequest(ledger_id=ledger_id)
+    get_response = connection.time_service.GetTime(get_request)
+    ts = next(iter(get_response))
 
-    request = G_SetTimeRequest(
+    set_request = G_SetTimeRequest(
         ledger_id=ledger_id,
         current_time=ts.current_time,
         new_time=datetime_to_timestamp(new_datetime),
     )
-    connection.time_service.SetTime(request)
+    connection.time_service.SetTime(set_request)
     LOG.info("Time on the server changed by the local client to %s.", new_datetime)
 
 


### PR DESCRIPTION
python: Give variables in `grpc_set_time` explicit names to avoid clashes in mypy.

Although the original code is legal Python, `mypy` gets confused that the `request` variables does double duty. For the moment, neither the previous nor the replacement code angers mypy,  That's only because there isn't yet a `.pyi` file for https://github.com/digital-asset/dazl-client/blob/8e7b5a887849e7e29abc17f6759cfe359e2123f8/python/dazl/_gen/com/daml/ledger/api/v1/testing/time_service_pb2.py, but the addition of one would trigger a problem here.