### PR TITLE
python: Add a blocking PackageLoader implementation.

### DIFF
--- a/python/dazl/ledger/blocking/__init__.py
+++ b/python/dazl/ledger/blocking/__init__.py
@@ -21,7 +21,20 @@ else:
     from typing_extensions import Protocol, runtime_checkable
 
 
-__all__ = ["Connection", "QueryStream"]
+__all__ = ["PackageService", "Connection", "QueryStream", "PackageLoader"]
+
+
+class PackageService(Protocol):
+    """
+    Protocol that describe a service that provides package information. The :class:`Connection`
+    protocol extends this interface.
+    """
+
+    async def get_package(self, __package_id) -> bytes:
+        raise NotImplementedError
+
+    async def list_package_ids(self):
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -56,3 +69,7 @@ class QueryStream(_QueryStream, Protocol):
 
     def __iter__(self):
         raise NotImplementedError
+
+
+# Imports internal to this package are at the bottom of the file to avoid circular dependencies
+from .pkgloader import PackageLoader  # noqa

--- a/python/dazl/ledger/blocking/__init__.pyi
+++ b/python/dazl/ledger/blocking/__init__.pyi
@@ -12,13 +12,14 @@ from ...damlast.daml_lf_1 import PackageRef, TypeConName
 from ...prim import ContractData, ContractId
 from ...query import Queries, Query
 from ..api_types import ArchiveEvent, Boundary, Command, CreateEvent, ExerciseResponse, PartyInfo
+from .pkgloader import PackageLoader
 
 if sys.version_info >= (3, 8):
     from typing import Protocol, runtime_checkable
 else:
     from typing_extensions import Protocol, runtime_checkable
 
-__all__ = ["PackageService", "Connection", "QueryStream"]
+__all__ = ["PackageService", "Connection", "QueryStream", "PackageLoader"]
 
 Self = TypeVar("Self")
 


### PR DESCRIPTION
This is a step on the way to a blocking "new-style" API to eventually replace the "old-style" blocking API.

There is a fair amount of duplication between the async and blocking implementations unfortunately, but Python's `asyncio` API and blocking calls are just ever so different that they require slightly different treatment. In addition the blocking API needs locks in ways that the the `asyncio` API does not, and trying to force code re-use where it's just not really possible just isn't worth it (I think).