### PR TITLE
python: Generate gRPC/Protobuf stub files for Go.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tls-testing = ["pyOpenSSL"]
 
 [tool.poetry.scripts]
 dazl = 'dazl.cli:main'
+protoc-gen-dazl-go = '_dazl_pb.plugin_go:main'
 protoc-gen-dazl-python = '_dazl_pb.plugin_python:main'
 
 [tool.black]

--- a/python/_dazl_pb/plugin_go/__init__.py
+++ b/python/_dazl_pb/plugin_go/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ..protoc import protoc_plugin
+from .plugin import run_all_plugins
+
+__all__ = ["main"]
+
+main = protoc_plugin(run_all_plugins)

--- a/python/_dazl_pb/plugin_go/_header.py
+++ b/python/_dazl_pb/plugin_go/_header.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+HEADER = """
+// Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+""".lstrip()

--- a/python/_dazl_pb/plugin_go/plugin.py
+++ b/python/_dazl_pb/plugin_go/plugin.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
+
+from . import plugin_grpc, plugin_pb
+
+__all__ = ["run_all_plugins"]
+
+
+def run_all_plugins(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
+    response = CodeGeneratorResponse()
+    response.MergeFrom(plugin_grpc.run_plugin(request))
+    response.MergeFrom(plugin_pb.run_plugin(request))
+    return response

--- a/python/_dazl_pb/plugin_go/plugin_grpc.py
+++ b/python/_dazl_pb/plugin_go/plugin_grpc.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
+
+from .. import protoc, util
+from ._header import HEADER
+
+__all__ = ["run_plugin"]
+
+
+def run_plugin(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
+    response = protoc.run_plugin("grpc_go", request)
+    return util.with_file_header(response, HEADER)

--- a/python/_dazl_pb/plugin_go/plugin_pb.py
+++ b/python/_dazl_pb/plugin_go/plugin_pb.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
+
+from .. import protoc
+
+__all__ = ["run_plugin"]
+
+
+def run_plugin(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
+    # the default Go plugin already seems to respect copyright headers, so we don't actually
+    # need to make any changes to the generated code
+    return protoc.run_plugin("go", request)


### PR DESCRIPTION
python: Generate gRPC/Protobuf stub files for Go.

This PR is merely about repackaging the Go gRPC/Protobuf generators in the same mechanics introduced in #315 for Python codegen.