### PR TITLE
meta: Fix a broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dazl
 ====
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/digital-asset/dazl-client/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/digital-asset/dazl-client/blob/main/LICENSE)
 <a href="https://circleci.com/gh/digital-asset/dazl-client">
 <img src="https://circleci.com/gh/digital-asset/dazl-client.svg?style=svg">
 </a>


### PR DESCRIPTION
meta: Fix a link broken by the recent `master` -> `main` rename.