### PR TITLE
python: Redefine Command as a sealed type.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ python-gen: $(proto_gen_python_src)
 # python: run mypy
 .PHONY: python-typecheck
 python-typecheck: .venv/poetry.lock
-	poetry run python3 -m mypy python $(protos)
+	poetry run python3 -m mypy python $(protos) --exclude='.*_py3_10\.py$$'
 
 # python: build BOTH $(py_bdist) and $(py_sdist)
 $(py_sdist) $(py_bdist) &: $(py_src)

--- a/python/dazl/client/bots.py
+++ b/python/dazl/client/bots.py
@@ -32,6 +32,7 @@ import warnings
 
 from .. import LOG
 from ..ledger import Command, CreateEvent, ExerciseResponse
+from ..ledger.api_types import is_command
 from ..prim import Party
 from ..protocols.events import BaseEvent
 from ..util.asyncio_util import LongRunningAwaitable, Signal, completed, failed, propagate
@@ -489,7 +490,7 @@ def wrap_as_command_submission(
 
         if ret is None:
             return completed(None)
-        elif isinstance(ret, (CommandBuilder, Command, list, tuple)):
+        elif is_command(ret) or isinstance(ret, (CommandBuilder, list, tuple)):
             try:
                 ret_fut = submit_fn(ret)
             except BaseException as exception:
@@ -523,7 +524,7 @@ def wrap_as_command_submission(
                         fut.set_result(None)
                     elif isinstance(ret, (CreateEvent, ExerciseResponse)):
                         fut.set_result(ret)
-                    elif isinstance(ret, (CommandBuilder, Command, list, tuple)):
+                    elif is_command(ret) or isinstance(ret, (CommandBuilder, list, tuple)):
                         propagate(ensure_future(submit_fn(ret)), fut)
                     elif inspect.isawaitable(ret):
                         LOG.error("A callback cannot return an Awaitable of an Awaitable")

--- a/python/dazl/client/commands.py
+++ b/python/dazl/client/commands.py
@@ -15,7 +15,7 @@ import warnings
 
 from ..damlast import TypeConName
 from ..ledger import Command, CreateAndExerciseCommand, CreateCommand, ExerciseCommand
-from ..ledger.api_types import Commands
+from ..ledger.api_types import Commands, is_command
 from ..prim import ContractData, ContractId, Party
 
 __all__ = [
@@ -214,16 +214,16 @@ def flatten_command_sequence(commands: Sequence[Commands]) -> List[Command]:
 
     for i, obj in enumerate(commands):
         if obj is not None:
-            if isinstance(obj, Command):
+            if is_command(obj):
                 ret.append(obj)
             else:
                 try:
-                    cmd_iter = iter(obj)
+                    cmd_iter = iter(obj)  # type: ignore
                 except TypeError:
                     errors.append(((i,), obj))
                     continue
                 for j, cmd in enumerate(cmd_iter):
-                    if isinstance(cmd, Command):
+                    if is_command(cmd):
                         ret.append(cmd)
                     else:
                         errors.append(((i, j), cmd))

--- a/python/dazl/ledger/grpc/conn_aio.py
+++ b/python/dazl/ledger/grpc/conn_aio.py
@@ -62,6 +62,8 @@ from ..api_types import (
     Right,
     User,
     Version,
+    is_command,
+    to_commands,
 )
 from ..config import Config
 from ..config.access import TokenBasedAccessConfig
@@ -181,12 +183,8 @@ class Connection(aio.Connection):
         into Daml so that only a single command is needed from the outside in order to satisfy your
         use case.
         """
-        if commands is None:
-            return
-        elif isinstance(commands, Command):
-            commands = [commands]
-
-        if len(commands) == 0:
+        commands = to_commands(commands)
+        if not commands:
             return
 
         retry_timeout = self._retry_timeout(timeout)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -4,10 +4,16 @@
 from __future__ import annotations
 
 from concurrent.futures.thread import ThreadPoolExecutor
+import sys
 from typing import Generator
 
 from dazl import testing
 import pytest
+
+# match statements are syntax errors in Python 3.8 and 3.9; we must exclude them from
+# test discovery or pytest will fail to discover tests properly
+if sys.version_info < (3, 10):
+    collect_ignore_glob = ["*_py3_10.py"]
 
 
 @pytest.fixture(scope="session", params=["1", "2"])

--- a/python/tests/unit/test_command.py
+++ b/python/tests/unit/test_command.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dazl import Command, ContractId, CreateCommand
+from dazl.damlast.lookup import parse_type_con_name
+
+template_id_str = "deadbeef:DeadBeef:DeadBeef"
+template_id = parse_type_con_name(template_id_str)
+cid = ContractId(template_id, "#0:0")
+choice = "Cook"
+payload = {"operator": "beef", "weight": "10kg"}
+key = {"operator": "beef"}
+
+
+def test_isinstance() -> None:
+    cmd = CreateCommand(template_id, payload)
+
+    # we expect isinstance to succeed at runtime, even though mypy fails to
+    # typecheck it
+    assert isinstance(cmd, Command)  # type: ignore

--- a/python/tests/unit/test_command_builder.py
+++ b/python/tests/unit/test_command_builder.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-
 from __future__ import annotations
 
 from unittest import TestCase

--- a/python/tests/unit/test_command_py3_10.py
+++ b/python/tests/unit/test_command_py3_10.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017-2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+
+from dazl import (
+    Command,
+    CreateAndExerciseCommand,
+    CreateCommand,
+    ExerciseByKeyCommand,
+    ExerciseCommand,
+)
+
+if sys.version_info >= (3, 11):
+    from typing import assert_never
+else:
+    from typing_extensions import assert_never
+
+from .test_command import choice, cid, key, payload, template_id
+
+
+def test_match() -> None:
+    commands = list[Command](
+        [
+            CreateCommand(template_id, payload),
+            ExerciseCommand(cid, choice),
+            CreateAndExerciseCommand(template_id, payload, choice),
+            ExerciseByKeyCommand(template_id, key, choice),
+        ]
+    )
+
+    found_create = False
+    found_exercise = False
+    found_create_and_exercise = False
+    found_exercise_by_key = False
+    for cmd in commands:
+        match cmd:
+            case CreateCommand(matched_template_id):
+                assert template_id == matched_template_id
+                found_create = True
+            case ExerciseCommand(matched_cid, matched_choice, matched_argument):
+                assert cid == matched_cid
+                assert choice == matched_choice
+                assert matched_argument == {}
+                found_exercise = True
+            case CreateAndExerciseCommand(matched_template_id, matched_payload, matched_choice):
+                assert template_id == matched_template_id
+                assert payload == matched_payload
+                assert choice == matched_choice
+                found_create_and_exercise = True
+            case ExerciseByKeyCommand(
+                matched_template_id, matched_key, matched_choice, matched_arg
+            ):
+                assert template_id == matched_template_id
+                assert key == matched_key
+                assert choice == matched_choice
+                assert matched_arg == {}
+                found_exercise_by_key = True
+            case _:
+                assert_never(cmd)
+
+    assert found_create
+    assert found_exercise
+    assert found_create_and_exercise
+    assert found_exercise_by_key


### PR DESCRIPTION
This is a bit of an experiment on the ergonomics of defining:

```python
Command = CreateCommand | ExerciseCommand | CreateAndExerciseCommand | ExerciseByKeyCommand
```

instead of the more traditional:

```python
class Command: ...
class CreateCommand(Command): ...
class ExerciseCommand(Command): ...
class CreateAndExerciseCommand(Command): ...
class ExerciseByKeyCommand(Command): ...
```

The advantage of using union types is mypy and other Python typecheckers can do a much better job of exhaustiveness checks. The disadvantage is that under Python 3.8 and Python 3.9, using union types breaks `isinstance` checks. This PR hacks around it by using defining alternate implementations for those two versions of Python, but keeping the typing definition union-based. (Side note: unfortunately Python 3.9 is scheduled for EOL in October 2025 so we'll be stuck with this awkwardness for a while.)

PEP 622, the original proposal for structural pattern matching included [sealed types](https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types), but [PEP 634](https://peps.python.org/pep-0634/), which succeeded it, dropped them. That would allowed us to use the best of both options, but sadly it isn't an option.