### PR TITLE
meta: Upgrade all fixtures and samples to Daml Connect 1.17.1.

### DIFF
--- a/.circleci/install-daml
+++ b/.circleci/install-daml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -xeuo pipefail
 
-version=1.17.0
+version=1.17.1
 
 function install {
     if ! link ; then

--- a/_fixtures/src/all-kinds-of/AllKindsOf.daml
+++ b/_fixtures/src/all-kinds-of/AllKindsOf.daml
@@ -1,8 +1,7 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
-module AllKindsOf
-
-where
+module AllKindsOf where
 
 import DA.TextMap
 

--- a/_fixtures/src/all-kinds-of/daml.yaml
+++ b/_fixtures/src/all-kinds-of/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: all-kinds-of
 version: 1.0.0
 source: AllKindsOf.daml

--- a/_fixtures/src/all-party/AllParty.daml
+++ b/_fixtures/src/all-party/AllParty.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module AllParty where
 

--- a/_fixtures/src/all-party/daml.yaml
+++ b/_fixtures/src/all-party/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: all-party
 version: 1.0.0
 source: AllParty.daml

--- a/_fixtures/src/complicated/Complicated.daml
+++ b/_fixtures/src/complicated/Complicated.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Complicated where
 

--- a/_fixtures/src/complicated/daml.yaml
+++ b/_fixtures/src/complicated/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: complicated
 version: 1.0.0
 source: Complicated.daml

--- a/_fixtures/src/dotted-fields/DottedFields.daml
+++ b/_fixtures/src/dotted-fields/DottedFields.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module DottedFields where
 

--- a/_fixtures/src/dotted-fields/daml.yaml
+++ b/_fixtures/src/dotted-fields/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: dotted-fields
 version: 1.0.0
 source: DottedFields.daml

--- a/_fixtures/src/kitchen-sink/KitchenSink/Customer.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Customer.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module KitchenSink.Customer where
 
 import KitchenSink.Retailer

--- a/_fixtures/src/kitchen-sink/KitchenSink/Retailer.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Retailer.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module KitchenSink.Retailer where
 
 import DA.Set

--- a/_fixtures/src/kitchen-sink/KitchenSink/SKU.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/SKU.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module KitchenSink.SKU where
 
 data SKU = SKU

--- a/_fixtures/src/kitchen-sink/KitchenSink/Supplier.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Supplier.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module KitchenSink.Supplier where
 
 import KitchenSink.SKU

--- a/_fixtures/src/kitchen-sink/KitchenSink/Warehouse.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Warehouse.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module KitchenSink.Warehouse where
 
 import KitchenSink.SKU

--- a/_fixtures/src/kitchen-sink/daml.yaml
+++ b/_fixtures/src/kitchen-sink/daml.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 sdk-version: 1.17.1
 name: kitchen-sink
 version: 1.0.0

--- a/_fixtures/src/map-support/MapSupport.daml
+++ b/_fixtures/src/map-support/MapSupport.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module MapSupport where
 
 import DA.Map

--- a/_fixtures/src/map-support/daml.yaml
+++ b/_fixtures/src/map-support/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 1.17.0
+sdk-version: 1.17.1
 name: map-support
 version: 1.0.0
 source: MapSupport.daml

--- a/_fixtures/src/pending/Pending.daml
+++ b/_fixtures/src/pending/Pending.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Pending where
 

--- a/_fixtures/src/pending/daml.yaml
+++ b/_fixtures/src/pending/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: pending
 version: 1.0.0
 source: Pending.daml

--- a/_fixtures/src/post-office/Main.daml
+++ b/_fixtures/src/post-office/Main.daml
@@ -1,4 +1,6 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module Main where
 
 
@@ -9,6 +11,8 @@ template PostmanRole
     postman : Party
   where
     signatory postman
+    key postman : Party
+    maintainer key
     controller postman can
       nonconsuming InviteParticipant : ()
         with
@@ -200,3 +204,11 @@ template AcknowlegedLetter
     signatory receiver
 
     agreement (show sender) <> " sent" <> content <> " to " <> (show receiver) <> " at " <> (show receiverAddress)
+
+
+template PrivateNote
+  with
+    party : Party
+    text : Text
+  where
+    signatory party

--- a/_fixtures/src/post-office/daml.yaml
+++ b/_fixtures/src/post-office/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: post-office
 version: 1.0.0
 source: Main.daml

--- a/_fixtures/src/same-name-a/SameName.daml
+++ b/_fixtures/src/same-name-a/SameName.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module SameName where
 
 import DA.Action

--- a/_fixtures/src/same-name-a/daml.yaml
+++ b/_fixtures/src/same-name-a/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.13.1
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: same-name-a
 version: 1.0.0
 source: SameName.daml

--- a/_fixtures/src/same-name-b/SameName.daml
+++ b/_fixtures/src/same-name-b/SameName.daml
@@ -1,3 +1,6 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module SameName where
 
 import DA.Action

--- a/_fixtures/src/same-name-b/daml.yaml
+++ b/_fixtures/src/same-name-b/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.13.1
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: same-name-b
 version: 1.0.0
 source: SameName.daml

--- a/_fixtures/src/simple/Simple.daml
+++ b/_fixtures/src/simple/Simple.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Simple where
 

--- a/_fixtures/src/simple/daml.yaml
+++ b/_fixtures/src/simple/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: simple
 version: 1.0.0
 source: Simple.daml

--- a/_fixtures/src/test-server/TestServer.daml
+++ b/_fixtures/src/test-server/TestServer.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module TestServer where
 

--- a/_fixtures/src/test-server/daml.yaml
+++ b/_fixtures/src/test-server/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: test-server
 version: 1.0.0
 source: TestServer.daml

--- a/_fixtures/src/upload-test/UploadTest.daml
+++ b/_fixtures/src/upload-test/UploadTest.daml
@@ -1,10 +1,11 @@
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- UploadTest.daml
 --
 -- This is ONLY used to test DAR uploading functionality. The test that uploads
 -- this DAR assumes it has not been uploaded by any other process before, so it
 -- should only be used for that one test.
-daml 1.2
-
 module UploadTest where
 
 template XYZ

--- a/_fixtures/src/upload-test/daml.yaml
+++ b/_fixtures/src/upload-test/daml.yaml
@@ -1,4 +1,7 @@
-sdk-version: 1.3.0
+# Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sdk-version: 1.17.1
 name: upload-test
 version: 1.0.0
 source: UploadTest.daml

--- a/_fixtures/templates/daml/Address.daml
+++ b/_fixtures/templates/daml/Address.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Address where
 

--- a/_fixtures/templates/daml/LibraryModules.daml
+++ b/_fixtures/templates/daml/LibraryModules.daml
@@ -1,4 +1,6 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 module LibraryModules where
 
 import Address()

--- a/_fixtures/templates/daml/Primitives.daml
+++ b/_fixtures/templates/daml/Primitives.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Primitives where
 

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -473,6 +473,9 @@ class DamlPrettyPrinter(PrettyPrintBase):
         elif PrimType.TEXTMAP == prim_type:
             return self._visit_type_app(("TextMap", *prim.args))
 
+        elif PrimType.GENMAP == prim_type:
+            return self._visit_type_app(("Map", *prim.args))
+
         elif PrimType.TYPE_REP == prim.prim:
             return "???"
 

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -9,4 +9,4 @@ from .dars import Pending
 def test_get_sdk_version():
     with DarFile(Pending) as dar:
         print(dar.manifest())
-        assert "1.3.0" == dar.sdk_version()
+        assert "1.17.1" == dar.sdk_version()

--- a/python/tests/unit/test_pkg_loader_do_with_retry.py
+++ b/python/tests/unit/test_pkg_loader_do_with_retry.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from dazl.damlast import DarFile
 from dazl.damlast.daml_lf_1 import PackageRef, TypeConName
 from dazl.damlast.errors import NameNotFoundError
@@ -13,8 +15,16 @@ import pytest
 from .dars import AllKindsOf
 
 ALL_KINDS_OF_PKG_REF = PackageRef(
-    "e32da8a173e9667e1cd6557a12bf3edbbb6e5a9eb017c3363280ba0b22100bc4"
+    "df817e6b917d544c4352a6872cc87b20631ac573ed9d8812ca3610acf62f32b0"
 )
+
+
+def test_pkg_ref_up_to_date():
+    from .dars import AllKindsOf
+
+    with DarFile(AllKindsOf) as dar:
+        logging.info("package IDs in AllKindsOf: %s", dar.package_ids())
+        assert ALL_KINDS_OF_PKG_REF in dar.package_ids()
 
 
 class PackageLoaderTest:

--- a/python/tests/unit/test_static_dump.py
+++ b/python/tests/unit/test_static_dump.py
@@ -4,12 +4,12 @@
 from dazl import LOG, async_network
 import pytest
 
-from .dars import PostOffice
+from .dars import Simple
 
 
 @pytest.mark.asyncio
 async def test_static_dump_and_tail(sandbox):
-    async with async_network(url=sandbox, dars=PostOffice) as network:
+    async with async_network(url=sandbox, dars=Simple) as network:
         client = network.aio_new_party()
         seen_contracts = []
 
@@ -27,6 +27,9 @@ async def test_static_dump_and_tail(sandbox):
         await client.ready()
 
         for i in range(0, 5):
-            await client.create("Main:PostmanRole", {"postman": client.party})
+            await client.create(
+                "Simple:OperatorNotification",
+                {"operator": client.party, "theObservers": [], "text": "Something"},
+            )
 
     assert len(seen_contracts) == 5

--- a/python/tests/unit/test_template_filtering.py
+++ b/python/tests/unit/test_template_filtering.py
@@ -27,14 +27,13 @@ async def test_template_filtering(sandbox):
                 CreateCommand("AllParty:PrivateContract", {"someParty": party}),
                 CreateCommand("AllParty:PrivateContract", {"someParty": party}),
                 CreateCommand("Main:PostmanRole", {"postman": party}),
-                CreateCommand("Main:PostmanRole", {"postman": party}),
             ]
         )
 
-        # The ACS should only contain the five contracts we created: two from Post Office, and three
+        # The ACS should only contain the five contracts we created: one from Post Office, and three
         # from AllKindsOf.
         contracts = client.find_active("*")
-        assert len(contracts) == 5
+        assert len(contracts) == 4
 
     # Now create a new client to the same sandbox, but with less DARs
     async with async_network(url=sandbox, dars=[PostOffice]) as network:
@@ -46,4 +45,4 @@ async def test_template_filtering(sandbox):
         # The ACS should only contain the two contracts we created that were part of the Post Office
         # model.
         contracts = client.find_active("*")
-        assert len(contracts) == 2
+        assert len(contracts) == 1

--- a/samples/hello-world/daml.yaml
+++ b/samples/hello-world/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.25
+sdk-version: 1.17.1
 name: hello-world
 source: src/daml
 version: 1.0.0

--- a/samples/hello-world/src/daml/Sample.daml
+++ b/samples/hello-world/src/daml/Sample.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Sample where
 

--- a/samples/hello-world/src/daml/SampleTest.daml
+++ b/samples/hello-world/src/daml/SampleTest.daml
@@ -1,4 +1,5 @@
-daml 1.2
+-- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module SampleTest where
 

--- a/samples/ping-pong/daml.yaml
+++ b/samples/ping-pong/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.13.12
+sdk-version: 1.17.1
 name: pingpong
 source: daml/PingPong.daml
 parties:

--- a/samples/ping-pong/daml/PingPong.daml
+++ b/samples/ping-pong/daml/PingPong.daml
@@ -1,7 +1,6 @@
 -- Copyright (c) 2017-2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-daml 1.2
 module PingPong where
 
 template Ping


### PR DESCRIPTION
meta: Upgrade all fixtures and samples to Daml Connect 1.17.1.