### PR TITLE
go: Simplify the process around building Go bindings.

### DIFF
--- a/python/_dazl_pb/plugin_go/plugin_grpc.py
+++ b/python/_dazl_pb/plugin_go/plugin_grpc.py
@@ -12,5 +12,6 @@ __all__ = ["run_plugin"]
 
 
 def run_plugin(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
-    response = protoc.run_plugin("grpc_go", request)
+    request.parameter = "paths=source_relative"
+    response = protoc.run_plugin("go-grpc", util.services_only(request))
     return util.with_file_header(response, HEADER)

--- a/python/_dazl_pb/plugin_go/plugin_pb.py
+++ b/python/_dazl_pb/plugin_go/plugin_pb.py
@@ -11,6 +11,7 @@ __all__ = ["run_plugin"]
 
 
 def run_plugin(request: CodeGeneratorRequest) -> CodeGeneratorResponse:
+    request.parameter = "paths=source_relative"
     # the default Go plugin already seems to respect copyright headers, so we don't actually
     # need to make any changes to the generated code
     return protoc.run_plugin("go", request)

--- a/python/_dazl_pb/protoc/__init__.py
+++ b/python/_dazl_pb/protoc/__init__.py
@@ -126,7 +126,7 @@ def run_plugin_built_in(plugin_name: str, request: CodeGeneratorRequest) -> Code
 
 
 def run_plugin_external(plugin_name: str, request: CodeGeneratorRequest) -> CodeGeneratorResponse:
-    args = ["protoc-gen-" + plugin_name]  # type: List[str]
+    args = [".cache/bin/protoc-gen-" + plugin_name]  # type: List[str]
     proc = subprocess.run(args, input=request.SerializeToString(), capture_output=True)  # type: ignore
 
     response = CodeGeneratorResponse()

--- a/python/_dazl_pb/util/__init__.py
+++ b/python/_dazl_pb/util/__init__.py
@@ -28,11 +28,16 @@ def with_file_header(response: CodeGeneratorResponse, header: str) -> CodeGenera
 def services_only(request: CodeGeneratorRequest) -> CodeGeneratorRequest:
     """
     Create a :class:`CodeGeneratorRequest` with the non-gRPC files stripped out (those without
-    ``service`` declarations. The original request is not modified.
+    ``service`` declarations). The original request is not modified.
     """
-    # include all of the Protobuf files, but restrict the list of "files_to_generate"
+    # include all the Protobuf files, but restrict the list of "files_to_generate" to those
+    # with at least one defined gRPC service
     files_with_services = {f.name for f in request.proto_file if len(f.service) > 0}
-    return CodeGeneratorRequest(
+    rewritten_request = CodeGeneratorRequest(
         proto_file=request.proto_file,
         file_to_generate=[f for f in request.file_to_generate if f in files_with_services],
+        compiler_version=request.compiler_version,
     )
+    if request.HasField("parameter"):
+        rewritten_request.parameter = request.parameter
+    return rewritten_request


### PR DESCRIPTION
go: Cut out the code in the `Makefile` dedicated to generating Go protobuf/gRPC bindings, and move all the logic into the specialized plugin. Prior to this PR, there was weird logic in the plugin, and weird logic in the `Makefile`. This changes things so that only place has weird logic—the plugin.