### PR TITLE
python: Have every file treat type annotations properly when there are forward references to types.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ protoc-gen-dazl-python = '_dazl_pb.plugin_python:main'
 line-length = 100
 
 [tool.isort]
+add_imports = ["from __future__ import annotations"]
 combine_as_imports = true
 combine_star = true
 force_sort_within_sections = true

--- a/python/_dazl_pb/collections.py
+++ b/python/_dazl_pb/collections.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections import defaultdict
 import sys
 from types import MappingProxyType

--- a/python/_dazl_pb/plugin_python/__init__.py
+++ b/python/_dazl_pb/plugin_python/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ..protoc import protoc_plugin
 from .plugin import run_all_plugins
 

--- a/python/_dazl_pb/plugin_python/plugin.py
+++ b/python/_dazl_pb/plugin_python/plugin.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
 
 from . import plugin_grpc, plugin_grpc_pyi, plugin_init, plugin_pb, plugin_pb_pyi

--- a/python/_dazl_pb/plugin_python/plugin_grpc.py
+++ b/python/_dazl_pb/plugin_python/plugin_grpc.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
 
 from .. import protoc, util

--- a/python/_dazl_pb/plugin_python/plugin_grpc_pyi.py
+++ b/python/_dazl_pb/plugin_python/plugin_grpc_pyi.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from io import StringIO
 import os
 from typing import TextIO

--- a/python/_dazl_pb/plugin_python/plugin_init.py
+++ b/python/_dazl_pb/plugin_python/plugin_init.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections import defaultdict
 from io import StringIO
 from os.path import basename, dirname, splitext

--- a/python/_dazl_pb/plugin_python/plugin_pb.py
+++ b/python/_dazl_pb/plugin_python/plugin_pb.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
 
 from .. import protoc, util

--- a/python/_dazl_pb/plugin_python/plugin_pb_pyi.py
+++ b/python/_dazl_pb/plugin_python/plugin_pb_pyi.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from io import StringIO
 from itertools import product
 import json

--- a/python/_dazl_pb/protoc/__init__.py
+++ b/python/_dazl_pb/protoc/__init__.py
@@ -24,6 +24,8 @@ To create a Protobuf plugin in Python, define an entrypoint as so:
        return response
 """
 
+from __future__ import annotations
+
 from functools import wraps
 import os
 from pathlib import Path

--- a/python/_dazl_pb/protoc/__main__.py
+++ b/python/_dazl_pb/protoc/__main__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from . import main
 
 main()

--- a/python/_dazl_pb/syntax/__init__.py
+++ b/python/_dazl_pb/syntax/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from . import python
 
 __all__ = ["python"]

--- a/python/_dazl_pb/syntax/python/__init__.py
+++ b/python/_dazl_pb/syntax/python/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ._basic import all_decl
 from .imports import ImportContext, rewrite_file_content
 from .pb import py_message_package, py_scalar_type, py_service_package

--- a/python/_dazl_pb/syntax/python/_basic.py
+++ b/python/_dazl_pb/syntax/python/_basic.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from io import StringIO
 from typing import Iterable
 

--- a/python/_dazl_pb/syntax/python/imports.py
+++ b/python/_dazl_pb/syntax/python/imports.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections import defaultdict
 from io import StringIO
 import re

--- a/python/_dazl_pb/syntax/python/pb.py
+++ b/python/_dazl_pb/syntax/python/pb.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
 from typing import Optional
 

--- a/python/_dazl_pb/syntax/python/symbols.py
+++ b/python/_dazl_pb/syntax/python/symbols.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import Dict, List, Tuple, Union
 

--- a/python/_dazl_pb/syntax/python/types.py
+++ b/python/_dazl_pb/syntax/python/types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Collection, Mapping, Optional
 
 from ...collections import merge

--- a/python/_dazl_pb/util/__init__.py
+++ b/python/_dazl_pb/util/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
 
 __all__ = ["with_file_header", "services_only"]

--- a/python/dazl/__init__.py
+++ b/python/dazl/__init__.py
@@ -4,6 +4,8 @@
 """
 This module contains the Python API for interacting with the Ledger API.
 """
+from __future__ import annotations
+
 from ast import literal_eval
 from configparser import ConfigParser
 from pathlib import Path

--- a/python/dazl/__main__.py
+++ b/python/dazl/__main__.py
@@ -5,6 +5,8 @@
 Main module that exposes utility functions that can be called directly from the command line.
 """
 
+from __future__ import annotations
+
 from .cli import main
 
 main()

--- a/python/dazl/_logging.py
+++ b/python/dazl/_logging.py
@@ -8,6 +8,8 @@ This is an internal API and not meant to be used directly outside of dazl; symbo
 file may change at any time.
 """
 
+from __future__ import annotations
+
 from functools import partial
 import logging
 import sys
@@ -112,7 +114,7 @@ class TimedLogMessageContext:
                 *self.args,
                 elapsed_ms,
                 exc_info=(exc_type, exc_val, exc_tb),
-                **self.kwargs
+                **self.kwargs,
             )
         else:
             self.logger.log(

--- a/python/dazl/_repr/__init__.py
+++ b/python/dazl/_repr/__init__.py
@@ -6,6 +6,8 @@ Default ``repr`` rules for dazl.
 THIS IS NOT A PUBLIC API, AND ITS CONTENTS ARE SUBJECT TO CHANGE AT ANY TIME!
 """
 
+from __future__ import annotations
+
 import builtins
 from reprlib import Repr
 from typing import Collection

--- a/python/dazl/cli/__init__.py
+++ b/python/dazl/cli/__init__.py
@@ -5,6 +5,8 @@
 Simple command-line handlers.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import List, Sequence
 

--- a/python/dazl/cli/_base.py
+++ b/python/dazl/cli/_base.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from argparse import ArgumentParser
 
 

--- a/python/dazl/cli/ls.py
+++ b/python/dazl/cli/ls.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 
 from .. import LOG, Network

--- a/python/dazl/cli/metadata.py
+++ b/python/dazl/cli/metadata.py
@@ -5,6 +5,8 @@
 This module prints the metadata obtained from a remote server.
 """
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from typing import Collection
 

--- a/python/dazl/cli/tail.py
+++ b/python/dazl/cli/tail.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from asyncio import ensure_future, get_event_loop
 import datetime

--- a/python/dazl/cli/upload.py
+++ b/python/dazl/cli/upload.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Sequence

--- a/python/dazl/cli/version.py
+++ b/python/dazl/cli/version.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from argparse import ArgumentParser
 
 from .. import __version__ as version

--- a/python/dazl/client/__init__.py
+++ b/python/dazl/client/__init__.py
@@ -15,6 +15,8 @@ It provides:
 For a higher-level, more declarative API, see :mod:`dazl.query`.
 """
 
+from __future__ import annotations
+
 from . import config
 from ._base_model import (
     CREATE_IF_MISSING,

--- a/python/dazl/client/_base_model.py
+++ b/python/dazl/client/_base_model.py
@@ -5,6 +5,8 @@
 This model contains definitions for the data classes used at the client layer of this library.
 """
 
+from __future__ import annotations
+
 from enum import IntEnum
 import sys
 from typing import NamedTuple, Optional

--- a/python/dazl/client/_conn_settings.py
+++ b/python/dazl/client/_conn_settings.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import NamedTuple, Optional, Tuple, Union
 from urllib.parse import urlparse
 

--- a/python/dazl/client/_events.py
+++ b/python/dazl/client/_events.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Awaitable, Callable, TypeVar, Union
 
 from ..protocols.events import BaseEvent

--- a/python/dazl/client/_network_client_impl.py
+++ b/python/dazl/client/_network_client_impl.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 from asyncio import Future, ensure_future, gather, sleep, wait_for
 from collections import defaultdict

--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 from asyncio import Future, ensure_future, gather, get_event_loop, sleep, wait
 from concurrent.futures import ALL_COMPLETED

--- a/python/dazl/client/_reader_sync.py
+++ b/python/dazl/client/_reader_sync.py
@@ -6,6 +6,8 @@ Functions for ensuring that readers across different parties remain as close in 
 as practical.
 """
 
+from __future__ import annotations
+
 from asyncio import Future, ensure_future, gather, sleep
 from typing import TYPE_CHECKING, Collection, List, Optional, Tuple
 

--- a/python/dazl/client/_run_level.py
+++ b/python/dazl/client/_run_level.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from threading import Event
 
 from ..scheduler import RunLevel

--- a/python/dazl/client/_writer_verify.py
+++ b/python/dazl/client/_writer_verify.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any
 import warnings
 

--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -17,6 +17,8 @@ This module contains the public API for interacting with the ledger from the per
 specific party.
 """
 
+from __future__ import annotations
+
 from asyncio import Future, ensure_future, get_event_loop
 from contextlib import contextmanager
 from functools import partial, wraps

--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import Future, InvalidStateError, ensure_future, gather, get_event_loop
 from collections import defaultdict
 from dataclasses import dataclass, field, replace

--- a/python/dazl/client/commands.py
+++ b/python/dazl/client/commands.py
@@ -5,6 +5,8 @@ Command types that are used in the dazl v5 API.
 
 These symbols are primarily kept for backwards compatibility.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass, fields
 from datetime import timedelta
 from typing import Any, Collection, List, Mapping, Optional, Sequence, Tuple, Union

--- a/python/dazl/client/config.py
+++ b/python/dazl/client/config.py
@@ -5,11 +5,12 @@
 This module contains configuration parameters used by the rest of the library.
 """
 
+from __future__ import annotations
+
 # We override types in this file LOTS because mypy does not understand what is happening
 # with the ``config_field`` function. There doesn't appear to be a way to describe
 # a dataclasses-like ``field`` function, which is why this config will be dropped
 # in dazl 8's API.
-
 import argparse
 from dataclasses import asdict, dataclass, field, fields
 from typing import (

--- a/python/dazl/client/errors.py
+++ b/python/dazl/client/errors.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Collection, Union
 
 from ..prim import DazlError, DazlWarning, Party

--- a/python/dazl/client/events.py
+++ b/python/dazl/client/events.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any, Callable, Collection, Iterator, TypeVar
 import warnings
 

--- a/python/dazl/client/ledger.py
+++ b/python/dazl/client/ledger.py
@@ -4,6 +4,8 @@
 """
 Types that describe the behavior of the ledger itself.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import warnings

--- a/python/dazl/client/pkg_loader.py
+++ b/python/dazl/client/pkg_loader.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import warnings
 
 from ..ledger.aio.pkgloader_compat import PackageLoader, SyncPackageService

--- a/python/dazl/client/runner.py
+++ b/python/dazl/client/runner.py
@@ -5,6 +5,8 @@
 Simple methods for instantiating an application written against dazl that incorporate common usage
 patterns.
 """
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from typing import Callable
 import warnings

--- a/python/dazl/client/state.py
+++ b/python/dazl/client/state.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import Future, get_event_loop, sleep
 from collections import defaultdict
 from dataclasses import dataclass

--- a/python/dazl/damlast/__init__.py
+++ b/python/dazl/damlast/__init__.py
@@ -41,6 +41,8 @@ encoding and decoding of values, see :mod:`dazl.values`.
 
 """
 
+from __future__ import annotations
+
 from .daml_lf_1 import TypeConName
 from .pkgfile import CachedDarFile, DarFile, get_dar_package_ids
 from .visitor import ExprVisitor, IdentityTypeVisitor, ModuleVisitor, PackageVisitor, TypeVisitor

--- a/python/dazl/damlast/_base.py
+++ b/python/dazl/damlast/_base.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from typing import TypeVar
 
 

--- a/python/dazl/damlast/_builtins_meta.py
+++ b/python/dazl/damlast/_builtins_meta.py
@@ -6,6 +6,8 @@ This module contains supporting infrastructure for built-in method definitions f
 Daml-LF files.
 """
 
+from __future__ import annotations
+
 from typing import Any, Optional, Sequence, Type as PyType, Union
 import warnings
 

--- a/python/dazl/damlast/builtins.py
+++ b/python/dazl/damlast/builtins.py
@@ -6,6 +6,8 @@ Define a few DAML values and functions that have been inlined in Python for effi
 simplicity.
 """
 
+from __future__ import annotations
+
 from typing import Any, Optional, Sequence
 
 from . import daml_types as daml

--- a/python/dazl/damlast/compat.py
+++ b/python/dazl/damlast/compat.py
@@ -10,6 +10,8 @@ deprecated :class:`dazl.model.types.Type` hierarchy to :class:`dazl.damlast.daml
 These functions will be removed WITHOUT an intermediate deprecation warning, as they are considered
 internal only.
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Tuple, Union
 import warnings
 

--- a/python/dazl/damlast/daml_lf_1.py
+++ b/python/dazl/damlast/daml_lf_1.py
@@ -6,6 +6,8 @@ DAML-LF Archive types
 ---------------------
 """
 
+from __future__ import annotations
+
 # NOTE TO IMPLEMENTORS: A future version of this file is intended to be code-generated instead of
 # manually maintained. The makeup of this file is intentionally highly formulaic in order to
 # facilitate a smooth transition to automatically-generated data structures.
@@ -17,7 +19,6 @@ DAML-LF Archive types
 #
 # The few local imports in this file should be inlined by a codegen process instead to keep this
 # file self-contained.
-
 from dataclasses import dataclass
 from enum import IntEnum as _IntEnum
 from io import StringIO

--- a/python/dazl/damlast/daml_types.py
+++ b/python/dazl/damlast/daml_types.py
@@ -7,6 +7,8 @@ DAML Types
 
 Constants and constructor functions for the various primitive DAML types.
 """
+from __future__ import annotations
+
 from typing import Mapping
 
 from .daml_lf_1 import FieldWithType, PrimType, Type, TypeConName, TypeSynName

--- a/python/dazl/damlast/errors.py
+++ b/python/dazl/damlast/errors.py
@@ -9,6 +9,8 @@ Error types
 .. autoclass:: NameNotFoundError
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from ..prim import DazlError

--- a/python/dazl/damlast/eval_scope.py
+++ b/python/dazl/damlast/eval_scope.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from types import MappingProxyType
 from typing import Collection, Mapping, Optional
 import warnings

--- a/python/dazl/damlast/expand.py
+++ b/python/dazl/damlast/expand.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from types import MappingProxyType
 from typing import Collection, Mapping, Optional
 

--- a/python/dazl/damlast/lookup.py
+++ b/python/dazl/damlast/lookup.py
@@ -6,13 +6,14 @@ DAML-LF fast lookups
 --------------------
 """
 
+from __future__ import annotations
+
 # Implementation notes:
 #
 # The code in here is fairly monotonous and boilerplate heavy. However, being too creative here can
 # potentially lead to performance degradations, particularly at application startup where type and
 # template lookups by name are very frequent. Please be conscious of the runtime costs of
 # modifications in this file!
-
 import threading
 from types import MappingProxyType
 from typing import (

--- a/python/dazl/damlast/parse.py
+++ b/python/dazl/damlast/parse.py
@@ -12,6 +12,8 @@ convert it to an :class:`Archive`; an :class:`Archive` contains the package and 
 in turn contain templates, data types, and values.
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from typing import Optional

--- a/python/dazl/damlast/pb_parse.py
+++ b/python/dazl/damlast/pb_parse.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from typing import Any, Dict, List as _List, Optional, Sequence
 
 from .daml_lf_1 import *

--- a/python/dazl/damlast/pkgfile.py
+++ b/python/dazl/damlast/pkgfile.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from io import BytesIO
 from os import PathLike
 from pathlib import Path

--- a/python/dazl/damlast/protocols.py
+++ b/python/dazl/damlast/protocols.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, AbstractSet, Any, Collection
 

--- a/python/dazl/damlast/types.py
+++ b/python/dazl/damlast/types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, Optional, no_type_check
 import warnings
 

--- a/python/dazl/damlast/util.py
+++ b/python/dazl/damlast/util.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Union
 import warnings
 

--- a/python/dazl/damlast/visitor.py
+++ b/python/dazl/damlast/visitor.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Generic, Optional, TypeVar
 
 from .daml_lf_1 import (

--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -5,6 +5,8 @@ This module contains the types needed to submit commands to and read events from
 Daml `gRPC Ledger API <https://docs.daml.com/app-dev/ledger-api.html>`_ or
 `HTTP JSON API <https://docs.daml.com/json-api/index.html>`_.
 """
+from __future__ import annotations
+
 import sys
 
 from .api_types import (

--- a/python/dazl/ledger/__init__.pyi
+++ b/python/dazl/ledger/__init__.pyi
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from datetime import datetime
 from logging import Logger
 from os import PathLike

--- a/python/dazl/ledger/_offsets.py
+++ b/python/dazl/ledger/_offsets.py
@@ -6,6 +6,8 @@ Utilities for working with ledger offsets.
 This API is _not_ public!
 """
 
+from __future__ import annotations
+
 from typing import Any, Optional, Union
 
 __all__ = [

--- a/python/dazl/ledger/_retry.py
+++ b/python/dazl/ledger/_retry.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from asyncio import sleep
 from datetime import datetime, timedelta
 from typing import Awaitable, Callable, TypeVar
@@ -26,7 +28,7 @@ async def retry(
     fn: Callable[[], Awaitable[T]],
     *,
     retry_safe_ex: Callable[[Exception], bool] = is_retryable_exception,
-    timeout: timedelta = DEFAULT_TIMEOUT
+    timeout: timedelta = DEFAULT_TIMEOUT,
 ) -> T:
     a, b = 0, 1
     start = datetime.utcnow()

--- a/python/dazl/ledger/aio/__init__.py
+++ b/python/dazl/ledger/aio/__init__.py
@@ -4,6 +4,8 @@
 `asyncio`-flavored protocols and base classes for connecting to a Daml ledger.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from inspect import iscoroutine
 import sys

--- a/python/dazl/ledger/aio/__init__.pyi
+++ b/python/dazl/ledger/aio/__init__.pyi
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import abc
 from datetime import datetime
 import sys

--- a/python/dazl/ledger/aio/pkgloader.py
+++ b/python/dazl/ledger/aio/pkgloader.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future, gather, get_event_loop, sleep, wait_for
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta

--- a/python/dazl/ledger/aio/pkgloader_compat.py
+++ b/python/dazl/ledger/aio/pkgloader_compat.py
@@ -6,6 +6,8 @@ Backwards compatibility symbols in support of the to-be-removed dazl.client.pkg_
 This file is here in order to avoid import cycles.
 """
 
+from __future__ import annotations
+
 from asyncio import get_event_loop
 from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import timedelta

--- a/python/dazl/ledger/api_types.py
+++ b/python/dazl/ledger/api_types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import abc
 from datetime import datetime
 import sys

--- a/python/dazl/ledger/blocking/__init__.py
+++ b/python/dazl/ledger/blocking/__init__.py
@@ -11,6 +11,8 @@ Thread-blocking protocols and base classes for connecting to a Daml ledger.
 .. autoclass:: QueryStream()
 """
 
+from __future__ import annotations
+
 import sys
 
 from .. import Connection as _Connection, QueryStream as _QueryStream

--- a/python/dazl/ledger/blocking/__init__.pyi
+++ b/python/dazl/ledger/blocking/__init__.pyi
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from datetime import datetime
 import sys
 from typing import AbstractSet, Any, Collection, Iterator, Optional, Sequence, TypeVar, Union

--- a/python/dazl/ledger/blocking/_aiowrapper.py
+++ b/python/dazl/ledger/blocking/_aiowrapper.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import new_event_loop, run_coroutine_threadsafe, set_event_loop, sleep
 from queue import Queue
 from threading import Thread

--- a/python/dazl/ledger/blocking/pkgloader.py
+++ b/python/dazl/ledger/blocking/pkgloader.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import timedelta
 import threading

--- a/python/dazl/ledger/config/__init__.py
+++ b/python/dazl/ledger/config/__init__.py
@@ -112,6 +112,8 @@ The :class:`URLConfig` protocol specifies the ledger implementation that ``dazl`
 
 """
 
+from __future__ import annotations
+
 import itertools
 import logging
 from logging import Logger

--- a/python/dazl/ledger/config/access.py
+++ b/python/dazl/ledger/config/access.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import base64
 from collections.abc import MutableSet as MutableSetBase, Set as SetBase
 import json

--- a/python/dazl/ledger/config/argv.py
+++ b/python/dazl/ledger/config/argv.py
@@ -3,6 +3,8 @@
 """
 Support for exposing dazl's configuration parameters through :mod:`argparse`.
 """
+from __future__ import annotations
+
 import argparse
 from argparse import SUPPRESS, Action, ArgumentParser
 import os

--- a/python/dazl/ledger/config/exc.py
+++ b/python/dazl/ledger/config/exc.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 __all__ = ["ConfigError", "ConfigWarning"]
 
 

--- a/python/dazl/ledger/config/ssl.py
+++ b/python/dazl/ledger/config/ssl.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from logging import Logger
 from os import PathLike, fspath
 from typing import TYPE_CHECKING, Optional

--- a/python/dazl/ledger/config/url.py
+++ b/python/dazl/ledger/config/url.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import timedelta
 import ipaddress
 from logging import Logger, getLogger

--- a/python/dazl/ledger/errors.py
+++ b/python/dazl/ledger/errors.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar

--- a/python/dazl/ledger/grpc/__init__.py
+++ b/python/dazl/ledger/grpc/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ..config import Config
 from .conn_aio import Connection
 

--- a/python/dazl/ledger/grpc/__init__.pyi
+++ b/python/dazl/ledger/grpc/__init__.pyi
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from os import PathLike
 from typing import Collection, Optional, Union
 

--- a/python/dazl/ledger/grpc/channel.py
+++ b/python/dazl/ledger/grpc/channel.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any, AsyncIterable, Callable, Iterable, List, Tuple, TypeVar, Union, cast
 from urllib.parse import urlparse
 

--- a/python/dazl/ledger/grpc/codec_aio.py
+++ b/python/dazl/ledger/grpc/codec_aio.py
@@ -4,13 +4,14 @@
 This module contains the mapping between Protobuf objects and Python/dazl types.
 """
 
+from __future__ import annotations
+
 # Earlier versions of dazl (before v8) had an API that mapped less directly to the gRPC Ledger API.
 # But with the HTTP JSON API, many common ledger methods now have much more direct translations that
 # still manage to adhere quite closely to dazl's historical behavior.
 #
 # References:
 #  * https://github.com/digital-asset/daml/blob/main/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
-
 from collections.abc import Mapping as _Mapping
 from typing import Any, List, Optional, Sequence, Set, Tuple, Union
 

--- a/python/dazl/ledger/grpc/conn_aio.py
+++ b/python/dazl/ledger/grpc/conn_aio.py
@@ -4,6 +4,8 @@
 This module contains the mapping between gRPC calls and Python/dazl types.
 """
 
+from __future__ import annotations
+
 import asyncio
 from datetime import datetime
 from typing import (

--- a/python/dazl/ledger/pkgcache.py
+++ b/python/dazl/ledger/pkgcache.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ..damlast.lookup import MultiPackageLookup
 
 __all__ = ["SHARED_PACKAGE_DATABASE"]

--- a/python/dazl/ledgerutil/__init__.py
+++ b/python/dazl/ledgerutil/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from .acs import ACS
 from .fetch import fetch_first, fetch_last
 

--- a/python/dazl/ledgerutil/acs.py
+++ b/python/dazl/ledgerutil/acs.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 from asyncio import CancelledError, Future, InvalidStateError, ensure_future, get_event_loop, sleep
 from collections.abc import Mapping as MappingBase

--- a/python/dazl/ledgerutil/fetch.py
+++ b/python/dazl/ledgerutil/fetch.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Optional, Union
 
 from ..damlast import TypeConName

--- a/python/dazl/metrics/__init__.py
+++ b/python/dazl/metrics/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from .api import MetricEvents

--- a/python/dazl/metrics/api.py
+++ b/python/dazl/metrics/api.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from datetime import timedelta
 
 from ..prim import Party

--- a/python/dazl/metrics/instrumenters.py
+++ b/python/dazl/metrics/instrumenters.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from asyncio import AbstractEventLoop, get_event_loop
 from datetime import datetime, timedelta
 from typing import Callable, Optional

--- a/python/dazl/metrics/prometheus.py
+++ b/python/dazl/metrics/prometheus.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import TYPE_CHECKING, ClassVar, Optional
 

--- a/python/dazl/model/__init__.py
+++ b/python/dazl/model/__init__.py
@@ -19,6 +19,8 @@ introduced in dazl v5) or :mod:`dazl.protocols` (for the API introduced in dazl 
 
 """
 
+from __future__ import annotations
+
 import warnings
 
 with warnings.catch_warnings():

--- a/python/dazl/model/core.py
+++ b/python/dazl/model/core.py
@@ -5,6 +5,8 @@
 This module has been relocated to ``dazl.client``, ``dazl.damlast``, ``dazl.protocols``, or
 ``dazl.query``.
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypeVar, Union
 import warnings
 

--- a/python/dazl/model/ledger.py
+++ b/python/dazl/model/ledger.py
@@ -4,6 +4,8 @@
 """
 This module has been relocated to ``dazl.client.ledger``.
 """
+from __future__ import annotations
+
 import warnings
 
 from ..client.ledger import LedgerMetadata

--- a/python/dazl/model/lookup.py
+++ b/python/dazl/model/lookup.py
@@ -5,6 +5,8 @@
 This module has been relocated to ``dazl.damlast.lookup``.
 """
 
+from __future__ import annotations
+
 from typing import Iterator, Tuple
 import warnings
 

--- a/python/dazl/model/network.py
+++ b/python/dazl/model/network.py
@@ -5,6 +5,8 @@
 This module has been relocated to ``dazl.client._conn_settings``.
 """
 
+from __future__ import annotations
+
 __all__ = ["HTTPConnectionSettings", "SSLSettings", "OAuthSettings", "connection_settings"]
 
 from ..client._conn_settings import (

--- a/python/dazl/model/reading.py
+++ b/python/dazl/model/reading.py
@@ -6,6 +6,8 @@ This module has been relocated to ``dazl.client.events``, though if possible you
 ``dazl.protocol.events``.
 """
 
+from __future__ import annotations
+
 from ..client._reader_sync import max_offset
 from ..client.events import EventKey, create_dispatch
 from ..protocols.events import (

--- a/python/dazl/model/types.py
+++ b/python/dazl/model/types.py
@@ -27,6 +27,8 @@ system.
 .. autoclass:: VariantType
 .. autoclass:: UnsupportedType
 """
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     AbstractSet,

--- a/python/dazl/model/types_store.py
+++ b/python/dazl/model/types_store.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import reduce

--- a/python/dazl/model/writing.py
+++ b/python/dazl/model/writing.py
@@ -5,6 +5,8 @@
 This module has been relocated to ``dazl.client.commands``, though if possible you should move to
 the command types defined in ``dazl.ledger`` instead.
 """
+from __future__ import annotations
+
 import warnings
 
 from ..client.commands import (

--- a/python/dazl/pretty/__init__.py
+++ b/python/dazl/pretty/__init__.py
@@ -11,6 +11,8 @@ This module contains utilities for pretty-printing various types in dazl.
 .. automodule:: dazl.pretty.util
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Type
 
 from ..damlast.protocols import SymbolLookup

--- a/python/dazl/pretty/_module_builder.py
+++ b/python/dazl/pretty/_module_builder.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from typing import Dict, List, Sequence
 
 from ..damlast.daml_lf_1 import DottedName, Module

--- a/python/dazl/pretty/_render_base.py
+++ b/python/dazl/pretty/_render_base.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
 from io import StringIO
 import json
 from typing import Callable, Dict, Optional, Sequence, Type as TType, Union

--- a/python/dazl/pretty/options.py
+++ b/python/dazl/pretty/options.py
@@ -5,6 +5,8 @@
 This module contains pretty-print/formatting utilities.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/python/dazl/pretty/pygments_daml_lexer.py
+++ b/python/dazl/pretty/pygments_daml_lexer.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pygments.lexer import inherit
 from pygments.lexers.haskell import HaskellLexer
 from pygments.token import Keyword

--- a/python/dazl/pretty/render_csharp.py
+++ b/python/dazl/pretty/render_csharp.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
 from typing import Mapping, Optional, Sequence, Union
 
 from ..damlast.daml_lf_1 import (

--- a/python/dazl/pretty/render_csv.py
+++ b/python/dazl/pretty/render_csv.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
 from io import StringIO
 from typing import Dict, List, Tuple
 

--- a/python/dazl/pretty/render_daml.py
+++ b/python/dazl/pretty/render_daml.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
 from io import StringIO
 from typing import Optional, Sequence, Union
 

--- a/python/dazl/pretty/render_python.py
+++ b/python/dazl/pretty/render_python.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
 
+from __future__ import annotations
+
 from io import StringIO
 from typing import Mapping, Optional, Sequence, Union
 import warnings

--- a/python/dazl/pretty/table/__init__.py
+++ b/python/dazl/pretty/table/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from .fmt_base import DEFAULT_FORMATTER_NAME
 from .write import write_acs

--- a/python/dazl/pretty/table/fmt_base.py
+++ b/python/dazl/pretty/table/fmt_base.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from .model import Formatter
 
 __all__ = ["DEFAULT_FORMATTER_NAME", "get_formatter"]

--- a/python/dazl/pretty/table/fmt_json.py
+++ b/python/dazl/pretty/table/fmt_json.py
@@ -5,6 +5,8 @@
 Formatting module for outputting captures.
 """
 
+from __future__ import annotations
+
 import json
 from typing import AbstractSet, Iterable
 

--- a/python/dazl/pretty/table/fmt_pretty.py
+++ b/python/dazl/pretty/table/fmt_pretty.py
@@ -6,6 +6,8 @@ Pretty print format that orders templates by ID, and attempts to render a more c
 representation.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import AbstractSet, Generator, Iterable, Mapping, Sequence
 

--- a/python/dazl/pretty/table/model.py
+++ b/python/dazl/pretty/table/model.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import AbstractSet, Dict, Iterable, Iterator, List, Optional
 

--- a/python/dazl/pretty/table/write.py
+++ b/python/dazl/pretty/table/write.py
@@ -5,6 +5,8 @@
 This module contains utilities for deterministically outputting contract information.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, TextIO
 
 from .fmt_base import get_formatter

--- a/python/dazl/pretty/util.py
+++ b/python/dazl/pretty/util.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from typing import Sequence
 
 

--- a/python/dazl/prim/__init__.py
+++ b/python/dazl/prim/__init__.py
@@ -6,6 +6,8 @@ Contains primitive declarations and functions for working with "native" Python t
 correspond to types over the Ledger API.
 """
 
+from __future__ import annotations
+
 from .basic import (
     LEDGER_STRING_REGEX,
     NAME_STRING_REGEX,

--- a/python/dazl/prim/basic.py
+++ b/python/dazl/prim/basic.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import re
 from typing import Any, Optional
 

--- a/python/dazl/prim/complex.py
+++ b/python/dazl/prim/complex.py
@@ -6,6 +6,8 @@ Contains functions for working with "native" Python types as they correspond to 
 Ledger API.
 """
 
+from __future__ import annotations
+
 from typing import Any, Dict, Mapping, Tuple
 
 __all__ = ["to_record", "to_variant"]

--- a/python/dazl/prim/contracts.py
+++ b/python/dazl/prim/contracts.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:

--- a/python/dazl/prim/datetime.py
+++ b/python/dazl/prim/datetime.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from functools import partial

--- a/python/dazl/prim/errors.py
+++ b/python/dazl/prim/errors.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 __all__ = ["DazlError", "DazlWarning", "DazlImportError"]
 
 import warnings

--- a/python/dazl/prim/json.py
+++ b/python/dazl/prim/json.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import date, datetime
 from decimal import Decimal
 import json

--- a/python/dazl/prim/map.py
+++ b/python/dazl/prim/map.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 __all__ = ["FrozenDict", "to_hashable"]
 
 

--- a/python/dazl/prim/numbers.py
+++ b/python/dazl/prim/numbers.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from decimal import Decimal
 from typing import Any, Optional
 

--- a/python/dazl/prim/party.py
+++ b/python/dazl/prim/party.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any, Collection, NewType, Sequence, Union, overload
 
 from .basic import to_str

--- a/python/dazl/protocols/__init__.py
+++ b/python/dazl/protocols/__init__.py
@@ -6,5 +6,7 @@ This module contains implementations for the different protocols and serializati
 supported by this client library.
 """
 
+from __future__ import annotations
+
 from ._base import LedgerClient, LedgerConnectionOptions, LedgerNetwork
 from .v1 import grpc

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -6,6 +6,8 @@ This module contains the abstract base class that defines the protocol for inter
 process that implements the Ledger API.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 import threading

--- a/python/dazl/protocols/autodetect.py
+++ b/python/dazl/protocols/autodetect.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime
 from functools import partial
 from threading import Event, RLock, Thread

--- a/python/dazl/protocols/core.py
+++ b/python/dazl/protocols/core.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any, Awaitable, Callable, Collection, Mapping, Optional, Sequence, TypeVar, Union
 
 from ..prim import ContractData, ContractId, Party

--- a/python/dazl/protocols/errors.py
+++ b/python/dazl/protocols/errors.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from ..prim import DazlError
 
 __all__ = [

--- a/python/dazl/protocols/events.py
+++ b/python/dazl/protocols/events.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 # TODO: `automodule reading` directive doesn't appear to work here, have to list each class individually.
 """
 Read-Side Types

--- a/python/dazl/protocols/oauth.py
+++ b/python/dazl/protocols/oauth.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/python/dazl/protocols/serializers.py
+++ b/python/dazl/protocols/serializers.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# This module will likely be deprecated in v8.
+from __future__ import annotations
 
+# This module will likely be deprecated in v8.
 from typing import Any, Sequence
 
 from ..damlast.daml_lf_1 import Type, TypeConName

--- a/python/dazl/protocols/v0/__init__.py
+++ b/python/dazl/protocols/v0/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import warnings
 
 warnings.warn("dazl.protocols.v0 is deprecated", DeprecationWarning, stacklevel=2)

--- a/python/dazl/protocols/v0/json_ser_command.py
+++ b/python/dazl/protocols/v0/json_ser_command.py
@@ -6,6 +6,8 @@ Methods for serializing domain objects and other things into basic primitive
 types over the wire on the REST interface using JSON.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 import warnings

--- a/python/dazl/protocols/v1/grpc.py
+++ b/python/dazl/protocols/v1/grpc.py
@@ -4,6 +4,8 @@
 """
 Support for the gRPC-based Ledger API.
 """
+from __future__ import annotations
+
 from asyncio import gather
 from datetime import datetime
 from threading import Event

--- a/python/dazl/protocols/v1/model/__init__.py
+++ b/python/dazl/protocols/v1/model/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import warnings
 
 warnings.warn(

--- a/python/dazl/protocols/v1/pb_parse_event.py
+++ b/python/dazl/protocols/v1/pb_parse_event.py
@@ -4,6 +4,8 @@
 """
 Conversion methods from Ledger API Protobuf-generated types to dazl/Pythonic types.
 """
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Union, cast

--- a/python/dazl/protocols/v1/pb_parse_metadata.py
+++ b/python/dazl/protocols/v1/pb_parse_metadata.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from typing import (

--- a/python/dazl/protocols/v1/pb_ser_command.py
+++ b/python/dazl/protocols/v1/pb_ser_command.py
@@ -4,6 +4,8 @@
 """
 Conversion methods to Ledger API Protobuf-generated types from dazl/Pythonic types.
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Union
 import warnings
 

--- a/python/dazl/query/__init__.py
+++ b/python/dazl/query/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections.abc import Mapping as MappingABC
 from typing import Any, Callable, Collection, Dict, Mapping, Optional, Union
 
@@ -25,7 +27,7 @@ class Filter:
         self,
         *,
         server_side: Optional[ContractData] = None,
-        client_side: Optional[Callable[[ContractData], bool]] = None
+        client_side: Optional[Callable[[ContractData], bool]] = None,
     ):
         self.server_side = server_side
         self.client_side = client_side

--- a/python/dazl/scheduler/__init__.py
+++ b/python/dazl/scheduler/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ._base import RunLevel, validate_install_signal_handlers
 from ._invoker import Invoker

--- a/python/dazl/scheduler/_base.py
+++ b/python/dazl/scheduler/_base.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
 from threading import current_thread, main_thread
 from typing import Optional

--- a/python/dazl/scheduler/_invoker.py
+++ b/python/dazl/scheduler/_invoker.py
@@ -4,6 +4,8 @@
 The core scheduling of logic, managing the tricky interaction between the man asyncio event loop and
 background threads.
 """
+from __future__ import annotations
+
 from asyncio import CancelledError, Future, InvalidStateError, gather, get_event_loop, wait_for
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta

--- a/python/dazl/scheduler/_invoker.pyi
+++ b/python/dazl/scheduler/_invoker.pyi
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 # Type definitions for _scheduler.py.
 #
 # These type definitions live in a separate file instead of in _scheduler.py because
@@ -9,7 +11,6 @@
 #    "Properly" typing the signatures of these functions would result in a bit of unnecessary and
 #    inaccurate casting in the bodies of these methods.
 #    (See https://github.com/python/typing/issues/446 for more information on this.)
-
 from asyncio import AbstractEventLoop, Future
 from concurrent.futures import Executor
 from typing import Awaitable, Callable, List, Optional, TypeVar, overload

--- a/python/dazl/server/__init__.py
+++ b/python/dazl/server/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from aiohttp import web
 
 from ..client import _NetworkImpl

--- a/python/dazl/server/management.py
+++ b/python/dazl/server/management.py
@@ -5,6 +5,8 @@
 Endpoints for managing parties/bots connected via a dazl client.
 """
 
+from __future__ import annotations
+
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Collection, NoReturn, Optional, Sequence
 import warnings

--- a/python/dazl/server/metrics.py
+++ b/python/dazl/server/metrics.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Collection, Mapping
 

--- a/python/dazl/testing/__init__.py
+++ b/python/dazl/testing/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from ._sandbox import SandboxLauncher
 from .connect import connect_with_new_party
 

--- a/python/dazl/testing/_cert.py
+++ b/python/dazl/testing/_cert.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Collection, Optional
 
 

--- a/python/dazl/testing/_sandbox.py
+++ b/python/dazl/testing/_sandbox.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from asyncio import get_event_loop
 from contextlib import ExitStack
 from datetime import timedelta

--- a/python/dazl/testing/connect.py
+++ b/python/dazl/testing/connect.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import gather
 from os import PathLike
 import sys

--- a/python/dazl/testing/connect.pyi
+++ b/python/dazl/testing/connect.pyi
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections.abc import Sequence as Seq
 from os import PathLike
 import sys
@@ -37,7 +39,7 @@ def connect_with_new_party(
     ledger_id: Optional[str] = None,
     dar: Union[str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
-    display_name: Union[None, str, NameGenFn] = None
+    display_name: Union[None, str, NameGenFn] = None,
 ) -> AsyncContextManager[ConnectionWithParty]: ...
 @overload
 def connect_with_new_party(
@@ -50,7 +52,7 @@ def connect_with_new_party(
     ledger_id: Optional[str] = None,
     dar: Union[str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
-    display_name: Union[None, str, NameGenFn] = None
+    display_name: Union[None, str, NameGenFn] = None,
 ) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty]]: ...
 @overload
 def connect_with_new_party(
@@ -63,7 +65,7 @@ def connect_with_new_party(
     ledger_id: Optional[str] = None,
     dar: Union[str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
-    display_name: Union[None, str, NameGenFn] = None
+    display_name: Union[None, str, NameGenFn] = None,
 ) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty, ConnectionWithParty]]: ...
 @overload
 def connect_with_new_party(
@@ -76,7 +78,7 @@ def connect_with_new_party(
     ledger_id: Optional[str] = None,
     dar: Union[str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
-    display_name: Union[None, str, NameGenFn] = None
+    display_name: Union[None, str, NameGenFn] = None,
 ) -> AsyncContextManager[
     Tuple[ConnectionWithParty, ConnectionWithParty, ConnectionWithParty, ConnectionWithParty]
 ]: ...
@@ -91,7 +93,7 @@ def connect_with_new_party(
     ledger_id: Optional[str] = None,
     dar: Union[str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
-    display_name: Union[None, str, NameGenFn] = None
+    display_name: Union[None, str, NameGenFn] = None,
 ) -> AsyncContextManager[Sequence[ConnectionWithParty]]: ...
 
 class ConnectionWithParty(Seq["ConnectionWithParty"]):

--- a/python/dazl/util/__init__.py
+++ b/python/dazl/util/__init__.py
@@ -8,6 +8,8 @@
 Module that exposes general utility functions.
 """
 
+from __future__ import annotations
+
 from . import dar, io
 from .io import find_free_port
 from .proc_util import ProcessLogger, kill_process_tree, wait_for_process_port

--- a/python/dazl/util/asyncio_util.py
+++ b/python/dazl/util/asyncio_util.py
@@ -4,6 +4,8 @@
 """
 This module contains utilities to help work with ``asyncio``.
 """
+from __future__ import annotations
+
 from asyncio import (
     AbstractEventLoop,
     AbstractEventLoopPolicy,

--- a/python/dazl/util/config_meta.py
+++ b/python/dazl/util/config_meta.py
@@ -5,6 +5,8 @@
 This module contains utilities required by :mod:`dazl.client.config`.
 """
 
+from __future__ import annotations
+
 from argparse import _ActionsContainer
 from dataclasses import Field, dataclass, field, fields
 import logging
@@ -21,7 +23,7 @@ def config_field(
     long_alias: Optional[str] = None,
     short_alias: Optional[str] = None,
     deprecated_alias: Optional[str] = None,
-    environment_variable: Optional[str] = None
+    environment_variable: Optional[str] = None,
 ) -> Field:
     return field(
         default=default_value,  # type: ignore
@@ -89,7 +91,7 @@ def add_argument(parser: "_ActionsContainer", key: str, config_param: "ConfigPar
                 type=config_param.param_type.value_ctor,
                 metavar=config_param.param_type.metavar,
                 help=config_param.description,
-                default=default_value
+                default=default_value,
             )
 
 

--- a/python/dazl/util/dar.py
+++ b/python/dazl/util/dar.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from io import BytesIO
 from typing import TYPE_CHECKING, AbstractSet, Collection, Mapping, Optional, Sequence
 import warnings

--- a/python/dazl/util/dar_repo.py
+++ b/python/dazl/util/dar_repo.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from contextlib import ExitStack
 from os import PathLike, fspath
 from pathlib import Path

--- a/python/dazl/util/enum.py
+++ b/python/dazl/util/enum.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/python/dazl/util/io.py
+++ b/python/dazl/util/io.py
@@ -5,6 +5,8 @@
 Utilities for dealing with the file system.
 """
 
+from __future__ import annotations
+
 from io import BufferedIOBase
 from pathlib import Path
 import socket

--- a/python/dazl/util/logging.py
+++ b/python/dazl/util/logging.py
@@ -6,6 +6,8 @@ Utilities for working with the built-in `logging` module.
 
 This module will be removed soon!
 """
+from __future__ import annotations
+
 import logging
 import warnings
 

--- a/python/dazl/util/notifications.py
+++ b/python/dazl/util/notifications.py
@@ -4,6 +4,8 @@
 Internal process communications that apply globally. These include signal handlers.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from threading import RLock
 from typing import Any, Callable

--- a/python/dazl/util/path_util.py
+++ b/python/dazl/util/path_util.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from os import PathLike, fspath
 from pathlib import Path
 from typing import Union

--- a/python/dazl/util/prim_natural.py
+++ b/python/dazl/util/prim_natural.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from itertools import product
 from typing import Callable, Optional

--- a/python/dazl/util/prim_types.py
+++ b/python/dazl/util/prim_types.py
@@ -5,6 +5,8 @@
 The :mod:`dazl.util.prim_types` module contains functions for converting arbitrary objects and
 on-wire formats to/from canonical Python types.
 """
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Mapping, Optional, Tuple, Union, overload

--- a/python/dazl/util/proc_util.py
+++ b/python/dazl/util/proc_util.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime
 import logging
 from subprocess import Popen, TimeoutExpired

--- a/python/dazl/util/termcap.py
+++ b/python/dazl/util/termcap.py
@@ -5,6 +5,8 @@
 This module contains helper methods for detecting terminal capabilities.
 """
 
+from __future__ import annotations
+
 from subprocess import DEVNULL, PIPE, Popen
 from typing import Optional, Tuple
 

--- a/python/dazl/util/tools.py
+++ b/python/dazl/util/tools.py
@@ -5,6 +5,8 @@
 This module contains miscellaneous utility methods that don't really fit anywhere else.
 """
 
+from __future__ import annotations
+
 from typing import (
     Callable,
     Collection,

--- a/python/dazl/util/typing.py
+++ b/python/dazl/util/typing.py
@@ -5,6 +5,8 @@
 This module contains helper utilities for working within the constraints of Python's type system.
 """
 
+from __future__ import annotations
+
 from types import MappingProxyType
 from typing import Any, Dict, Optional, Type, TypeVar
 

--- a/python/dazl/values/__init__.py
+++ b/python/dazl/values/__init__.py
@@ -9,6 +9,8 @@ The :mod:`dazl.values` module contains utilities for converting between differen
 of DAML-LF types.
 """
 
+from __future__ import annotations
+
 from .canonical import CanonicalMapper
 from .context import Context
 from .json import JsonDecoder, JsonEncoder

--- a/python/dazl/values/canonical.py
+++ b/python/dazl/values/canonical.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any, Mapping, Tuple
 
 from ..damlast.daml_lf_1 import DefDataType, Type

--- a/python/dazl/values/context.py
+++ b/python/dazl/values/context.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, NoReturn, Optional, Sequence
 import warnings
 

--- a/python/dazl/values/json.py
+++ b/python/dazl/values/json.py
@@ -8,6 +8,8 @@ Documentation for this encoding format can be found at:
 https://docs.daml.com/json-api/lf-value-specification.html
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 from ..damlast.daml_lf_1 import DefDataType, Type as DamlType

--- a/python/dazl/values/mapper.py
+++ b/python/dazl/values/mapper.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import sys
 from typing import TYPE_CHECKING, Any
 

--- a/python/dazl/values/protobuf.py
+++ b/python/dazl/values/protobuf.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import collections.abc
 from typing import Any, Optional, Type as PyType, TypeVar
 

--- a/python/dazl/values/pysample_encoder.py
+++ b/python/dazl/values/pysample_encoder.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Any
 
 from ..damlast.daml_lf_1 import DefDataType, Type as DamlType

--- a/python/dazl/values/string.py
+++ b/python/dazl/values/string.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/python/dazl_internal/background_http_server.py
+++ b/python/dazl_internal/background_http_server.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from http.server import HTTPServer
 from threading import Thread
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Generator
 

--- a/python/tests/structure/test_structure.py
+++ b/python/tests/structure/test_structure.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 

--- a/python/tests/unit/blocking_setup.py
+++ b/python/tests/unit/blocking_setup.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import new_event_loop, set_event_loop
 from pathlib import Path
 from threading import Thread

--- a/python/tests/unit/config.py
+++ b/python/tests/unit/config.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
 import sys
 from typing import Sequence, Union

--- a/python/tests/unit/dars.py
+++ b/python/tests/unit/dars.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Mapping
 

--- a/python/tests/unit/test_acs_find_active.py
+++ b/python/tests/unit/test_acs_find_active.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future, wait_for
 
 from dazl import AIOPartyClient, async_network, connect

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl import async_network, connect

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future, wait_for
 import datetime
 from decimal import Decimal

--- a/python/tests/unit/test_api_consistency.py
+++ b/python/tests/unit/test_api_consistency.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import Party
 from dazl.client.api import AIOPartyClient, SimplePartyClient
 

--- a/python/tests/unit/test_autoload_explicit_packages.py
+++ b/python/tests/unit/test_autoload_explicit_packages.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future
 import logging
 

--- a/python/tests/unit/test_cli_ls.py
+++ b/python/tests/unit/test_cli_ls.py
@@ -4,6 +4,8 @@
 """
 Tests to ensure that CLI commands work properly.
 """
+from __future__ import annotations
+
 from dazl.cli import _main
 
 

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from __future__ import annotations
+
 from unittest import TestCase
 
 from dazl.client.commands import CommandBuilder, CommandDefaults, CommandPayload, create

--- a/python/tests/unit/test_command_compat.py
+++ b/python/tests/unit/test_command_compat.py
@@ -5,6 +5,8 @@ Ensure that v7 Commands and v8 Commands behave as expected, particularly with re
 deprecations.
 """
 
+from __future__ import annotations
+
 from dazl.client import commands as v7
 from dazl.damlast.lookup import parse_type_con_name
 from dazl.ledger import api_types as v8

--- a/python/tests/unit/test_complicated_types.py
+++ b/python/tests/unit/test_complicated_types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl.ledger import ExerciseCommand

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import http.server
 import tempfile
 

--- a/python/tests/unit/test_connection_command_submission.py
+++ b/python/tests/unit/test_connection_command_submission.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl.testing import connect_with_new_party

--- a/python/tests/unit/test_daml_lf_1.py
+++ b/python/tests/unit/test_daml_lf_1.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast.daml_lf_1 import DottedName, ModuleRef, PackageRef, TypeConName
 
 

--- a/python/tests/unit/test_damlast_lookup.py
+++ b/python/tests/unit/test_damlast_lookup.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast import DarFile
 from dazl.damlast.lookup import MultiPackageLookup
 

--- a/python/tests/unit/test_damlast_lookup_normalizations.py
+++ b/python/tests/unit/test_damlast_lookup_normalizations.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from dazl.damlast.lookup import matching_normalizations, normalize
 from dazl.model.lookup import template_reverse_globs
 import pytest

--- a/python/tests/unit/test_damlast_parse_type_con_name.py
+++ b/python/tests/unit/test_damlast_parse_type_con_name.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast.lookup import parse_type_con_name
 from dazl.damlast.util import package_local_name, package_ref
 

--- a/python/tests/unit/test_dar_file.py
+++ b/python/tests/unit/test_dar_file.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast import DarFile
 
 from .dars import Pending

--- a/python/tests/unit/test_dar_upload.py
+++ b/python/tests/unit/test_dar_upload.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import sleep
 
 from dazl import Network, connect

--- a/python/tests/unit/test_docs.py
+++ b/python/tests/unit/test_docs.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
+#
 # Note: These tests are not currently run since they hardcode URLs for documentation purposes.
 # But at the very least, they _are_ typechecked.
 
+from __future__ import annotations
 
 import pytest
 

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.testing import connect_with_new_party
 import pytest
 

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from asyncio import gather
 
 from dazl import async_network, connect

--- a/python/tests/unit/test_event_handler_exceptions.py
+++ b/python/tests/unit/test_event_handler_exceptions.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from dazl import async_network, connect
 from dazl.protocols.events import ReadyEvent
 import pytest

--- a/python/tests/unit/test_historical_dar_parsing.py
+++ b/python/tests/unit/test_historical_dar_parsing.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pathlib import Path
 import time
 

--- a/python/tests/unit/test_internal_natural_language.py
+++ b/python/tests/unit/test_internal_natural_language.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 
 from dazl.util.prim_natural import parse_datetime

--- a/python/tests/unit/test_ledger_api_version.py
+++ b/python/tests/unit/test_ledger_api_version.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl import connect

--- a/python/tests/unit/test_ledger_blocking.py
+++ b/python/tests/unit/test_ledger_blocking.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 import threading
 

--- a/python/tests/unit/test_ledger_config_access.py
+++ b/python/tests/unit/test_ledger_config_access.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.ledger.config import PropertyBasedAccessConfig, TokenBasedAccessConfig
 from dazl.ledger.config.access import DamlLedgerApiNamespace
 from dazl.prim import Party

--- a/python/tests/unit/test_ledger_config_argv.py
+++ b/python/tests/unit/test_ledger_config_argv.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import argparse
 from io import StringIO
 import logging

--- a/python/tests/unit/test_ledger_config_url.py
+++ b/python/tests/unit/test_ledger_config_url.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from urllib.parse import urlparse
 
 from dazl.ledger.config import create_url

--- a/python/tests/unit/test_ledger_create_user.py
+++ b/python/tests/unit/test_ledger_create_user.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from dazl import connect
 from dazl.ledger import ActAs, Admin, ReadAs, User
 import pytest

--- a/python/tests/unit/test_ledger_end.py
+++ b/python/tests/unit/test_ledger_end.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import dazl
 import pytest
 

--- a/python/tests/unit/test_ledger_query.py
+++ b/python/tests/unit/test_ledger_query.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import gather, wait_for
 import logging
 

--- a/python/tests/unit/test_ledger_stream.py
+++ b/python/tests/unit/test_ledger_stream.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future, gather, sleep
 
 import dazl

--- a/python/tests/unit/test_ledger_submit.py
+++ b/python/tests/unit/test_ledger_submit.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import gather
 
 import dazl

--- a/python/tests/unit/test_ledger_tls.py
+++ b/python/tests/unit/test_ledger_tls.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from asyncio import sleep
 
 from dazl import connect, testing

--- a/python/tests/unit/test_ledger_token.py
+++ b/python/tests/unit/test_ledger_token.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from asyncio import sleep
 
 from dazl import connect, testing

--- a/python/tests/unit/test_ledgerutil_acs.py
+++ b/python/tests/unit/test_ledgerutil_acs.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import gather
 import logging
 

--- a/python/tests/unit/test_ledgerutil_acs_close.py
+++ b/python/tests/unit/test_ledgerutil_acs_close.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Optional
 
 from dazl.ledger.errors import ConnectionClosedError

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import frozendict
 from dazl.testing import connect_with_new_party
 import pytest

--- a/python/tests/unit/test_matches.py
+++ b/python/tests/unit/test_matches.py
@@ -5,6 +5,8 @@
 This module contains tests for testing contract data against a match object.
 """
 
+from __future__ import annotations
+
 from dazl.query import is_match
 
 

--- a/python/tests/unit/test_pb_serialize.py
+++ b/python/tests/unit/test_pb_serialize.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Generator
 

--- a/python/tests/unit/test_pending.py
+++ b/python/tests/unit/test_pending.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from dazl import async_network, connect
 from dazl.ledger import CreateCommand, ExerciseCommand
 import pytest

--- a/python/tests/unit/test_pkg_loader.py
+++ b/python/tests/unit/test_pkg_loader.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import Event, ensure_future, get_event_loop, sleep
 from typing import AbstractSet
 

--- a/python/tests/unit/test_pkg_loader_do_with_retry.py
+++ b/python/tests/unit/test_pkg_loader_do_with_retry.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl.damlast import DarFile

--- a/python/tests/unit/test_pretty_daml.py
+++ b/python/tests/unit/test_pretty_daml.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast import DarFile, daml_types as daml
 from dazl.damlast.daml_lf_1 import DottedName, ModuleRef, PackageRef, TypeConName
 from dazl.damlast.lookup import MultiPackageLookup

--- a/python/tests/unit/test_prim_decimal_to_str.py
+++ b/python/tests/unit/test_prim_decimal_to_str.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from decimal import Decimal
 
 from dazl.prim import decimal_to_str

--- a/python/tests/unit/test_prim_json_encoder.py
+++ b/python/tests/unit/test_prim_json_encoder.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 
 from dazl.damlast.lookup import parse_type_con_name

--- a/python/tests/unit/test_prim_to_bool.py
+++ b/python/tests/unit/test_prim_to_bool.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.prim import to_bool
 
 

--- a/python/tests/unit/test_prim_types.py
+++ b/python/tests/unit/test_prim_types.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 
 from dazl.damlast.lookup import parse_type_con_name

--- a/python/tests/unit/test_protocol_ledgerapi.py
+++ b/python/tests/unit/test_protocol_ledgerapi.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl.testing import connect_with_new_party

--- a/python/tests/unit/test_query.py
+++ b/python/tests/unit/test_query.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl.damlast.lookup import parse_type_con_name
 from dazl.query import EMPTY, Filter, parse_query
 import pytest

--- a/python/tests/unit/test_select.py
+++ b/python/tests/unit/test_select.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import async_network, connect
 from dazl.client.errors import UnknownTemplateWarning
 import pytest

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import sleep
 import logging
 

--- a/python/tests/unit/test_service_queue.py
+++ b/python/tests/unit/test_service_queue.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from asyncio import ensure_future, gather, new_event_loop, set_event_loop, sleep
 from unittest import TestCase
 

--- a/python/tests/unit/test_simple_client_api.py
+++ b/python/tests/unit/test_simple_client_api.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import logging
 
 from dazl import simple_client

--- a/python/tests/unit/test_startup_errors.py
+++ b/python/tests/unit/test_startup_errors.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import asyncio
 from asyncio import CancelledError, ensure_future, wait_for
 

--- a/python/tests/unit/test_static_dump.py
+++ b/python/tests/unit/test_static_dump.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import LOG, async_network, connect
 import pytest
 

--- a/python/tests/unit/test_template_filtering.py
+++ b/python/tests/unit/test_template_filtering.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import async_network, connect
 from dazl.ledger import CreateCommand
 import pytest

--- a/python/tests/unit/test_template_reverse_globs.py
+++ b/python/tests/unit/test_template_reverse_globs.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 # noinspection PyProtectedMember
 from dazl.client.events import _template_reverse_globs as template_reverse_globs
 

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dazl import simple_client
 from dazl.ledger import ExerciseCommand
 

--- a/python/tests/unit/test_values_canonical.py
+++ b/python/tests/unit/test_values_canonical.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import date
 
 from dazl.damlast import daml_types as daml

--- a/python/tests/unit/test_values_json_decoder.py
+++ b/python/tests/unit/test_values_json_decoder.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import date, datetime
 
 from dazl.damlast import daml_types as daml

--- a/python/tests/unit/test_values_protobuf.py
+++ b/python/tests/unit/test_values_protobuf.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta, timezone
 
 from dazl._gen.com.daml.ledger.api import v1 as lapipb

--- a/python/tests/unit/test_write_cancel.py
+++ b/python/tests/unit/test_write_cancel.py
@@ -4,6 +4,8 @@
 """
 Tests to ensure that cancelled command submissions behave correctly.
 """
+from __future__ import annotations
+
 from asyncio import ensure_future
 
 from dazl import async_network, connect

--- a/python/tests/unittest_example/unittest_example.py
+++ b/python/tests/unittest_example/unittest_example.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from pathlib import Path
 
 daml_project_root = Path(__file__).parent.parent.parent.parent / "_fixtures/src/post-office"


### PR DESCRIPTION
python: Have every file treat type annotations properly when there are forward references to types.

In particular, add `from __future__ import annotations`, which delays type annotation evaluation.