### PR TITLE
docs: Fix a problem with the docs under dazl.ledger.

### DIFF
--- a/docs/dazl.ledger.rst
+++ b/docs/dazl.ledger.rst
@@ -33,8 +33,9 @@ Connecting to a ledger, and printing out all create events that ``Alice`` can se
 
    async def main():
       async with dazl.connect(url='localhost:6865', read_as='Alice') as conn:
-         async for event in conn.creates():
-            print(event.contract_id, event.payload)
+         async with conn.query('*') as stream:
+            async for event in stream.creates():
+               print(event.contract_id, event.payload)
 
    # Python 3.7+ or later
    asyncio.run(main())


### PR DESCRIPTION
docs: There is a problem with the docs under `dazl.ledger` (see https://discuss.daml.com/t/cannot-run-dazl-introductury-example/3503/2); this fixes that problem.

A longer term fix would be more in the style of #293 (moving the sample code to a file under unit tests), but I don't want to leave incorrect information out there.