### PR TITLE
python: Make package parsing a bit faster.

### DIFF
--- a/python/tests/unit/test_historical_dar_parsing.py
+++ b/python/tests/unit/test_historical_dar_parsing.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import time
 
 from dazl import LOG
 from dazl.damlast import DarFile
@@ -15,6 +16,13 @@ dars = list(ARCHIVES.glob("**/*.dar"))
 @pytest.mark.parametrize("dar", dars)
 def test_dar_version_compatibility(dar):
     short_dar = dar.relative_to(ARCHIVES)
+    start_time = time.time()
     dar_file = DarFile(dar)
     archives = dar_file.archives()
-    LOG.info("Successfully read %s with package IDs %r.", short_dar, [a.hash for a in archives])
+    end_time = time.time()
+    LOG.info(
+        "Successfully read %s in %0.2f seconds with package IDs %r.",
+        short_dar,
+        end_time - start_time,
+        [a.hash for a in archives],
+    )


### PR DESCRIPTION
python: Make package parsing a bit faster.

Make the `DefValue.expr` property in dazl's Daml-LF classes evaluated lazily instead of eagerly. The parser spends a _huge_ amount of time here, despite dazl's code not actually currently making use of `DefValue`'s for any reason.

Parsing the file https://github.com/digital-asset/dazl-client/blob/master/_fixtures/archives/1.16.0/Test.dar takes 0.77 seconds on my machine before this change, and 0.20 afterwards. On ledgers with a large number of packages, this should dramatically speed up most operations involving packages.