### PR TITLE
python: Some more typing fixes for Protobuf definitions.

### DIFF
--- a/python/dazl/ledger/grpc/codec_aio.py
+++ b/python/dazl/ledger/grpc/codec_aio.py
@@ -155,15 +155,15 @@ class Codec:
     ) -> G_CreateAndExerciseCommand:
         item_type, _, choice = await self._look_up_choice(template_id, choice_name)
 
-        cmd_pb = G_CreateAndExerciseCommand(
-            template_id=self.encode_identifier(item_type),
-            choice=choice_name,
-        )
         payload_field, payload_pb = await self.encode_value(con(item_type), payload)
         if payload_pb != "record":
             raise ValueError("unexpected non-record type when constructing payload")
         argument_field, argument_pb = await self.encode_value(choice.arg_binder.type, argument)
-        cmd_pb.create_arguments = payload_pb
+        cmd_pb = G_CreateAndExerciseCommand(
+            create_arguments=payload_pb,
+            template_id=self.encode_identifier(item_type),
+            choice=choice_name,
+        )
         set_value(cmd_pb.choice_argument, argument_field, argument_pb)
 
         return cmd_pb

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -80,7 +80,7 @@ class DarFile(_DarFile):
         warnings.warn(
             "get_archives is deprecated; there is no replacement.", DeprecationWarning, stacklevel=2
         )
-        return {a.hash: a.payload for a in self._pb_archives()}
+        return {PackageRef(a.hash): a.payload for a in self._pb_archives()}
 
     def get_dalf_names(self) -> "Sequence[PackageRef]":
         warnings.warn(
@@ -148,7 +148,7 @@ def parse_dalf(contents: bytes) -> "PackageStore":
 
     a = Archive()
     a.ParseFromString(contents)
-    return _parse_daml_metadata_pb(parse_archive(a.hash, a.payload))
+    return _parse_daml_metadata_pb(parse_archive(PackageRef(a.hash), a.payload))
 
 
 def get_dar_package_ids(dar: "Dar") -> "Collection[PackageRef]":


### PR DESCRIPTION
python: A few more fixes to make `dazl`'s code compatible with a future auto-generated version of typing stub files.