### PR TITLE
python: Change the sandbox test fixutres to use SandboxLauncher direc…

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 
 @pytest.fixture(scope="session", params=["1", "2"])
-def sandbox(request, sandbox_v1, sandbox_v2) -> "Generator[str, None, None]":
+def sandbox(request, sandbox_v1, sandbox_v2) -> "Generator[testing.SandboxLauncher, None, None]":
     """
     Run an instance of the Sandbox, or use one configured through environment variables.
 
@@ -32,15 +32,15 @@ def sandbox(request, sandbox_v1, sandbox_v2) -> "Generator[str, None, None]":
 
 
 @pytest.fixture(scope="session")
-def sandbox_v1() -> "Generator[str, None, None]":
+def sandbox_v1() -> "Generator[testing.SandboxLauncher, None, None]":
     with testing.sandbox(project_root=None, version="1.18.1") as sb:
-        yield sb.url
+        yield sb
 
 
 @pytest.fixture(scope="session")
-def sandbox_v2() -> "Generator[str, None, None]":
+def sandbox_v2() -> "Generator[testing.SandboxLauncher, None, None]":
     with testing.sandbox(project_root=None, version="2.0.0") as sb:
-        yield sb.url
+        yield sb
 
 
 @pytest.fixture()

--- a/python/tests/unit/test_acs_find_active.py
+++ b/python/tests/unit/test_acs_find_active.py
@@ -5,6 +5,7 @@ from asyncio import ensure_future, wait_for
 
 from dazl import AIOPartyClient, async_network, connect
 from dazl.ledger import ExerciseCommand
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import Simple
@@ -14,13 +15,13 @@ OperatorNotification = "Simple:OperatorNotification"
 
 
 @pytest.mark.asyncio
-async def test_acs_find_active_retrieves_contracts(sandbox):
+async def test_acs_find_active_retrieves_contracts(sandbox: SandboxLauncher) -> None:
     seen_notifications = []
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
         client.add_ledger_created(
             OperatorNotification, lambda event: seen_notifications.append(event.cid)

--- a/python/tests/unit/test_all_party.py
+++ b/python/tests/unit/test_all_party.py
@@ -4,6 +4,7 @@
 import logging
 
 from dazl import async_network, connect
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import AllParty as AllPartyDar
@@ -13,16 +14,16 @@ PublicContract = "AllParty:PublicContract"
 
 
 @pytest.mark.asyncio
-async def test_some_party_receives_public_contract(sandbox):
+async def test_some_party_receives_public_contract(sandbox: SandboxLauncher) -> None:
     some_party_cids = []
     publisher_cids = []
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         all_party_info = await conn.allocate_party()
         some_party_info = await conn.allocate_party()
         publisher_party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=AllPartyDar) as network:
+    async with async_network(url=sandbox.url, dars=AllPartyDar) as network:
         network.set_config(party_groups=[all_party_info.party])
 
         some_client = network.aio_party(some_party_info.party)

--- a/python/tests/unit/test_all_types.py
+++ b/python/tests/unit/test_all_types.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping, Optional
 from dazl.ledger import ArchiveEvent, CreateEvent
 from dazl.ledger.aio import Connection
 from dazl.prim import ContractData
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 
 from .dars import AllKindsOf
@@ -38,8 +38,8 @@ SOME_ARGS: Mapping[str, Any] = dict(
 
 
 @pytest.mark.asyncio
-async def test_all_types(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=AllKindsOf) as p:
+async def test_all_types(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=AllKindsOf) as p:
         # start a reader that makes sure a create occurs, sends an archive choice,
         # and then waits for that archive event to appear.
         fut = ensure_future(consume_singular_event(p.connection))
@@ -59,14 +59,14 @@ async def test_all_types(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_maps(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=AllKindsOf) as p:
+async def test_maps(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=AllKindsOf) as p:
         await p.connection.create(
             "AllKindsOf:MappyContract", {"operator": p.party, "value": {"Map_internal": []}}
         )
 
 
-async def consume_singular_event(conn: "Connection") -> "Optional[ContractData]":
+async def consume_singular_event(conn: Connection) -> Optional[ContractData]:
     cdata = None
     async with conn.stream(TEMPLATE) as stream:
         async for event in stream.items():

--- a/python/tests/unit/test_autoload_explicit_packages.py
+++ b/python/tests/unit/test_autoload_explicit_packages.py
@@ -8,14 +8,15 @@ from dazl import Network, connect
 from dazl.damlast.errors import PackageNotFoundError
 from dazl.damlast.lookup import MultiPackageLookup
 from dazl.damlast.pkgfile import DarFile
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import Simple
 
 
 @pytest.mark.asyncio
-async def test_autoload_explicit_packages(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_autoload_explicit_packages(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
     with DarFile(Simple) as dar_file:
@@ -26,13 +27,13 @@ async def test_autoload_explicit_packages(sandbox):
     # Start the sandbox and make sure our package is loaded.
     logging.info("Preloading the DAR...")
     network = Network()
-    network.set_config(url=sandbox)
+    network.set_config(url=sandbox.url)
     await network.aio_global().ensure_dar(Simple)
 
     # Now start the sandbox again, but without any preloading.
     logging.info("Now running the real test...")
     network = Network()
-    network.set_config(url=sandbox, eager_package_fetch=False)
+    network.set_config(url=sandbox.url, eager_package_fetch=False)
     client = network.aio_party(party_info.party)
     fut = ensure_future(network.aio_run())
     await client.ready()

--- a/python/tests/unit/test_cli_ls.py
+++ b/python/tests/unit/test_cli_ls.py
@@ -5,15 +5,16 @@
 Tests to ensure that CLI commands work properly.
 """
 from dazl.cli import _main
+from dazl.testing import SandboxLauncher
 
 
-def test_simple_ls(sandbox):
-    exit_code = _main(f"dazl ls --url {sandbox} --parties=Alice".split(" "))
+def test_simple_ls(sandbox: SandboxLauncher) -> None:
+    exit_code = _main(f"dazl ls --url {sandbox.url} --parties=Alice".split(" "))
     assert exit_code == 0
 
 
 def test_simple_ls_two_parties(sandbox):
-    exit_code = _main(f"dazl ls --url {sandbox} --parties=Alice,Bob".split(" "))
+    exit_code = _main(f"dazl ls --url {sandbox.url} --parties=Alice,Bob".split(" "))
 
     assert exit_code == 0
 
@@ -21,7 +22,7 @@ def test_simple_ls_two_parties(sandbox):
 def test_env_ls(sandbox):
     import os
 
-    os.environ["DAML_LEDGER_URL"] = sandbox
+    os.environ["DAML_LEDGER_URL"] = sandbox.url
     os.environ["DAML_LEDGER_PARTY"] = "Alice"
     exit_code = _main("dazl ls".split(" "))
 

--- a/python/tests/unit/test_complicated_types.py
+++ b/python/tests/unit/test_complicated_types.py
@@ -4,7 +4,7 @@
 import logging
 
 from dazl.ledger import ExerciseCommand
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 
 from .dars import Complicated as ComplicatedDar
@@ -16,8 +16,8 @@ class Complicated:
 
 
 @pytest.mark.asyncio
-async def test_complicated_types(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=ComplicatedDar) as p:
+async def test_complicated_types(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=ComplicatedDar) as p:
         await p.connection.create(Complicated.OperatorRole, {"operator": p.party})
 
         async with p.connection.query(Complicated.OperatorRole) as stream:

--- a/python/tests/unit/test_connection_command_submission.py
+++ b/python/tests/unit/test_connection_command_submission.py
@@ -3,14 +3,14 @@
 
 import logging
 
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 from tests.unit.dars import KitchenSink
 
 
 @pytest.mark.asyncio
-async def test_create(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=KitchenSink, admin=True) as p:
+async def test_create(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=KitchenSink, admin=True) as p:
         suppliers_party_info = await p.connection.allocate_party()
         await p.connection.create(
             "KitchenSink.Warehouse:Warehouse",
@@ -23,8 +23,8 @@ async def test_create(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_exercise_by_key(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=KitchenSink) as p:
+async def test_exercise_by_key(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=KitchenSink) as p:
         await p.connection.create(
             "KitchenSink.Retailer:Retailer",
             {
@@ -46,8 +46,8 @@ async def test_exercise_by_key(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_create_and_exercise(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=KitchenSink) as p:
+async def test_create_and_exercise(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=KitchenSink) as p:
         result = await p.connection.create_and_exercise(
             "KitchenSink.Retailer:Retailer",
             {
@@ -64,8 +64,8 @@ async def test_create_and_exercise(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_create_and_exercise_unit_arg(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=KitchenSink) as p:
+async def test_create_and_exercise_unit_arg(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=KitchenSink) as p:
         result = await p.connection.create_and_exercise(
             "KitchenSink.Retailer:Order",
             {

--- a/python/tests/unit/test_dar_upload.py
+++ b/python/tests/unit/test_dar_upload.py
@@ -4,17 +4,18 @@
 from asyncio import sleep
 
 from dazl import Network, connect
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import UploadTest
 
 
 @pytest.mark.asyncio
-async def test_dar_uploads_near_startup(sandbox):
+async def test_dar_uploads_near_startup(sandbox: SandboxLauncher) -> None:
     package_ids = []
 
     network = Network()
-    network.set_config(url=sandbox)
+    network.set_config(url=sandbox.url)
 
     async def upload_dars_and_verify():
         await upload_test_dars(network)
@@ -37,15 +38,15 @@ async def test_dar_uploads_near_startup(sandbox):
     "basis. When this happens, PackagesAddedEvent will be dropped. If this is still a use-case you "
     "need, please write your own poller around lookup.package_ids."
 )
-async def test_package_events(sandbox):
+async def test_package_events(sandbox: SandboxLauncher) -> None:
     initial_events = []
     follow_up_events = []
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
     network = Network()
-    network.set_config(url=sandbox)
+    network.set_config(url=sandbox.url)
     client = network.aio_party(party_info.party)
 
     async def upload_dars_and_verify():
@@ -69,6 +70,6 @@ async def test_package_events(sandbox):
     assert len(follow_up_events) == 1
 
 
-async def upload_test_dars(network: "Network"):
+async def upload_test_dars(network: Network) -> None:
     g = network.aio_global()
     await g.ensure_dar(UploadTest)

--- a/python/tests/unit/test_dotted_fields.py
+++ b/python/tests/unit/test_dotted_fields.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 
 from .dars import DottedFields
@@ -11,8 +11,8 @@ from .dars import DottedFields
 @pytest.mark.skip(
     "These tests are temporarily disabled because the new encoder does not support this."
 )
-async def test_record_dotted_fields_submit(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=DottedFields) as p:
+async def test_record_dotted_fields_submit(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=DottedFields) as p:
         await p.connection.create(
             "DottedFields:American",
             {
@@ -36,8 +36,8 @@ async def test_record_dotted_fields_submit(sandbox):
 @pytest.mark.skip(
     "These tests are temporarily disabled because the new encoder does not support this."
 )
-async def test_variant_dotted_fields_submit(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=DottedFields) as p:
+async def test_variant_dotted_fields_submit(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=DottedFields) as p:
         await p.connection.create(
             "DottedFields:Person",
             {

--- a/python/tests/unit/test_dynamic_parties.py
+++ b/python/tests/unit/test_dynamic_parties.py
@@ -3,20 +3,21 @@
 from asyncio import gather
 
 from dazl import async_network, connect
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import PostOffice
 
 
 @pytest.mark.asyncio
-async def test_parties_can_be_added_after_run_forever(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_parties_can_be_added_after_run_forever(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         operator_info = await conn.allocate_party()
         party_a_info = await conn.allocate_party()
         party_b_info = await conn.allocate_party()
         party_c_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=PostOffice) as network:
+    async with async_network(url=sandbox.url, dars=PostOffice) as network:
         operator_client = network.aio_party(operator_info.party)
         party_a_client = network.aio_party(party_a_info.party)
         party_b_client = network.aio_party(party_b_info.party)

--- a/python/tests/unit/test_event_handler_exceptions.py
+++ b/python/tests/unit/test_event_handler_exceptions.py
@@ -1,18 +1,20 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 from dazl import async_network, connect
 from dazl.protocols.events import ReadyEvent
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import PostOffice
 
 
 @pytest.mark.asyncio
-async def test_event_handler_exceptions(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_event_handler_exceptions(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party = (await conn.allocate_party()).party
 
-    async with async_network(url=sandbox, dars=PostOffice) as network:
+    async with async_network(url=sandbox.url, dars=PostOffice) as network:
         client = network.aio_party(party)
 
         def throw_error(event: ReadyEvent):

--- a/python/tests/unit/test_ledger_api_version.py
+++ b/python/tests/unit/test_ledger_api_version.py
@@ -4,12 +4,13 @@
 import logging
 
 from dazl import connect
+from dazl.testing import SandboxLauncher
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_ledger_api_version(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_ledger_api_version(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         version = await conn.get_version()
 
         logging.info("Ledger API version: %s", version.version)

--- a/python/tests/unit/test_ledger_create_user.py
+++ b/python/tests/unit/test_ledger_create_user.py
@@ -1,20 +1,22 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 from dazl import connect
 from dazl.ledger import ActAs, Admin, ReadAs, User
+from dazl.testing import SandboxLauncher
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_ledger_create_user(sandbox_v2) -> None:
-    async with connect(url=sandbox_v2, admin=True) as conn:
+async def test_ledger_create_user(sandbox_v2: SandboxLauncher) -> None:
+    async with connect(url=sandbox_v2.url, admin=True) as conn:
         party_info = await conn.allocate_party()
         await conn.create_user(User("testuser1", party_info.party))
 
 
 @pytest.mark.asyncio
-async def test_ledger_create_user_with_rights(sandbox_v2) -> None:
-    async with connect(url=sandbox_v2, admin=True) as conn:
+async def test_ledger_create_user_with_rights(sandbox_v2: SandboxLauncher) -> None:
+    async with connect(url=sandbox_v2.url, admin=True) as conn:
         party_info = await conn.allocate_party()
         await conn.create_user(
             User("testuser2", party_info.party),

--- a/python/tests/unit/test_ledger_end.py
+++ b/python/tests/unit/test_ledger_end.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dazl
+from dazl.testing import SandboxLauncher
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_ledger_end(sandbox) -> None:
-    async with dazl.connect(url=sandbox, admin=True) as conn:
+async def test_ledger_end(sandbox: SandboxLauncher) -> None:
+    async with dazl.connect(url=sandbox.url, admin=True) as conn:
         actual = await conn.get_ledger_end()
 
     # the actual offset is unpredictable, but it will always be defined and non-empty

--- a/python/tests/unit/test_ledger_query.py
+++ b/python/tests/unit/test_ledger_query.py
@@ -9,6 +9,7 @@ from dazl.ledger import Boundary, CreateEvent
 from dazl.ledger.aio import Connection
 from dazl.ledger.grpc import Connection as GrpcConnection
 from dazl.prim import ContractData, Party
+from dazl.testing import SandboxLauncher
 import pytest
 from tests.unit import dars
 
@@ -20,13 +21,13 @@ def payload(operator: Party, text: str) -> ContractData:
 
 
 @pytest.mark.asyncio
-async def test_query_no_filter(sandbox) -> None:
-    async with dazl.connect(url=sandbox, admin=True) as conn:
+async def test_query_no_filter(sandbox: SandboxLauncher) -> None:
+    async with dazl.connect(url=sandbox.url, admin=True) as conn:
         party_info, _ = await gather(
             conn.allocate_party(), conn.upload_package(dars.Simple.read_bytes())
         )
 
-    async with dazl.connect(url=sandbox, act_as=party_info.party) as conn:
+    async with dazl.connect(url=sandbox.url, act_as=party_info.party) as conn:
         texts = ["Red", "Red", "Green", "Blue", "Blue", "Blue"]
         for text in texts:
             await conn.create(TEMPLATE, payload(party_info.party, text))

--- a/python/tests/unit/test_ledger_submit.py
+++ b/python/tests/unit/test_ledger_submit.py
@@ -5,14 +5,15 @@ from asyncio import gather
 
 import dazl
 from dazl.damlast.lookup import MultiPackageLookup
+from dazl.testing import SandboxLauncher
 import pytest
 from tests.unit import dars
 
 
 @pytest.mark.asyncio
-async def test_command_submission_with_stdlib_values(sandbox) -> None:
+async def test_command_submission_with_stdlib_values(sandbox: SandboxLauncher) -> None:
 
-    async with dazl.connect(url=sandbox, admin=True) as conn:
+    async with dazl.connect(url=sandbox.url, admin=True) as conn:
         party_info, _ = await gather(
             conn.allocate_party(), conn.upload_package(dars.KitchenSink.read_bytes())
         )
@@ -24,7 +25,7 @@ async def test_command_submission_with_stdlib_values(sandbox) -> None:
 
     # override lookup intentionally to make sure this test is not polluted with cached state from other tests
     async with dazl.connect(
-        url=sandbox, act_as=party_info.party, lookup=MultiPackageLookup()
+        url=sandbox.url, act_as=party_info.party, lookup=MultiPackageLookup()
     ) as conn:
         # bare create a contract with a specific package ID; this should have the side-effect of resolving
         # dependent packages (in this case, stdlib itself)

--- a/python/tests/unit/test_ledger_token.py
+++ b/python/tests/unit/test_ledger_token.py
@@ -13,7 +13,7 @@ from .dars import PostOffice
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("daml_sdk_version", daml_sdk_versions())
-async def test_v1_token(daml_sdk_version):
+async def test_v1_token(daml_sdk_version: str) -> None:
     async with testing.sandbox(
         version=daml_sdk_version, use_auth=True, ledger_id="sandbox"
     ) as sandbox:
@@ -26,7 +26,7 @@ async def test_v1_token(daml_sdk_version):
 
 
 @pytest.mark.asyncio
-async def test_v2_token(sandbox_v2):
+async def test_v2_token() -> None:
     async with testing.sandbox(
         version=known_version_2, use_auth=True, ledger_id="sandbox"
     ) as sandbox:

--- a/python/tests/unit/test_ledgerutil_acs_close.py
+++ b/python/tests/unit/test_ledgerutil_acs_close.py
@@ -5,14 +5,14 @@ from typing import Optional
 
 from dazl.ledger.errors import ConnectionClosedError
 from dazl.ledgerutil.acs import RUNNING, Snapshot, snapshots
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 from tests.unit.dars import PostOffice
 
 
 @pytest.mark.asyncio
-async def test_acs(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=PostOffice) as p:
+async def test_acs(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=PostOffice) as p:
         await p.connection.create("Main:PostmanRole", {"postman": p.party})
         snapshot = None  # type: Optional[Snapshot]
         snapshot_loop_count = 0

--- a/python/tests/unit/test_map_support.py
+++ b/python/tests/unit/test_map_support.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dazl import frozendict
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 
 from .dars import MapSupport
 
 
 @pytest.mark.asyncio
-async def test_map_support(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=MapSupport, admin=True) as p:
+async def test_map_support(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=MapSupport, admin=True) as p:
         await p.connection.create(
             "MapSupport:Sample",
             {"party": p.party, "mappings": {"65": "A", "97": "a"}, "text": None},
@@ -25,8 +25,8 @@ async def test_map_support(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_complicated_map_support(sandbox):
-    async with connect_with_new_party(url=sandbox, dar=MapSupport, admin=True) as p:
+async def test_complicated_map_support(sandbox: SandboxLauncher) -> None:
+    async with connect_with_new_party(url=sandbox.url, dar=MapSupport, admin=True) as p:
         await p.connection.create(
             "MapSupport:ComplicatedSample",
             {

--- a/python/tests/unit/test_pending.py
+++ b/python/tests/unit/test_pending.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+from typing import Sequence
+
 from dazl import async_network, connect
-from dazl.ledger import CreateCommand, ExerciseCommand
+from dazl.ledger import Command, CreateCommand, ExerciseCommand
+from dazl.protocols.events import ContractCreateEvent
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import Pending
@@ -14,13 +19,13 @@ OperatorNotification = "Simple:OperatorNotification"
 
 
 @pytest.mark.asyncio
-async def test_select_template_retrieves_contracts(sandbox):
+async def test_select_template_retrieves_contracts(sandbox: SandboxLauncher) -> None:
     number_of_contracts = 10
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party = (await conn.allocate_party()).party
 
-    async with async_network(url=sandbox, dars=Pending) as network:
+    async with async_network(url=sandbox.url, dars=Pending) as network:
         client = network.aio_party(party)
         client.add_ledger_ready(
             lambda _: [
@@ -33,7 +38,7 @@ async def test_select_template_retrieves_contracts(sandbox):
         )
 
         @client.ledger_created(AccountRequest)
-        async def on_account_request(event):
+        async def on_account_request(event: ContractCreateEvent) -> Sequence[Command]:
             counter_cid, counter_cdata = await event.acs_find_one(Counter)
             return [
                 ExerciseCommand(event.cid, "CreateAccount", dict(accountId=counter_cdata["value"])),

--- a/python/tests/unit/test_protocol_ledgerapi.py
+++ b/python/tests/unit/test_protocol_ledgerapi.py
@@ -3,16 +3,19 @@
 
 import logging
 
-from dazl.testing import connect_with_new_party
+from dazl.testing import SandboxLauncher, connect_with_new_party
 import pytest
 
 from .dars import PostOffice
 
 
 @pytest.mark.asyncio
-async def test_protocol_ledger_api(sandbox):
+async def test_protocol_ledger_api(sandbox: SandboxLauncher) -> None:
     # first, administrative stuff--upload the DAR and allocate two parties that we'll use later
-    async with connect_with_new_party(url=sandbox, dar=PostOffice, party_count=2) as (postman, p1):
+    async with connect_with_new_party(url=sandbox.url, dar=PostOffice, party_count=2) as (
+        postman,
+        p1,
+    ):
         event = await postman.connection.create("Main:PostmanRole", {"postman": postman.party})
         result = await postman.connection.exercise(
             event.contract_id, "InviteParticipant", {"party": p1.party, "address": "Somewhere!"}

--- a/python/tests/unit/test_select.py
+++ b/python/tests/unit/test_select.py
@@ -3,6 +3,7 @@
 
 from dazl import async_network, connect
 from dazl.client.errors import UnknownTemplateWarning
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import Simple
@@ -12,11 +13,11 @@ OperatorNotification = "Simple:OperatorNotification"
 
 
 @pytest.mark.asyncio
-async def test_select_star_retrieves_contracts(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_select_star_retrieves_contracts(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
 
         network.start()
@@ -29,11 +30,11 @@ async def test_select_star_retrieves_contracts(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_select_star_on_empty_ledger_retrieves_nothing(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_select_star_on_empty_ledger_retrieves_nothing(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
 
         network.start()
@@ -44,11 +45,11 @@ async def test_select_star_on_empty_ledger_retrieves_nothing(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_select_template_retrieves_contracts(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_select_template_retrieves_contracts(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
 
         network.start()
@@ -61,11 +62,11 @@ async def test_select_template_retrieves_contracts(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_select_unknown_template_retrieves_empty_set(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_select_unknown_template_retrieves_empty_set(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
 
         network.start()
@@ -79,7 +80,7 @@ async def test_select_unknown_template_retrieves_empty_set(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_select_operates_on_acs_before_event_handlers(sandbox):
+async def test_select_operates_on_acs_before_event_handlers(sandbox: SandboxLauncher) -> None:
     notification_count = 3
 
     # we expect that, upon each on_created notification of an OperatorNotification contract,
@@ -91,10 +92,10 @@ async def test_select_operates_on_acs_before_event_handlers(sandbox):
         nonlocal actual_select_count
         actual_select_count += len(client.find_active(OperatorNotification))
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
         client.add_ledger_ready(
             lambda e: client.create(OperatorRole, {"operator": party_info.party})
@@ -110,7 +111,7 @@ async def test_select_operates_on_acs_before_event_handlers(sandbox):
 
 
 @pytest.mark.asyncio
-async def test_select_reflects_archive_events(sandbox):
+async def test_select_reflects_archive_events(sandbox: SandboxLauncher):
     notification_count = 3
 
     # we expect that, upon each on_created notification of an OperatorNotification contract,
@@ -122,10 +123,10 @@ async def test_select_reflects_archive_events(sandbox):
         nonlocal actual_select_count
         actual_select_count += len(event.acs_find_active(OperatorNotification))
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Simple) as network:
+    async with async_network(url=sandbox.url, dars=Simple) as network:
         client = network.aio_party(party_info.party)
         client.add_ledger_ready(
             lambda e: client.create(OperatorRole, {"operator": party_info.party})

--- a/python/tests/unit/test_server.py
+++ b/python/tests/unit/test_server.py
@@ -6,6 +6,7 @@ import logging
 
 from aiohttp import ClientSession
 from dazl import Network, Party, async_network, connect
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import TestServer as TestServerDar
@@ -14,15 +15,15 @@ LOG = logging.getLogger("test_server")
 
 
 @pytest.mark.asyncio
-async def test_server_endpoint(sandbox):
+async def test_server_endpoint(sandbox: SandboxLauncher) -> None:
     SERVER_PORT = 53390
 
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         alice = (await conn.allocate_party()).party
         bob = (await conn.allocate_party()).party
         carol = (await conn.allocate_party()).party
 
-    async with async_network(url=sandbox, dars=TestServerDar) as network:
+    async with async_network(url=sandbox.url, dars=TestServerDar) as network:
         network.set_config(server_port=SERVER_PORT)
 
         _ = network.aio_party(alice)
@@ -59,7 +60,7 @@ async def test_server_endpoint(sandbox):
         await network.aio_run(client_main(network, SERVER_PORT, alice, bob, carol), keep_open=False)
 
 
-def ensure_person_contract(network: Network, party: Party):
+def ensure_person_contract(network: Network, party: Party) -> None:
     client = network.aio_party(party)
     client.add_ledger_ready(lambda _: client.create("TestServer:Person", dict(party=party)))  # type: ignore
 

--- a/python/tests/unit/test_simple_client_api.py
+++ b/python/tests/unit/test_simple_client_api.py
@@ -4,16 +4,17 @@
 import logging
 
 from dazl import simple_client
+from dazl.testing import SandboxLauncher
 
 from .blocking_setup import blocking_setup
 from .dars import PostOffice
 
 
-def test_simple_client_api(sandbox):
-    party = blocking_setup(sandbox, PostOffice)
+def test_simple_client_api(sandbox: SandboxLauncher) -> None:
+    party = blocking_setup(sandbox.url, PostOffice)
 
     logging.info("Creating client...")
-    with simple_client(url=sandbox, party=party) as client:
+    with simple_client(url=sandbox.url, party=party) as client:
         client.ready()
         logging.info("Submitting...")
         client.create("Main:PostmanRole", {"postman": party})

--- a/python/tests/unit/test_template_filtering.py
+++ b/python/tests/unit/test_template_filtering.py
@@ -3,21 +3,22 @@
 
 from dazl import async_network, connect
 from dazl.ledger import CreateCommand
+from dazl.testing import SandboxLauncher
 import pytest
 
 from .dars import AllParty, PostOffice
 
 
 @pytest.mark.asyncio
-async def test_template_filtering(sandbox):
+async def test_template_filtering(sandbox: SandboxLauncher) -> None:
     # First, create a few contracts stretching across two DARs and validate that all of those
     # contracts show up in the active contract set. async_network will supply the list of DARs to
     # dazl.
-    async with connect(url=sandbox, admin=True) as conn:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
         party = party_info.party
 
-    async with async_network(url=sandbox, dars=[AllParty, PostOffice]) as network:
+    async with async_network(url=sandbox.url, dars=[AllParty, PostOffice]) as network:
         client = network.aio_party(party)
 
         network.start()
@@ -36,7 +37,7 @@ async def test_template_filtering(sandbox):
         assert len(contracts) == 4
 
     # Now create a new client to the same sandbox, but with less DARs
-    async with async_network(url=sandbox, dars=[PostOffice]) as network:
+    async with async_network(url=sandbox.url, dars=[PostOffice]) as network:
         client = network.aio_party(party)
         network.start()
 

--- a/python/tests/unit/test_threadsafe_methods.py
+++ b/python/tests/unit/test_threadsafe_methods.py
@@ -3,6 +3,7 @@
 
 from dazl import simple_client
 from dazl.ledger import ExerciseCommand
+from dazl.testing import SandboxLauncher
 
 from .blocking_setup import blocking_setup
 from .dars import Simple
@@ -11,10 +12,10 @@ OperatorRole = "Simple:OperatorRole"
 OperatorNotification = "Simple:OperatorNotification"
 
 
-def test_threadsafe_methods(sandbox):
-    party = blocking_setup(sandbox, Simple)
+def test_threadsafe_methods(sandbox: SandboxLauncher) -> None:
+    party = blocking_setup(sandbox.url, Simple)
 
-    with simple_client(url=sandbox, party=party) as client:
+    with simple_client(url=sandbox.url, party=party) as client:
         client.ready()
         client.create(OperatorRole, {"operator": party})
 

--- a/python/tests/unit/test_write_cancel.py
+++ b/python/tests/unit/test_write_cancel.py
@@ -7,16 +7,17 @@ Tests to ensure that cancelled command submissions behave correctly.
 from asyncio import ensure_future
 
 from dazl import async_network, connect
+from dazl.testing import SandboxLauncher
 import pytest
 from tests.unit.dars import Pending
 
 
 @pytest.mark.asyncio
-async def test_cancelled_write(sandbox):
-    async with connect(url=sandbox, admin=True) as conn:
+async def test_cancelled_write(sandbox: SandboxLauncher) -> None:
+    async with connect(url=sandbox.url, admin=True) as conn:
         party_info = await conn.allocate_party()
 
-    async with async_network(url=sandbox, dars=Pending) as network:
+    async with async_network(url=sandbox.url, dars=Pending) as network:
         client = network.aio_party(party_info.party)
 
         network.start()


### PR DESCRIPTION
python: Change the definition of the `sandbox` test fixture to be an instance of `dazl.testing.SandboxLauncher` instead of a string that is the URL to the created sandbox. This will enable writing tests that stop and start the sandbox at will.