### PR TITLE
python: Properly type connect arguments.

### DIFF
--- a/python/dazl/ledger/__init__.pyi
+++ b/python/dazl/ledger/__init__.pyi
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from logging import Logger
-from os import PathLike
+import sys
 from typing import (
     AbstractSet,
     Any,
@@ -25,7 +24,6 @@ from typing import (
 
 from ..damlast import TypeConName
 from ..damlast.daml_lf_1 import PackageRef
-from ..damlast.lookup import SymbolLookup
 from ..prim import ContractData, ContractId, Parties, TimeDeltaLike
 from ..query import Queries, Query
 from .aio import Connection as AioConnection, QueryStream as AioQueryStream
@@ -54,7 +52,12 @@ from .api_types import (
     Version,
 )
 from .blocking import Connection as BlockingConnection, QueryStream as BlockingQueryStream
-from .config import Config
+from .config import Config, ConfigArgs
+
+if sys.version_info >= (3, 12):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 __all__ = [
     "aio",
@@ -113,126 +116,20 @@ class OnBoundaryDecorator(Protocol):
 # dazl.ledger.blocking above, even though that's not actually the case. Either way we silence
 # that warning too.
 #
-# TODO: Look into ways of generating this signatures from Config.create
-#
-# noinspection PyShadowingNames
 @overload
-def connect(
-    *,
-    url: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    scheme: Optional[str] = None,
-    read_as: Optional[Parties] = None,
-    act_as: Optional[Parties] = None,
-    admin: Optional[bool] = False,
-    ledger_id: Optional[str] = None,
-    application_name: Optional[str] = None,
-    oauth_token: Optional[str] = None,
-    oauth_token_file: Optional[str] = None,
-    ca: Optional[bytes] = None,
-    ca_file: Optional[PathLike] = None,
-    cert: Optional[bytes] = None,
-    cert_file: Optional[PathLike] = None,
-    cert_key: Optional[bytes] = None,
-    cert_key_file: Optional[PathLike] = None,
-    connect_timeout: Optional[TimeDeltaLike] = None,
-    use_http_proxy: bool = True,
-    logger: Optional[Logger] = None,
-    logger_name: Optional[str] = None,
-    log_level: Optional[str] = None,
-    lookup: Optional[SymbolLookup] = None,
-) -> AioConnection: ...
+def connect(**kwargs: Unpack[ConfigArgs]) -> AioConnection: ...
 
 # noinspection PyShadowingNames
 @overload
-def connect(
-    *,
-    blocking: Literal[False],
-    url: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    scheme: Optional[str] = None,
-    read_as: Optional[Parties] = None,
-    act_as: Optional[Parties] = None,
-    admin: Optional[bool] = False,
-    ledger_id: Optional[str] = None,
-    application_name: Optional[str] = None,
-    oauth_token: Optional[str] = None,
-    oauth_token_file: Optional[str] = None,
-    ca: Optional[bytes] = None,
-    ca_file: Optional[PathLike] = None,
-    cert: Optional[bytes] = None,
-    cert_file: Optional[PathLike] = None,
-    cert_key: Optional[bytes] = None,
-    cert_key_file: Optional[PathLike] = None,
-    connect_timeout: Optional[TimeDeltaLike] = None,
-    use_http_proxy: bool = True,
-    logger: Optional[Logger] = None,
-    logger_name: Optional[str] = None,
-    log_level: Optional[str] = None,
-    lookup: Optional[SymbolLookup] = None,
-) -> AioConnection: ...
+def connect(*, blocking: Literal[False], **kwargs: Unpack[ConfigArgs]) -> AioConnection: ...
 
 # noinspection PyShadowingNames
 @overload
-def connect(
-    *,
-    blocking: Literal[True],
-    url: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    scheme: Optional[str] = None,
-    read_as: Optional[Parties] = None,
-    act_as: Optional[Parties] = None,
-    admin: Optional[bool] = False,
-    ledger_id: Optional[str] = None,
-    application_name: Optional[str] = None,
-    oauth_token: Optional[str] = None,
-    oauth_token_file: Optional[str] = None,
-    ca: Optional[bytes] = None,
-    ca_file: Optional[PathLike] = None,
-    cert: Optional[bytes] = None,
-    cert_file: Optional[PathLike] = None,
-    cert_key: Optional[bytes] = None,
-    cert_key_file: Optional[PathLike] = None,
-    connect_timeout: Optional[TimeDeltaLike] = None,
-    use_http_proxy: bool = True,
-    logger: Optional[Logger] = None,
-    logger_name: Optional[str] = None,
-    log_level: Optional[str] = None,
-    lookup: Optional[SymbolLookup] = None,
-) -> BlockingConnection: ...
+def connect(*, blocking: Literal[True], **kwargs: Unpack[ConfigArgs]) -> BlockingConnection: ...
 
 # noinspection PyShadowingNames
 @overload
-def connect(
-    *,
-    blocking: bool,
-    url: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    scheme: Optional[str] = None,
-    read_as: Optional[Parties] = None,
-    act_as: Optional[Parties] = None,
-    admin: Optional[bool] = False,
-    ledger_id: Optional[str] = None,
-    application_name: Optional[str] = None,
-    oauth_token: Optional[str] = None,
-    oauth_token_file: Optional[str] = None,
-    ca: Optional[bytes] = None,
-    ca_file: Optional[PathLike] = None,
-    cert: Optional[bytes] = None,
-    cert_file: Optional[PathLike] = None,
-    cert_key: Optional[bytes] = None,
-    cert_key_file: Optional[PathLike] = None,
-    connect_timeout: Optional[TimeDeltaLike] = None,
-    use_http_proxy: bool = True,
-    logger: Optional[Logger] = None,
-    logger_name: Optional[str] = None,
-    log_level: Optional[str] = None,
-    lookup: Optional[SymbolLookup] = None,
-) -> Connection: ...
+def connect(*, blocking: bool, **kwargs: Unpack[ConfigArgs]) -> Connection: ...
 
 class PackageService(Protocol):
     def get_package(

--- a/python/dazl/ledger/config/log.py
+++ b/python/dazl/ledger/config/log.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2017-2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from logging import Logger
+from typing import Optional, TypedDict
+
+__all__ = ["LoggerArgs"]
+
+
+class LoggerArgs(TypedDict, total=False):
+    logger: Optional[Logger]

--- a/python/dazl/ledger/config/url.py
+++ b/python/dazl/ledger/config/url.py
@@ -8,16 +8,25 @@ import ipaddress
 from logging import Logger, getLogger
 import os
 from reprlib import repr
+import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, TypedDict, runtime_checkable
 from urllib.parse import urlparse
 import warnings
 
 from ...prim import TimeDeltaLike, to_timedelta
 from .exc import ConfigError, ConfigWarning
+from .log import LoggerArgs
+
+if sys.version_info >= (3, 12):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 __all__ = [
     "URLConfig",
+    "URLConfigArgs",
+    "_URLConfigArgs",
     "create_url",
     "KNOWN_SCHEME_PORTS",
     "DEFAULT_CONNECT_TIMEOUT",
@@ -46,23 +55,36 @@ DAML_LEDGER_PORT = "DAML_LEDGER_PORT"
 DAML_LEDGER_SCHEME = "DAML_LEDGER_SCHEME"
 
 
-def create_url(
-    *,
-    url: Optional[str] = None,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    scheme: Optional[str] = None,
-    connect_timeout: Optional[TimeDeltaLike] = None,
-    retry_timeout: Optional[TimeDeltaLike] = None,
-    use_http_proxy: Optional[bool] = None,
-    logger: Optional[Logger] = None,
-):
+class URLConfigArgs(TypedDict, total=False):
+    url: Optional[str]
+    host: Optional[str]
+    port: Optional[int]
+    scheme: Optional[str]
+    connect_timeout: Optional[TimeDeltaLike]
+    retry_timeout: Optional[TimeDeltaLike]
+    use_http_proxy: Optional[bool]
+
+
+class _URLConfigArgs(URLConfigArgs, LoggerArgs, total=False):
+    pass
+
+
+def create_url(**kwargs: Unpack[_URLConfigArgs]):
     """
     Create an instance of :class:`URLConfig`, possibly with values taken from environment variables,
     or defaulted if otherwise unspecified.
 
     See :meth:`Config.create` for a more detailed description of these parameters.
     """
+    url = kwargs.get("url", None)
+    host = kwargs.get("host", None)
+    port = kwargs.get("port", None)
+    scheme = kwargs.get("scheme", None)
+    connect_timeout = kwargs.get("connect_timeout", None)
+    retry_timeout = kwargs.get("retry_timeout", None)
+    use_http_proxy = kwargs.get("use_http_proxy", None)
+    logger = kwargs.get("logger", None)
+
     if logger is None:
         logger = getLogger("dazl.conn")
 


### PR DESCRIPTION
Now that `Unpack` exists (https://peps.python.org/pep-0692/), it's possible to reduce some of the boilerplate around the type signatures of `connect`. 

So fix that, which also fixes a subtle error in the current set of typing rules: `retry_timeout` was never added to `connect` even though it's supported just fine.