### PR TITLE
python: Drop explicit references to dazl in docs where it's not absolutely essential.

### DIFF
--- a/python/dazl/client/api.py
+++ b/python/dazl/client/api.py
@@ -837,12 +837,12 @@ class AIOPartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -915,17 +915,17 @@ class AIOPartyClient(PartyClient):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1004,22 +1004,22 @@ class AIOPartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1100,23 +1100,23 @@ class AIOPartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument (positional
             argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1676,12 +1676,12 @@ class SimplePartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1753,17 +1753,17 @@ class SimplePartyClient(PartyClient):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1841,22 +1841,22 @@ class SimplePartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -1937,23 +1937,23 @@ class SimplePartyClient(PartyClient):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument (positional
             argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.

--- a/python/dazl/ledger/__init__.py
+++ b/python/dazl/ledger/__init__.py
@@ -100,7 +100,7 @@ class PackageService(Protocol):
         :param __package_id:
             The package ID of the DALF to retrieve.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :return:
             The byte array contents of the DALF associated with the package ID.
@@ -202,7 +202,7 @@ class Connection(PackageService, Protocol):
         :param __commands:
             A command or sequence of commands to submit to the ledger.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -233,12 +233,12 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The template of the contract to be created.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -272,17 +272,17 @@ class Connection(PackageService, Protocol):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -318,23 +318,23 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument (positional
             argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -370,22 +370,22 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -418,7 +418,7 @@ class Connection(PackageService, Protocol):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -452,12 +452,12 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -486,12 +486,12 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The name of the template for which to fetch contracts.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __query:
             A filter to apply to the set of returned contracts.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param read_as:
             An optional set of read-as parties to use to submit this query. Note that for a
@@ -542,14 +542,14 @@ class Connection(PackageService, Protocol):
         :param __template_id:
             The name of the template for which to fetch contracts.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __query:
             A filter to apply to the set of returned contracts. Note that this does not filter
             :class:`ArchiveEvent`; readers of the stream MUST be able to cope with "mismatched"
             archives that come from the result of applying a filter.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param offset:
             An optional offset at which to start receiving events. If ``None``, start from the
@@ -645,7 +645,7 @@ class Connection(PackageService, Protocol):
         :param __contents:
             The contents of a DAR file (for example, as obtained from running ``daml build``).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         """
         raise NotImplementedError

--- a/python/dazl/ledger/errors.py
+++ b/python/dazl/ledger/errors.py
@@ -27,7 +27,7 @@ class CallbackReturnWarning(Warning):
     Raised when a user callback on a stream returns a value. These objects have no meaning and are
     ignored by dazl.
 
-    This warning is raised primarily because older versions of dazl interpreted returning commands
+    This warning is raised primarily because older versions interpreted returning commands
     from a callback as a request to send commands to the underlying ledger, and this is not
     supported in newer APIs.
     """

--- a/python/dazl/ledger/grpc/codec_aio.py
+++ b/python/dazl/ledger/grpc/codec_aio.py
@@ -6,7 +6,7 @@ This module contains the mapping between Protobuf objects and Python/dazl types.
 
 from __future__ import annotations
 
-# Earlier versions of dazl (before v8) had an API that mapped less directly to the gRPC Ledger API.
+# Earlier versions (before v8) had an API that mapped less directly to the gRPC Ledger API.
 # But with the HTTP JSON API, many common ledger methods now have much more direct translations that
 # still manage to adhere quite closely to dazl's historical behavior.
 #

--- a/python/dazl/ledger/grpc/conn_aio.py
+++ b/python/dazl/ledger/grpc/conn_aio.py
@@ -211,12 +211,12 @@ class Connection(aio.Connection):
         :param __template_id:
             The template of the contract to be created.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -271,17 +271,17 @@ class Connection(aio.Connection):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -342,23 +342,23 @@ class Connection(aio.Connection):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __payload:
             Template arguments for the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument (positional
             argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -416,22 +416,22 @@ class Connection(aio.Connection):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __choice_name:
             The name of the choice to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __argument:
             The choice arguments. Can be omitted for choices that take no argument.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -481,7 +481,7 @@ class Connection(aio.Connection):
         :param __contract_id:
             The contract ID of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.
@@ -525,12 +525,12 @@ class Connection(aio.Connection):
         :param __template_id:
             The template of the contract to be created (positional argument only).
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param __key:
             The key of the contract to exercise.
 
-            Note that future versions of dazl reserve the right to rename this parameter name at any
+            Note that future versions reserve the right to rename this parameter name at any
             time; it should be passed in as a positional parameter and never by name.
         :param workflow_id:
             An optional workflow ID.

--- a/python/dazl/values/canonical.py
+++ b/python/dazl/values/canonical.py
@@ -46,7 +46,7 @@ class CanonicalMapper(ValueMapper):
         actual_keys = frozenset(orig_mapping)
         if actual_keys.issuperset(expected_keys):
             if actual_keys != expected_keys:
-                # Earlier versions of dazl were more tolerant of extra fields. To keep backwards
+                # Earlier versions were more tolerant of extra fields. To keep backwards
                 # compatibility, we'll emit a warning, though this may become an exception
                 # eventually.
                 context.value_warn(


### PR DESCRIPTION
python: As part of renaming `dazl` to "Python client binding libraries", remove references to `dazl` that are not linked to names of symbols in code.