### PR TITLE
python: Simplify some imports.

### DIFF
--- a/python/dazl/ledger/grpc/channel.py
+++ b/python/dazl/ledger/grpc/channel.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 from typing import List, Tuple, Union, cast
 from urllib.parse import urlparse
 

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -12,10 +12,7 @@ import threading
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from .. import LOG
-from .._gen.com.daml.ledger.api.v1.transaction_pb2 import (
-    Transaction as G_Transaction,
-    TransactionTree as G_TransactionTree,
-)
+from .._gen.com.daml.ledger.api import v1 as lapipb
 from ..damlast.lookup import MultiPackageLookup
 from ..prim import Party
 from ..scheduler import Invoker
@@ -114,7 +111,7 @@ class LedgerClient:
         """
         raise NotImplementedError("commands must be implemented")
 
-    async def commands_transaction(self, __1: "CommandPayload") -> G_Transaction:
+    async def commands_transaction(self, __1: "CommandPayload") -> "lapipb.Transaction":
         """
         Submit a command to the ledger and retrieve the resulting transaction.
 
@@ -125,7 +122,7 @@ class LedgerClient:
         """
         raise NotImplementedError("commands_transaction must be implemented")
 
-    async def commands_transaction_tree(self, __1: "CommandPayload") -> G_TransactionTree:
+    async def commands_transaction_tree(self, __1: "CommandPayload") -> "lapipb.TransactionTree":
         """
         Submit a command to the ledger and retrieve the resulting transaction tree.
 

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -20,7 +20,7 @@ import warnings
 from toposort import toposort_flatten
 
 from ... import LOG
-from ..._gen.com.daml.daml_lf_1_14.daml_lf_pb2 import ArchivePayload as G_ArchivePayload
+from ..._gen.com.daml.daml_lf_1_14 import daml_lf_pb2 as lfpb
 from ...damlast.daml_lf_1 import (
     Archive,
     DefDataType,
@@ -71,13 +71,13 @@ def parse_archive_payload(raw_bytes: bytes, package_id: "Optional[PackageRef]" =
 
 @dataclass(frozen=True)
 class ArchiveDependencyResult:
-    sorted_archives: "Mapping[PackageRef, G_ArchivePayload]"
-    unresolvable_archives: "Mapping[PackageRef, G_ArchivePayload]"
+    sorted_archives: "Mapping[PackageRef, lfpb.ArchivePayload]"
+    unresolvable_archives: "Mapping[PackageRef, lfpb.ArchivePayload]"
 
 
 # noinspection PyDeprecation
 def find_dependencies(
-    metadatas_pb: "Mapping[PackageRef, G_ArchivePayload]",
+    metadatas_pb: "Mapping[PackageRef, lfpb.ArchivePayload]",
     existing_package_ids: "Collection[PackageRef]",
 ) -> "ArchiveDependencyResult":
     """

--- a/python/tests/unit/test_pb_serialize.py
+++ b/python/tests/unit/test_pb_serialize.py
@@ -4,8 +4,8 @@
 from dataclasses import dataclass
 from typing import Generator
 
-from dazl._gen.com.daml.ledger.api.v1.commands_pb2 import Command as G_Command
-from dazl._gen.com.daml.ledger.api.v1.value_pb2 import (
+from dazl._gen.com.daml.ledger.api.v1 import (
+    Command as G_Command,
     RecordField as G_RecordField,
     Value as G_Value,
 )

--- a/python/tests/unit/test_values_protobuf.py
+++ b/python/tests/unit/test_values_protobuf.py
@@ -3,7 +3,7 @@
 
 from datetime import date, datetime, timedelta, timezone
 
-from dazl._gen.com.daml.ledger.api.v1 import value_pb2
+from dazl._gen.com.daml.ledger.api import v1 as lapipb
 from dazl.damlast import CachedDarFile, daml_types as daml
 from dazl.damlast.lookup import MultiPackageLookup
 from dazl.values import Context, ProtobufDecoder, ProtobufEncoder
@@ -42,7 +42,7 @@ def test_values_protobuf_encode_bool_false(encode_context):
 def test_values_protobuf_encode_enum(encode_context, lookup):
     color_enum_type = daml.con(lookup.data_type_name("*:AllKindsOf:Color"))
     actual = encode_context.convert(color_enum_type, "Red")
-    assert actual == ("enum", value_pb2.Enum(constructor="Red"))
+    assert actual == ("enum", lapipb.Enum(constructor="Red"))
 
 
 def test_values_protobuf_encode_enum_invalid(encode_context, lookup):
@@ -80,7 +80,7 @@ def test_values_protobuf_encode_datetime(encode_context):
 
 
 def test_values_protobuf_decode_date(decode_context):
-    value = value_pb2.Value()
+    value = lapipb.Value()
     value.date = 18262
 
     actual = decode_context.convert(daml.Date, value)
@@ -88,7 +88,7 @@ def test_values_protobuf_decode_date(decode_context):
 
 
 def test_values_protobuf_decode_date_far_in_the_past(decode_context):
-    value = value_pb2.Value()
+    value = lapipb.Value()
     value.date = -1
 
     actual = decode_context.convert(daml.Date, value)
@@ -96,7 +96,7 @@ def test_values_protobuf_decode_date_far_in_the_past(decode_context):
 
 
 def test_values_protobuf_decode_datetime(decode_context):
-    value = value_pb2.Value()
+    value = lapipb.Value()
     value.timestamp = ARBITRARY_DATETIME_TIMESTAMP
 
     actual = decode_context.convert(daml.Time, value)


### PR DESCRIPTION
Before #275, there wasn't a great way to avoid boilerplate and lengthy import sections for Protobuf-generated code. But now there is!

Wherever Protobuf types are used, do `from dazl._gen.com.daml.ledger.api import v1 as lapipb`  (Ledger API ProtoBuf).