### PR TITLE
python: Fix various mypy violations.

### DIFF
--- a/python/_dazl_pb/syntax/python/symbols.py
+++ b/python/_dazl_pb/syntax/python/symbols.py
@@ -44,7 +44,7 @@ class SymbolTable:
     messages within the same file can be referenced without being fully-qualified.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._packages = {}  # type: Dict[str, str]
         self._imports = {}  # type: Dict[str, str]
         self._map_types = {}  # type: Dict[str, Tuple[FieldDescriptorProto, FieldDescriptorProto]]

--- a/python/dazl/client/_party_client_impl.py
+++ b/python/dazl/client/_party_client_impl.py
@@ -663,11 +663,17 @@ class _PartyClientImpl:
             else:
                 LOG.debug("Command finished: %s", pending_command)
 
-    async def main_writer(self):
+    async def main_writer(self) -> None:
         """
         Main coroutine for submitting commands.
         """
         LOG.info("Writer loop for party %s is starting...", self.party)
+        if self._pool is None:
+            raise RuntimeError("unexpected start to main_writer with undefined pool")
+        if self._client_fut is None:
+            raise RuntimeError("unexpected start to main_writer with undefined client")
+        if self._config is None:
+            raise RuntimeError("unexpected start to main_writer with undefined config")
         ledger_fut = ensure_future(self._pool.ledger())
 
         client = await self._client_fut  # type: LedgerClient

--- a/python/dazl/client/state.py
+++ b/python/dazl/client/state.py
@@ -174,7 +174,7 @@ class TemplateContractData:
     Storage for state related to a specific :class:`Template`.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # raw ContractId to ContractContextualData
         self._data = dict()  # type: Dict[str, ContractContextualData]
         # outstanding ACS queries

--- a/python/dazl/damlast/_builtins_meta.py
+++ b/python/dazl/damlast/_builtins_meta.py
@@ -6,7 +6,7 @@ This module contains supporting infrastructure for built-in method definitions f
 Daml-LF files.
 """
 
-from typing import Any, Optional, Sequence, Type as PyType, Union
+from typing import Any, Dict, Optional, Sequence, Type as PyType, Union
 import warnings
 
 from .daml_lf_1 import BuiltinFunction, Expr, Type, ValName
@@ -15,6 +15,10 @@ from .util import package_local_name
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
     from ..model.types import TypeReference
+
+warnings.warn(
+    "The symbols in dazl.damlast.builtin are deprecated", DeprecationWarning, stacklevel=2
+)
 
 
 class _BuiltinMeta(type):
@@ -52,15 +56,15 @@ class Builtin(metaclass=_BuiltinMeta):
 
 
 class BuiltinTable:
-    def __init__(self):
-        self.by_name = dict()  # type: [BuiltinFunction, PyType[Builtin]]
-        self.by_builtin = dict()  # type: [str, PyType[Builtin]]
+    def __init__(self) -> None:
+        self.by_name = dict()  # type: Dict[BuiltinFunction, PyType[Builtin]]
+        self.by_builtin = dict()  # type: Dict[str, PyType[Builtin]]
 
     def add(self, builtin: "PyType[Builtin]"):
         if builtin.builtin is not None:
-            self.by_builtin[builtin.builtin] = builtin
+            self.by_builtin[builtin.builtin] = builtin  # type: ignore
         elif builtin.name is not None:
-            self.by_name[builtin.name] = builtin
+            self.by_name[builtin.name] = builtin  # type: ignore
         else:
             raise ValueError(f"A builtin could not be registered! {builtin!r}")
 
@@ -72,11 +76,11 @@ class BuiltinTable:
         """
         if isinstance(ref, BuiltinFunction):
             # All BuiltinFunctions MUST be defined
-            return self.by_builtin[ref]
+            return self.by_builtin[ref]  # type: ignore
         elif isinstance(ref, (ValName, TypeReference)):
-            return self.by_name.get(package_local_name(ref))
+            return self.by_name.get(package_local_name(ref))  # type: ignore
         elif isinstance(ref, str):
-            return self.by_name.get(ref)
+            return self.by_name.get(ref)  # type: ignore
         else:
             raise TypeError(f"unexpected key type: {ref!r}")
 

--- a/python/dazl/damlast/builtins.py
+++ b/python/dazl/damlast/builtins.py
@@ -7,10 +7,15 @@ simplicity.
 """
 
 from typing import Any, Optional, Sequence
+import warnings
 
 from . import daml_types as daml
 from ._builtins_meta import Builtin, BuiltinTable
 from .daml_lf_1 import BuiltinFunction, Expr, PrimLit, Type
+
+warnings.warn(
+    "The symbols in dazl.damlast.builtin are deprecated", DeprecationWarning, stacklevel=2
+)
 
 builtins = BuiltinTable()
 

--- a/python/dazl/damlast/daml_lf_1.py
+++ b/python/dazl/damlast/daml_lf_1.py
@@ -1477,7 +1477,7 @@ class Expr:
         from_required_interface: "_typing.Callable[[FromRequiredInterface], _T]",
         unsafe_from_required_interface: "_typing.Callable[[UnsafeFromRequiredInterface], _T]",
         experimental: "_typing.Callable[[Expr.Experimental], _T]",
-    ) -> "T":
+    ) -> "_T":
         if self._Sum_name == "var":
             return var(self.var)  # type: ignore
         elif self._Sum_name == "val":

--- a/python/dazl/damlast/eval_scope.py
+++ b/python/dazl/damlast/eval_scope.py
@@ -68,7 +68,7 @@ class EvaluationScope:
         return self._vars[var_name]
 
     def resolve_type(self, type_ref) -> "Type":
-        pass
+        raise RuntimeError("this function is not implemented")
 
     def resolve_value(self, value_ref) -> "Optional[Expr]":
         if value_ref in self._blocked_value_refs:

--- a/python/dazl/damlast/pkgfile.py
+++ b/python/dazl/damlast/pkgfile.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from os import PathLike
 from pathlib import Path
 import threading
-from typing import AbstractSet, BinaryIO, Collection, Generator, Mapping, Optional, Union
+from typing import AbstractSet, BinaryIO, Collection, Generator, Mapping, Optional, TypeVar, Union
 import warnings
 from zipfile import ZipFile
 
@@ -18,6 +18,8 @@ from .parse import parse_archive
 Dar = Union[bytes, str, Path, BinaryIO]
 
 __all__ = ["Dar", "DarFile", "CachedDarFile", "get_dar_package_ids"]
+
+Self = TypeVar("Self")
 
 
 class DarFile:
@@ -62,7 +64,7 @@ class DarFile:
         else:
             raise TypeError("DarFile only understands file paths or binary blobs")
 
-    def __enter__(self) -> "DarFile":
+    def __enter__(self: Self) -> "Self":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/python/dazl/ledger/__init__.pyi
+++ b/python/dazl/ledger/__init__.pyi
@@ -384,8 +384,8 @@ class Connection(PackageService, Protocol):
     def allocate_party(
         self,
         *,
-        identifier_hint: str = None,
-        display_name: str = None,
+        identifier_hint: Optional[str] = None,
+        display_name: Optional[str] = None,
         timeout: Optional[TimeDeltaLike] = ...,
     ) -> Union[PartyInfo, Awaitable[PartyInfo]]: ...
     def list_known_parties(

--- a/python/dazl/ledger/grpc/conn_aio.py
+++ b/python/dazl/ledger/grpc/conn_aio.py
@@ -852,8 +852,8 @@ class Connection(aio.Connection):
     async def allocate_party(
         self,
         *,
-        identifier_hint: str = None,
-        display_name: str = None,
+        identifier_hint: Optional[str] = None,
+        display_name: Optional[str] = None,
         timeout: Optional[TimeDeltaLike] = None,
     ) -> PartyInfo:
         """

--- a/python/dazl/model/types.py
+++ b/python/dazl/model/types.py
@@ -722,13 +722,8 @@ class TemplateChoice:
         self._controllers = controllers
 
     @property
-    def type(self):
+    def type(self) -> Type:
         return self.data_type
-
-    def controllers(self, cdata: ContractData) -> Collection[Party]:
-        """
-        Return every :class:`Party` that can exercise this choice given the specified contract data.
-        """
 
 
 def as_commands(commands_ish, allow_callables=False):

--- a/python/dazl/model/types_store.py
+++ b/python/dazl/model/types_store.py
@@ -61,7 +61,7 @@ class PackageStoreBuilder:
     Convenience class for building up a :class:`PackageStore`.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         warnings.warn(
             "PackageStoreBuilder is deprecated; there is no direct replacement.",
             DeprecationWarning,

--- a/python/dazl/pretty/table/model.py
+++ b/python/dazl/pretty/table/model.py
@@ -35,7 +35,7 @@ class TableBuilder:
     State built up during a ledger run.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.entries = dict()  # type: Dict[ContractId, RowBuilder]
 
     def add(

--- a/python/dazl/protocols/_base.py
+++ b/python/dazl/protocols/_base.py
@@ -150,6 +150,7 @@ class LedgerClient:
         """
         Return the (current) last offset of the ledger.
         """
+        raise NotImplementedError("events_end must be implemented")
 
 
 class _LedgerConnection:

--- a/python/dazl/testing/connect.pyi
+++ b/python/dazl/testing/connect.pyi
@@ -35,7 +35,7 @@ def connect_with_new_party(
     act_as: Union[None, Party, Collection[Party]] = None,
     admin: Optional[bool] = False,
     ledger_id: Optional[str] = None,
-    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    dar: Union[None, str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
     display_name: Union[None, str, NameGenFn] = None
 ) -> AsyncContextManager[ConnectionWithParty]: ...
@@ -48,7 +48,7 @@ def connect_with_new_party(
     act_as: Union[None, Party, Collection[Party]] = None,
     admin: Optional[bool] = False,
     ledger_id: Optional[str] = None,
-    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    dar: Union[None, str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
     display_name: Union[None, str, NameGenFn] = None
 ) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty]]: ...
@@ -61,7 +61,7 @@ def connect_with_new_party(
     act_as: Union[None, Party, Collection[Party]] = None,
     admin: Optional[bool] = False,
     ledger_id: Optional[str] = None,
-    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    dar: Union[None, str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
     display_name: Union[None, str, NameGenFn] = None
 ) -> AsyncContextManager[Tuple[ConnectionWithParty, ConnectionWithParty, ConnectionWithParty]]: ...
@@ -74,7 +74,7 @@ def connect_with_new_party(
     act_as: Union[None, Party, Collection[Party]] = None,
     admin: Optional[bool] = False,
     ledger_id: Optional[str] = None,
-    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    dar: Union[None, str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
     display_name: Union[None, str, NameGenFn] = None
 ) -> AsyncContextManager[
@@ -89,7 +89,7 @@ def connect_with_new_party(
     act_as: Union[None, Party, Collection[Party]] = None,
     admin: Optional[bool] = False,
     ledger_id: Optional[str] = None,
-    dar: Union[str, bytes, PathLike, BinaryIO] = None,
+    dar: Union[None, str, bytes, PathLike, BinaryIO] = None,
     identifier_hint: Union[None, str, NameGenFn] = None,
     display_name: Union[None, str, NameGenFn] = None
 ) -> AsyncContextManager[Sequence[ConnectionWithParty]]: ...

--- a/python/dazl/util/asyncio_util.py
+++ b/python/dazl/util/asyncio_util.py
@@ -371,7 +371,7 @@ class LongRunningAwaitable:
 class ServiceQueue(Generic[T]):
 
     # noinspection PyDeprecation
-    def __init__(self):
+    def __init__(self) -> None:
         warnings.warn(
             "ServiceQueue is deprecated; there is no planned replacement",
             DeprecationWarning,
@@ -415,12 +415,6 @@ class ServiceQueue(Generic[T]):
         self._q.put_nowait((None, fut))
         return fut
 
-    def abort(self) -> Sequence[T_co]:
-        """
-        Gracefully terminate the open iterator as quickly as possible and return all remaining
-        elements in the queue.
-        """
-
     async def next(self) -> Optional[T_co]:
         if not self._service_fut.done():
             await self._service_fut
@@ -435,7 +429,7 @@ class ServiceQueue(Generic[T]):
             fut.set_result(None)
             return None
         else:
-            self._prev_fut = fut
+            self._prev_fut = fut  # type: ignore
             return value
 
     def __aiter__(self):

--- a/python/dazl/util/dar_repo.py
+++ b/python/dazl/util/dar_repo.py
@@ -4,14 +4,14 @@ from contextlib import ExitStack
 from os import PathLike, fspath
 from pathlib import Path
 import time
-from typing import List, Sequence, Union
+from typing import List, Sequence, Set, Union
 import warnings
 
 from .. import LOG
 
 
 class LocalDarRepository:
-    def __init__(self):
+    def __init__(self) -> None:
         warnings.warn(
             "LocalDarRepository is deprecated; use PackageLookup instead",
             DeprecationWarning,
@@ -19,7 +19,7 @@ class LocalDarRepository:
         )
         self._context = ExitStack()
         self._dar_paths = []  # type: List[Path]
-        self._files = set()
+        self._files = set()  # type: Set[Path]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
 


### PR DESCRIPTION
python: Fix a handful of errors and warnings that are triggered by the latest version of mypy.

The version of mypy on the `v7` branch is behind `main`, so these violations wouldn't have necessarily failed the `v7` build, but they are currently preventing a merge to `main`.