### PR TITLE
python: Fixed some leaky deprecation warnings

### DIFF
--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -27,8 +27,9 @@ from typing import (
 import warnings
 
 from .. import LOG
+from ..client.errors import ConfigurationError
 from ..damlast.daml_lf_1 import PackageRef
-from ..model.core import ConfigurationError, Party
+from ..prim import Party
 from ..util.config_meta import (
     BOOLEAN_TYPE,
     COUNT_TYPE,

--- a/python/dazl/model/__init__.py
+++ b/python/dazl/model/__init__.py
@@ -21,7 +21,9 @@ introduced in dazl v5) or :mod:`dazl.protocols` (for the API introduced in dazl 
 
 import warnings
 
-from . import core, ledger, lookup, network, reading, types, writing
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from . import core, ledger, lookup, network, reading, types, writing
 
 __all__ = ["core", "ledger", "lookup", "network", "reading", "writing"]
 

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -4,6 +4,7 @@
 
 from io import StringIO
 from typing import Mapping, Optional, Sequence, Union
+import warnings
 
 from .. import LOG
 from ..damlast import daml_types as daml
@@ -20,10 +21,13 @@ from ..damlast.daml_lf_1 import (
     Update,
 )
 from ..damlast.util import def_value, module_name
-from ..model.types import ModuleRef, Type as OldType
-from ..model.types_store import PackageStore
 from ._render_base import PrettyPrintBase, pretty_print_syntax
 from .util import indent, maybe_parentheses
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from ..model.types import ModuleRef, Type as OldType
+    from ..model.types_store import PackageStore
 
 
 def values_by_module(


### PR DESCRIPTION
Fixed some leaky deprecation warnings that would happen even when deprecated types weren't explicitly imported.