### PR TITLE
meta: Correct a configuration error that prevented Daml 2.0 tests from actually running.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,6 @@ jobs:
     parameters:
       python_version:
         type: string
-      daml_sdk_version:
-        type: string
     docker:
       - image: cimg/python:<<parameters.python_version>>-browsers
     resource_class: medium+
@@ -69,13 +67,9 @@ jobs:
           python_version: <<parameters.python_version>>
       - run:
           name: Python unit tests
-          env:
-            DAML_SDK_VERSION: <<parameters.daml_sdk_version>>
           command: make python-unit-test
       - run:
           name: Python integration tests
-          env:
-            DAML_SDK_VERSION: <<parameters.daml_sdk_version>>
           command: make python-integration-test
       - run:
           name: Python packaging
@@ -127,7 +121,6 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.6.13", "3.7.12", "3.8.12", "3.9.10", "3.10.2"]
-              daml_sdk_version: ["1.18.1", "2.0.0"]
       - build:
           requires:
            - blackduck

--- a/_fixtures/scripts/generate.py
+++ b/_fixtures/scripts/generate.py
@@ -33,7 +33,7 @@ dependencies: []
 #!/bin/sh
 
 mkdir -p {artifact_dar.parent}
-(cd {target} && daml build -o {artifact_dar})
+(cd {target} && DAML_SDK_VERSION= daml build -o {artifact_dar})
 '''.lstrip())
     (target / 'build.sh').chmod(0o755)
 

--- a/_fixtures/src/all-kinds-of/AllKindsOf.daml
+++ b/_fixtures/src/all-kinds-of/AllKindsOf.daml
@@ -38,9 +38,10 @@ template OneOfEverything
   where
     signatory operator
 
-    controller operator can
-        Accept: ()
-            do return ()
+    choice Accept : ()
+      controller operator
+        do
+          return ()
 
 
 template MappyContract

--- a/_fixtures/src/complicated/Complicated.daml
+++ b/_fixtures/src/complicated/Complicated.daml
@@ -28,20 +28,23 @@ template OperatorRole
     operator: Party
   where
     signatory operator
-    controller operator can
-      nonconsuming PublishEmpty : ContractId OperatorEmptyNotification
+
+    nonconsuming choice PublishEmpty : ContractId OperatorEmptyNotification
+      controller operator
         do
           create OperatorEmptyNotification with operator
 
-      nonconsuming PublishFormula : ContractId OperatorFormulaNotification
-        with
-          formula : Formula Text
+    nonconsuming choice PublishFormula : ContractId OperatorFormulaNotification
+      with
+        formula : Formula Text
+      controller operator
         do
           create OperatorFormulaNotification with operator; formula
 
-      nonconsuming PublishMoreContrived : ContractId OperatorContrivedNotification
-        with
-          contrived : MoreContrived [Int]
+    nonconsuming choice PublishMoreContrived : ContractId OperatorContrivedNotification
+      with
+        contrived : MoreContrived [Int]
+      controller operator
         do
           create OperatorContrivedNotification with operator; contrived
 

--- a/_fixtures/src/kitchen-sink/KitchenSink/Customer.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Customer.daml
@@ -39,31 +39,33 @@ template Cart
 
     ensure all (>0) $ M.values contents 
 
-    controller customer can
-      Add : ContractId Cart
-        with
-          moreContents : M.Map SKU Int
+    choice Add : ContractId Cart
+      with
+        moreContents : M.Map SKU Int
+      controller customer
         do
           create Cart with contents = combineCart 1 contents moreContents; ..
 
-      Remove : ContractId Cart
-        with
-          unwantedContents : M.Map SKU Int
+    choice Remove : ContractId Cart
+      with
+        unwantedContents : M.Map SKU Int
+      controller customer
         do
           create Cart with contents = combineCart (-1) contents unwantedContents; ..
 
-      Finish : ContractId Order
-        with
-          -- | This is the payment amount for the order. If this weren't a test case DAR,
-          -- this might need to be a more complicated representation. But for now we'll assume
-          -- a currency with two digits after the decimal point.
-          payment : Numeric 2
-          expedite : Bool
+    choice Finish : ContractId Order
+      with
+        -- | This is the payment amount for the order. If this weren't a test case DAR,
+        -- this might need to be a more complicated representation. But for now we'll assume
+        -- a currency with two digits after the decimal point.
+        payment : Numeric 2
+        expedite : Bool
+      controller customer
         do
           create Order with ..
 
-    controller retailer can
-      Cancel : ()
+    choice Cancel : ()
+      controller retailer
         do
           pure ()
 

--- a/_fixtures/src/kitchen-sink/KitchenSink/Supplier.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Supplier.daml
@@ -28,12 +28,13 @@ template Item
     key SKU with .. : SKU
     maintainer key.supplier
 
-    controller supplier can
-      Remove : ()
+    choice Remove : ()
+      controller supplier
         do
           assertEq state Draft
 
-      nonconsuming Activate : ContractId Item
+    nonconsuming choice Activate : ContractId Item
+      controller supplier
         do
           if state == Retired then
             return self
@@ -41,7 +42,8 @@ template Item
             archive self
             create this with state = Retired
 
-      nonconsuming RetireOrRemove : Either () (ContractId Item)
+    nonconsuming choice RetireOrRemove : Either () (ContractId Item)
+      controller supplier
         do
           case state of
             Draft -> Left <$> archive self
@@ -50,10 +52,11 @@ template Item
               Right <$> create this with state = Retired
             Retired -> Right <$> pure self
 
-      nonconsuming CreateShipment : ContractId SupplierDelivery
-        with
-          warehouse : Party
-          quantity : Int
+    nonconsuming choice CreateShipment : ContractId SupplierDelivery
+      with
+        warehouse : Party
+        quantity : Int
+      controller supplier
         do
           create SupplierDelivery with sku = SKU with .. ; ..
 
@@ -68,14 +71,15 @@ template SupplierDelivery
     signatory sku.supplier
     observer warehouse
     
-    controller warehouse can
-      Accept : ContractId WarehouseStock
+    choice Accept : ContractId WarehouseStock
+      controller warehouse
         do
           addStock warehouse sku quantity
 
-      Reject : ContractId ReturnedInventory
-        with
-          reason : Text
+    choice Reject : ContractId ReturnedInventory
+      with
+        reason : Text
+      controller warehouse
         do
           create ReturnedInventory with ..
 
@@ -91,7 +95,7 @@ template ReturnedInventory
     signatory warehouse
     observer sku.supplier
 
-    controller sku.supplier can
-      Dispose : ()
+    choice Dispose : ()
+      controller sku.supplier
         do
           pure ()

--- a/_fixtures/src/kitchen-sink/KitchenSink/Warehouse.daml
+++ b/_fixtures/src/kitchen-sink/KitchenSink/Warehouse.daml
@@ -14,15 +14,16 @@ template Warehouse
     signatory warehouse
     observer suppliers
     
-    choice AddStock : ContractId WarehouseStock with
+    choice AddStock : ContractId WarehouseStock
+      with
         sku : SKU
         quantity : Int
       controller sku.supplier
-      do
-        optCid <- lookupByKey @WarehouseRetailer (warehouse, sku.supplier)
-        case optCid of
-          None -> abort $ "unknown supplier: " <> (show sku.supplier)
-          Some cid -> addStock warehouse sku quantity
+        do
+          optCid <- lookupByKey @WarehouseRetailer (warehouse, sku.supplier)
+          case optCid of
+            None -> abort $ "unknown supplier: " <> (show sku.supplier)
+            Some cid -> addStock warehouse sku quantity
 
 
 template WarehouseStock

--- a/_fixtures/src/pending/Pending.daml
+++ b/_fixtures/src/pending/Pending.daml
@@ -14,8 +14,8 @@ template Counter
     key owner: Party
     maintainer key
 
-    controller owner can
-      Increment: ContractId Counter
+    choice Increment: ContractId Counter
+      controller owner
         do
           create Counter with owner; value = value + 1
 
@@ -25,10 +25,11 @@ template AccountRequest
     owner: Party
   where
     signatory [owner]
-    controller owner can
-      CreateAccount: ContractId Account
-        with
-          accountId : Int
+
+    choice CreateAccount: ContractId Account
+      with
+        accountId : Int
+      controller owner
         do
           create Account with owner; accountId
 

--- a/_fixtures/src/post-office/Main.daml
+++ b/_fixtures/src/post-office/Main.daml
@@ -13,10 +13,11 @@ template PostmanRole
     signatory postman
     key postman : Party
     maintainer key
-    controller postman can
-      nonconsuming InviteParticipant : ()
-        with
-          party : Party; address: Text
+
+    nonconsuming choice InviteParticipant : ()
+      with
+        party : Party; address: Text
+      controller postman
         do
           create InviteAuthorRole with postman; author = party
           create InviteReceiverRole with postman; receiver = party; address
@@ -28,11 +29,13 @@ template AuthorRole
     author: Party
   where
     signatory postman
-    controller author can
-      nonconsuming CreateLetter : ContractId UnsortedLetter
-        with
-          address : Text
-          content : Text
+    observer author
+
+    nonconsuming choice CreateLetter : ContractId UnsortedLetter
+      with
+        address : Text
+        content : Text
+      controller author
         do
           create UnsortedLetter
             with
@@ -41,10 +44,11 @@ template AuthorRole
               address
               content
 
-      nonconsuming CreateIntLetter : ContractId UnsortedLetter
-        with
-          address : Text
-          content : Int
+    nonconsuming choice CreateIntLetter : ContractId UnsortedLetter
+      with
+        address : Text
+        content : Int
+      controller author
         do
           create UnsortedLetter
             with
@@ -53,10 +57,11 @@ template AuthorRole
               address
               content = (show content)
 
-      nonconsuming CreateDecimalLetter : ContractId UnsortedLetter
-        with
-          address : Text
-          content : Decimal
+    nonconsuming choice CreateDecimalLetter : ContractId UnsortedLetter
+      with
+        address : Text
+        content : Decimal
+      controller author
         do
           create UnsortedLetter
             with
@@ -65,10 +70,11 @@ template AuthorRole
               address
               content = (show content)
 
-      nonconsuming CreateTimeLetter : ContractId UnsortedLetter
-        with
-          address : Text
-          content : Time
+    nonconsuming choice CreateTimeLetter : ContractId UnsortedLetter
+      with
+        address : Text
+        content : Time
+      controller author
         do
           create UnsortedLetter
             with
@@ -77,10 +83,11 @@ template AuthorRole
               address
               content = (show content)
 
-      nonconsuming CreateListIntLetter : ContractId UnsortedLetter
-        with
-          address : Text
-          content : [Int]
+    nonconsuming choice CreateListIntLetter : ContractId UnsortedLetter
+      with
+        address : Text
+        content : [Int]
+      controller author
         do
           create UnsortedLetter
             with
@@ -96,10 +103,12 @@ template ReceiverRole
     address : Text
   where
     signatory postman
-    controller receiver can
-      AcceptLetter : ContractId AcknowlegedLetter
-        with
-          sentLetterCid : ContractId SentLetter
+    observer receiver
+
+    choice AcceptLetter : ContractId AcknowlegedLetter
+      with
+        sentLetterCid : ContractId SentLetter
+      controller receiver
         do
           sentLetterCid2 <- fetch sentLetterCid
           assert $ sentLetterCid2.receiver == receiver
@@ -112,8 +121,8 @@ template ReceiverRole
               receiverAddress = address
               content = sentLetterCid2.content
 
-    controller postman can
-      Deactivate : ()
+    choice Deactivate : ()
+      controller postman
         do
           assert $ postman == postman
 
@@ -123,8 +132,10 @@ template InviteAuthorRole
     author : Party
   where
     signatory postman
-    controller author can
-      AcceptInviteAuthorRole : ContractId AuthorRole
+    observer author
+
+    choice AcceptInviteAuthorRole : ContractId AuthorRole
+      controller author
         do
           create AuthorRole with postman; author
 
@@ -135,8 +146,10 @@ template InviteReceiverRole
     address : Text
   where
     signatory postman
-    controller receiver can
-      AcceptInviteReceiverRole : ContractId ReceiverRole
+    observer receiver
+
+    choice AcceptInviteReceiverRole : ContractId ReceiverRole
+      controller receiver
         do
           create ReceiverRole with postman; receiver; address
 
@@ -150,10 +163,12 @@ template UnsortedLetter
     content : Text
   where
     signatory sender
-    controller postman can
-      Sort : ContractId SortedLetter
-        with
-          receiverCid : ContractId ReceiverRole
+    observer postman
+
+    choice Sort : ContractId SortedLetter
+      with
+        receiverCid : ContractId ReceiverRole
+      controller postman
         do
           receiverCid2 <- fetch receiverCid
           assert $ receiverCid2.address == address
@@ -176,8 +191,10 @@ template SortedLetter
     content : Text
   where
     signatory sender
-    controller postman can
-      Deliver : ContractId SentLetter
+    observer postman
+
+    choice Deliver : ContractId SentLetter
+      controller postman
         do
           create SentLetter with sender; receiver; receiverAddress; content
 
@@ -189,8 +206,10 @@ template SentLetter
     content : Text
   where
     signatory sender
-    controller receiver can
-      AcceptSentLetter : ContractId AcknowlegedLetter
+    observer receiver
+
+    choice AcceptSentLetter : ContractId AcknowlegedLetter
+      controller receiver
         do
           create AcknowlegedLetter with sender; receiver; receiverAddress; content
 

--- a/_fixtures/src/same-name-a/SameName.daml
+++ b/_fixtures/src/same-name-a/SameName.daml
@@ -29,11 +29,11 @@ template Publisher
   where
     signatory publisher
 
-    controller publisher can
-      PublishBook : [ContractId Book]
-        with
-          draft: Draft
-          copies: Int
+    choice PublishBook : [ContractId Book]
+      with
+        draft: Draft
+        copies: Int
+      controller publisher
         do
           replicateA copies $ create Book
             with
@@ -56,10 +56,11 @@ template Author
     author: Party
   where
     signatory author
-    controller author can
-      RequestRelationship: ContractId PublisherAuthorRelationshipRequest
-        with
-          publisher: Party
+
+    choice RequestRelationship: ContractId PublisherAuthorRelationshipRequest
+      with
+        publisher: Party
+      controller author
         do
           create PublisherAuthorRelationshipRequest with ..
 
@@ -70,11 +71,13 @@ template PublisherAuthorRelationshipRequest
     author: Party
   where
     signatory author
-    controller publisher can
-      Accept : ContractId PublisherAuthorRelationship
+
+    choice Accept : ContractId PublisherAuthorRelationship
+      controller publisher
         do
           create PublisherAuthorRelationship with ..
 
-      Reject : ()
+    choice Reject : ()
+      controller publisher
         do
           pure ()

--- a/_fixtures/src/same-name-b/SameName.daml
+++ b/_fixtures/src/same-name-b/SameName.daml
@@ -29,11 +29,11 @@ template Publisher
   where
     signatory publisher
 
-    controller publisher can
-      PublishBook : [ContractId Book]
-        with
-          draft: Draft
-          copies: Int
+    choice PublishBook : [ContractId Book]
+      with
+        draft: Draft
+        copies: Int
+      controller publisher
         do
           replicateA copies $ create Book
             with
@@ -57,10 +57,11 @@ template Author
     name: Text
   where
     signatory author
-    controller author can
-      RequestRelationship: ContractId PublisherAuthorRelationshipRequest
-        with
-          publisher: Party
+
+    choice RequestRelationship: ContractId PublisherAuthorRelationshipRequest
+      with
+        publisher: Party
+      controller author
         do
           create PublisherAuthorRelationshipRequest with ..
 
@@ -71,11 +72,13 @@ template PublisherAuthorRelationshipRequest
     author: Party
   where
     signatory author
-    controller publisher can
-      Accept : ContractId PublisherAuthorRelationship
+
+    choice Accept : ContractId PublisherAuthorRelationship
+      controller publisher
         do
           create PublisherAuthorRelationship with ..
 
-      Reject : ()
+    choice Reject : ()
+      controller publisher
         do
           pure ()

--- a/_fixtures/src/simple/Simple.daml
+++ b/_fixtures/src/simple/Simple.daml
@@ -8,19 +8,21 @@ template OperatorRole
     operator: Party
   where
     signatory operator
-    controller operator can
-      nonconsuming Publish: ContractId OperatorNotification
-        with
-          text : Text
+
+    choice Publish : ContractId OperatorNotification
+      with
+       text : Text
+      controller operator
         do
           create OperatorNotification with
             operator
             theObservers = []
             text
 
-      nonconsuming PublishMany: [ContractId OperatorNotification]
-        with
-          count : Int
+    nonconsuming choice PublishMany : [ContractId OperatorNotification]
+      with
+        count : Int
+      controller operator
         do
           mapA (\i -> create OperatorNotification with
             operator
@@ -37,10 +39,10 @@ template OperatorNotification
     signatory operator
     observer theObservers
 
-    controller operator can
-      Share: ContractId OperatorNotification
-        with
-          sharingParty: Party
+    choice Share : ContractId OperatorNotification
+      with
+        sharingParty: Party
+      controller operator
         do
           create OperatorNotification with
             operator

--- a/_fixtures/src/test-server/TestServer.daml
+++ b/_fixtures/src/test-server/TestServer.daml
@@ -3,6 +3,8 @@
 
 module TestServer where
 
+import Daml.Script
+
 template Person
   with
     party: Party
@@ -27,31 +29,3 @@ template Message
   where
     signatory sender
     observer receiver
-
-
-test_server = scenario do
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
-  carol <- getParty "Carol"
-
-  alice_cid <- submit alice do
-    create Person with party = alice
-  submit bob do
-    create Person with party = bob
-  submit carol do
-    create Person with party = carol
-  
-  submit alice do
-    exercise alice_cid SayHello with
-      receiver = bob
-      text = "hi from Alice"
-    exercise alice_cid SayHello with
-      receiver = carol
-      text = "hi from Alice"
-  
-  submit carol do
-    exerciseByKey @Person carol SayHello with
-      receiver = alice
-      text = "hi from Carol"
-
-  return ()

--- a/_fixtures/src/test-server/TestServerTest.daml
+++ b/_fixtures/src/test-server/TestServerTest.daml
@@ -1,0 +1,38 @@
+-- Copyright (c) 2017-2022, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module TestServerTest where
+
+import Daml.Script
+
+import TestServer
+
+test_server : Script ()
+test_server = do
+  alice <- allocateParty "Alice"
+  bob <- allocateParty "Bob"
+  carol <- allocateParty "Carol"
+
+  alice_cid <- submit alice do
+    createCmd Person with party = alice
+  submit bob do
+    createCmd Person with party = bob
+  submit carol do
+    createCmd Person with party = carol
+  
+  submit alice do
+    exerciseCmd alice_cid SayHello with
+      receiver = bob
+      text = "hi from Alice"
+
+  submit alice do
+    exerciseCmd alice_cid SayHello with
+      receiver = carol
+      text = "hi from Alice"
+  
+  submit carol do
+    exerciseByKeyCmd @Person carol SayHello with
+      receiver = alice
+      text = "hi from Carol"
+
+  pure ()

--- a/_fixtures/src/test-server/daml.yaml
+++ b/_fixtures/src/test-server/daml.yaml
@@ -8,3 +8,4 @@ source: TestServer.daml
 dependencies:
 - daml-prim
 - daml-stdlib
+- daml-script

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -7,10 +7,8 @@ from typing import Generator
 from dazl import testing
 import pytest
 
-DEFAULT_SDK_VERSION = "1.17.0"
 
-
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", params=["1.18.1", "2.0.0"])
 def sandbox() -> "Generator[str, None, None]":
     """
     Run an instance of the Sandbox, or use one configured through environment variables.

--- a/python/tests/unit/test_pkg_loader_do_with_retry.py
+++ b/python/tests/unit/test_pkg_loader_do_with_retry.py
@@ -15,7 +15,7 @@ import pytest
 from .dars import AllKindsOf
 
 ALL_KINDS_OF_PKG_REF = PackageRef(
-    "7a40787b503cc6a38ebb8b98d8c442c3a7e26ee79c6f16eb59b752fc31fee7a7"
+    "9951a03af2a6cd1a1a9d15d8094bdca0c680290a896b4b9d943b2294b8bf1476"
 )
 
 

--- a/python/tests/unit/test_protocol_ledgerapi.py
+++ b/python/tests/unit/test_protocol_ledgerapi.py
@@ -26,14 +26,14 @@ async def test_protocol_ledger_api(sandbox):
         # postman inviting participants may not yet have been observed by the clients. Instead, use
         # stream() since it remains open until explicitly closed. We break the never-ending iterator
         # as soon as we see one of each contract.
-        async with p1.connection.stream("Main:InviteAuthorRole") as query:
-            async for event in query:
+        async with p1.connection.stream("Main:InviteAuthorRole") as stream:
+            async for event in stream.creates():
                 result = await p1.connection.exercise(event.contract_id, "AcceptInviteAuthorRole")
                 logging.info("The result of AcceptInviteAuthorRole: %s", result)
                 break
 
-        async with p1.connection.stream("Main:InviteReceiverRole") as query:
-            async for event in query:
+        async with p1.connection.stream("Main:InviteReceiverRole") as stream:
+            async for event in stream.creates():
                 result = await p1.connection.exercise(event.contract_id, "AcceptInviteReceiverRole")
                 logging.info("The result of AcceptInviteReceiverRole: %s", result)
                 break

--- a/scripts/make/dars
+++ b/scripts/make/dars
@@ -21,7 +21,7 @@ do
   case "${1}" in
   -M)
     echo "${dar}: ${daml_yaml} $(find "${daml_dir}" -name '*.daml' -type f | tr '\n' ' ')"
-    echo "	cd \"${daml_dir}\" && daml build"
+    echo "	cd \"${daml_dir}\" && DAML_SDK_VERSION=1.18.1 daml build"
     echo ""
     ;;
   -d)


### PR DESCRIPTION
meta: Correct a configuration error that prevented Daml 2.0 tests from actually running.

Also addressed:
* rewrote the Daml models to use Daml 2.0 syntax

#### Notes

In #329, I accidentally used `env` instead of `environment` in the CircleCI config file, which meant the dual-SDK-version tests weren't running as expected.

After fixing the initial error, I played around with a few different ways of triggering the tests (including tests that are, by design, supposed to only work with one or the other version). I stumbled across parameterized fixtures, which also solves nicely for being able to run the tests locally, so I switched to that instead.