### PR TITLE
python: Move some of the testing code for dazl into dazl itself

### DIFF
--- a/docs/dazl.rst
+++ b/docs/dazl.rst
@@ -19,6 +19,7 @@ Subpackages
     dazl.model
     dazl.pretty
     dazl.protocols
+    dazl.testing
     dazl.util
 
 Module contents

--- a/docs/dazl.testing.rst
+++ b/docs/dazl.testing.rst
@@ -1,0 +1,56 @@
+.. Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+   SPDX-License-Identifier: Apache-2.0
+
+:mod:`dazl.testing`
+======================
+
+.. py:currentmodule:: dazl.testing
+
+This module provides testing utilities for writing simple tests around a Daml ledger running with a
+local sandbox. Call the :func:`sandbox` function which returns an object that controls the lifecycle
+of a sandbox process.
+
+Starting up a Daml sandbox and uploading relevant DARs takes long enough (more than one second) that
+you'll probably want to start a single sandbox to run for the duration of the tests. In order to
+achieve good test isolation, though, you don't necessarily want to use the same parties for each
+test, you should also use :func:`connect_with_new_party`, which will automatically allocate and
+return a new party on every invocation.
+
+Example:
+
+.. code-block:: python
+
+   # this assumes a daml.yaml file exists in the same location as your Python code;
+   # you may need to adjust this location for your own project
+   project_root = path.dirname(__file__)
+
+   async def main():
+      async with sandbox(project_root=) as sb:
+         async with connect_with_new_party(url=sb.url) as p:
+            logging.info("Connecting as party: %s", p.party)
+            await p.conn.create("Some:Asset", {"owner": p.party, "amount": 1000})
+
+   # Python 3.7+ only
+   asyncio.run(main())
+
+
+.. py:function:: sandbox
+
+   :param project_root:
+      The root project directory for your Daml project. If supplied, the DAR from this project is
+      automatically uploaded like ``daml start`` does. If ``None``, an empty sandbox is started and
+      you must supply your own DAR.
+   :type project_root: str or os.PathLike
+   :param version:
+      The Daml Connect version to use.
+   :type version: str
+   :param timeout:
+      The amount of time to wait for a Sandbox to start before giving up. The defualt is 10 seconds.
+   :type timeout: datetime.timedelta
+
+   Launch a sandbox running on a randomized port, optionally using the DARs as specified by a local
+   Daml project.
+
+   The resulting object can be used as a context manager _or_ an asynchronous context manager.
+
+.. autofunction:: connect_with_new_party

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -41,26 +41,19 @@ globals:
 
     @pytest.fixture(scope="session")
     def sandbox():
-        port = dazl.util.find_free_port()
-
-        sandbox_proc = subprocess.Popen(
-            ["daml", "start", "--start-navigator=no", "--open-browser=no", f"--sandbox-port={port}"],
-            cwd=daml_project_root)
-        try:
-            yield "http://localhost:{port}"
-        finally:
-            sandbox_proc.terminate()
+        with dazl.testing.sandbox(project_root=daml_project_root) as sandbox_proc:
+            return sandbox_proc
 
 
     def test_something(sandbox):
         network = dazl.Network()
-        network.set_config(url=sandbox_url)
+        network.set_config(url=sandbox.url)
         network.start_in_background()
         try:
             client = self.network.simple_new_party()
             client.ready()
 
-            client.submit_create('Main:PostmanRole', {'postman': client.party})
+            client.create('Main:PostmanRole', {'postman': client.party})
             assert len(client.find_active('Main:PostmanRole') == 1
 
         finally:

--- a/python/dazl/testing/__init__.py
+++ b/python/dazl/testing/__init__.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from ._sandbox import SandboxLauncher
 from .connect import connect_with_new_party
 
-__all__ = ["connect_with_new_party"]
+__all__ = ["connect_with_new_party", "sandbox", "SandboxLauncher"]
+
+sandbox = SandboxLauncher

--- a/python/dazl/testing/_sandbox.py
+++ b/python/dazl/testing/_sandbox.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from asyncio import get_event_loop
+from datetime import timedelta
+import logging
+import os
+import subprocess
+import threading
+from typing import Optional, Union
+
+from ..util import ProcessLogger, find_free_port, kill_process_tree, wait_for_process_port
+
+DEFAULT_TIMEOUT = timedelta(seconds=10)
+
+
+class SandboxLauncher:
+    """
+    A simple launcher for an in-memory Sandbox.
+    """
+
+    def __init__(
+        self,
+        *,
+        project_root: "Union[None, str, os.PathLike]",
+        version: "Optional[str]" = None,
+        timeout: "Optional[timedelta]" = DEFAULT_TIMEOUT,
+    ):
+        self._version = version
+        self._timeout = timeout
+        self._lock = threading.RLock()
+        self._project_root = project_root
+        self._process = None  # type: Optional[subprocess.Popen]
+        self._url = None  # type: Optional[str]
+
+        url = os.environ.get("DAZL_TEST_DAML_LEDGER_URL")
+        if url:
+            # if we're supposed to use a different already-running implementation,
+            # then do that instead
+            logging.info(
+                "Using the sandbox at %s because `DAZL_TEST_DAML_LEDGER_URL` is defined", url
+            )
+            self._url = url
+
+    @property
+    def url(self) -> str:
+        """
+        Return a URL that can be used to connect to this running Sandbox.
+        """
+        u = self._url
+        if u is not None:
+            return u
+        else:
+            raise RuntimeError("the sandbox is not running (did you call start()?)")
+
+    def start(self) -> None:
+        """
+        Start the sandbox and return a URL that can be used to connect to it.
+        """
+        if self._url is not None:
+            return
+
+        port = find_free_port()
+
+        env = os.environ.copy()
+        # Running dazl's tests against a different Sandbox merely requires the DAML_SDK_VERSION
+        # variable be set to a different value
+        if self._version is not None:
+            env["DAML_SDK_VERSION"] = self._version
+
+        with self._lock:
+            # one last check inside the lock
+            if self._url is not None:
+                return
+
+            if self._process is not None:
+                # this shouldn't ever happen, but we explicitly check for it because running
+                # multiple sandbox processes could be very confusing
+                raise RuntimeError("we somehow have a process without a URL")
+
+            cwd = None  # type: Union[None, str, os.PathLike]
+            if self._project_root:
+                cmdline = [
+                    "daml",
+                    "start",
+                    "--start-navigator=no",
+                    "--open-browser=no",
+                    f"--sandbox-port={port}",
+                ]
+                cwd = self._project_root
+            else:
+                cmdline = ["daml", "sandbox", "--port", str(port)]
+
+            self._process = subprocess.Popen(
+                cmdline,
+                env=env,
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            ProcessLogger(self._process, logging.getLogger("sandbox")).start()
+            wait_for_process_port(self._process, port, DEFAULT_TIMEOUT)
+
+            self._url = f"http://localhost:{port}"
+
+    def stop(self) -> None:
+        """
+        Stop the sandbox.
+        """
+        process = self._process
+        if process is not None:
+            # Clean up the process that we started. Note that some really old versions of the SDK
+            # had issues that left dangling child processes running even after the parent process is
+            # killed, so make sure that we find and destroy them too if the parent process doesn't
+            # kill its own children quickly enough.
+            try:
+                kill_process_tree(process)
+            finally:
+                self._url = None
+
+    def __enter__(self) -> "SandboxLauncher":
+        """
+        Start the sandbox.
+        """
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Stop the sandbox.
+        """
+        self.stop()
+
+    async def __aenter__(self) -> "SandboxLauncher":
+        """
+        Start the sandbox.
+        """
+        loop = get_event_loop()
+        await loop.run_in_executor(None, self.start)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """
+        Stop the sandbox.
+        """
+        loop = get_event_loop()
+        await loop.run_in_executor(None, self.stop)

--- a/python/tests/unittest_example/unittest_example.py
+++ b/python/tests/unittest_example/unittest_example.py
@@ -2,49 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
-from typing import Optional
 
 daml_project_root = Path(__file__).parent.parent.parent.parent / "_fixtures/src/post-office"
-
-
-import subprocess
-import unittest
-
-import dazl
 
 # DOC_BEGIN: EXAMPLE
 # Change this to point to your DAML project directory.
 # daml_project_root = "<path to directory containing daml.yaml>"
 
-# This field will contain t
-sandbox_url = None  # type: Optional[str]
-sandbox_proc = None  # type: Optional[subprocess.Popen]
+import unittest
+
+from dazl import Network, testing
+
+sandbox_proc = testing.sandbox(project_root=daml_project_root)
 
 
 def setUpModule():
     """
     Called by ``unittest`` before the tests in this module are going to be run.
     """
-    global sandbox_url, sandbox_proc
-
-    port = dazl.util.find_free_port()
-
-    sandbox_proc = subprocess.Popen(
-        ["daml", "start", "--start-navigator=no", "--open-browser=no", f"--sandbox-port={port}"],
-        cwd=daml_project_root,
-    )
-    sandbox_url = f"http://localhost:{port}"
+    global sandbox_proc
+    sandbox_proc.start()
 
 
 def tearDownModule():
     if sandbox_proc is not None:
-        sandbox_proc.terminate()
+        sandbox_proc.stop()
 
 
 class ExampleTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.network = dazl.Network()
-        self.network.set_config(url=sandbox_url)
+        self.network = Network()
+        self.network.set_config(url=sandbox_proc.url)
         self.network.start_in_background()
 
     def tearDown(self) -> None:
@@ -55,7 +43,7 @@ class ExampleTest(unittest.TestCase):
         client = self.network.simple_new_party()
         client.ready()
 
-        client.submit_create("Main:PostmanRole", {"postman": client.party})
+        client.create("Main:PostmanRole", {"postman": client.party})
         self.assertEqual(len(client.find_active("Main:PostmanRole")), 1)
 
 


### PR DESCRIPTION
python: Move some of the testing code for dazl into dazl itself so that it can be used by clients as well.