### PR TITLE
python: Add tests for metering in Daml 2.3.

### DIFF
--- a/.circleci/install-daml
+++ b/.circleci/install-daml
@@ -8,7 +8,7 @@ function install {
         curl -sSL https://get.daml.com/ | sh
         link
     fi
-    daml install 2.2.0
+    daml install 2.3.7
     daml install 1.18.1
 }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -39,7 +39,7 @@ def sandbox_v1() -> "Generator[testing.SandboxLauncher, None, None]":
 
 @pytest.fixture(scope="session")
 def sandbox_v2() -> "Generator[testing.SandboxLauncher, None, None]":
-    with testing.sandbox(project_root=None, version="2.0.0") as sb:
+    with testing.sandbox(project_root=None, version="2.3.7") as sb:
         yield sb
 
 

--- a/python/tests/unit/test_ledger_metrics.py
+++ b/python/tests/unit/test_ledger_metrics.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2017-2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from uuid import uuid4
+
+from dazl import connect
+import pytest
+
+from .dars import Simple
+
+
+@pytest.mark.asyncio
+async def test_ledger_metrics(sandbox_v2) -> None:
+    app_name = uuid4().hex
+
+    async with connect(url=sandbox_v2.url, admin=True, application_name=app_name) as conn:
+        report = await conn.get_metering_report(datetime.fromtimestamp(0), application_id=app_name)
+        assert len(report.application_reports) == 0
+
+        party_info = await conn.allocate_party()
+        await conn.upload_package(Simple.read_bytes())
+
+        await conn.create(
+            "Simple:OperatorNotification",
+            {"operator": party_info.party, "theObservers": [], "text": "some_stuff"},
+            act_as=party_info.party,
+        )
+        await conn.create(
+            "Simple:OperatorNotification",
+            {"operator": party_info.party, "theObservers": [], "text": "more_stuff"},
+            act_as=party_info.party,
+        )
+        report = await conn.get_metering_report(datetime.fromtimestamp(0), application_id=app_name)
+        assert len(report.application_reports) == 1
+        assert report.application_reports[0].event_count == 2


### PR DESCRIPTION
python: Add tests that target the metering endpoints in Daml 2.3.

This is ahead of getting them to work with Daml 2.4, which changed the way that these services worked.