### PR TITLE
Add `[build-system]` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,7 @@ log_cli = true
 log_cli_level = "DEBUG"
 junit_family = "xunit1"
 testpaths = ["python/tests/structure", "python/tests/unit"]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I think this is standard so tooling knows what to get to interpret the `[tool.poetry.*]` sections?

In any event, I needed this information in order to package and build this project (from the PyPI sdist, not git repo) in Nixpkgs.