### PR TITLE
python: Make the testing sandbox more resilient on startup.

### DIFF
--- a/python/dazl/testing/_sandbox.py
+++ b/python/dazl/testing/_sandbox.py
@@ -179,7 +179,7 @@ class SandboxLauncher:
                 raise RuntimeError("we somehow have a process without a URL")
 
             if self._use_auth or self._use_tls:
-                self._certificate = cert_gen(subject_alternative_name="localhost")
+                self._certificate = cert_gen(subject_alternative_name=["127.0.0.1", "localhost"])
 
                 temp_dir = Path(self._exit_stack.enter_context(tempfile.TemporaryDirectory()))
                 self._crt_file = temp_dir / "tmp.crt"
@@ -210,7 +210,12 @@ class SandboxLauncher:
                 universal_newlines=True,
             )
             ProcessLogger(self._process, self.log).start()
-            wait_for_process_port(self._process, self._url_source.port, DEFAULT_TIMEOUT)
+            wait_for_process_port(
+                self._process,
+                self._url_source.port,
+                DEFAULT_TIMEOUT,
+                participant_admin_port=options.participant_admin_port,
+            )
 
     def stop(self) -> None:
         """
@@ -260,6 +265,7 @@ class SandboxLauncher:
 
 class SandboxOptions:
     port: int
+    participant_admin_port: int
     project_root: Optional[str] = None
     ledger_id: Optional[str] = None
     use_auth: bool = False
@@ -271,6 +277,7 @@ class SandboxOptions:
         self,
         *,
         port: int,
+        participant_admin_port: Optional[int] = None,
         project_root: Optional[str] = None,
         ledger_id: Optional[str] = None,
         use_auth: bool = False,
@@ -279,6 +286,9 @@ class SandboxOptions:
         key_file: Optional[Path] = None,
     ):
         object.__setattr__(self, "port", port)
+        object.__setattr__(
+            self, "participant_admin_port", participant_admin_port or find_free_port()
+        )
         object.__setattr__(self, "project_root", project_root)
         object.__setattr__(self, "ledger_id", ledger_id)
         object.__setattr__(self, "use_auth", use_auth)
@@ -317,7 +327,6 @@ class SandboxOptions:
         if self.ledger_id and (self.ledger_id != "sandbox"):
             raise ValueError('for Daml 2.x ledgers, ledger ID must be unset, or set to "sandbox"')
 
-        participant_admin_port = find_free_port()
         domain_api_port = find_free_port()
         domain_admin_port = find_free_port()
 
@@ -329,7 +338,7 @@ class SandboxOptions:
         # for the time being, we don't use any of Canton's other ports, but it's important that
         # they are bound to random ports to avoid conflicts
         config_options = {
-            f"{participant}.admin-api.port": str(participant_admin_port),
+            f"{participant}.admin-api.port": str(self.participant_admin_port),
             f"{domain}.public-api.port": str(domain_api_port),
             f"{domain}.admin-api.port": str(domain_admin_port),
         }
@@ -343,12 +352,15 @@ class SandboxOptions:
                 self.cert_file
             )
         if self.use_tls:
-            # config_options["canton.participants.sandbox.ledger-api.host"] = "localhost"
             if self.cert_file is None:
                 raise ValueError("cert_file must be specified when use_auth=True")
             if self.key_file is None:
-                raise ValueError("cert_file must be specified when use_auth=True")
+                raise ValueError("key_file must be specified when use_auth=True")
 
+            # with TLS on, recent Java versions enforce SNI name consistency,
+            # but for some reason, SANs with "127.0.0.1" are also rejected, so we need
+            # to use "localhost" here
+            config_options[f"{participant}.ledger-api.address"] = "localhost"
             config_options[f"{participant}.ledger-api.tls.cert-chain-file"] = str(self.cert_file)
             config_options[f"{participant}.ledger-api.tls.private-key-file"] = str(self.key_file)
 

--- a/python/dazl/util/proc_util.py
+++ b/python/dazl/util/proc_util.py
@@ -3,13 +3,21 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from datetime import datetime
 import logging
+from os import PathLike
+from pathlib import Path
 from subprocess import Popen, TimeoutExpired
 import sys
 from threading import Event, Thread
 import time
+from typing import Optional
 
+from google.protobuf.empty_pb2 import Empty
+from grpc import insecure_channel, secure_channel, ssl_channel_credentials
+
+from .._gen.com.digitalasset.canton.health.admin.v0.status_service_pb2_grpc import StatusServiceStub
 from ..prim import DazlError, TimeDeltaLike, to_timedelta
 
 __all__ = ["kill_process_tree", "wait_for_process_port", "ProcessLogger", "ProcessDiedException"]
@@ -50,7 +58,14 @@ def kill_process_tree(process: Popen):
         process.communicate()
 
 
-def wait_for_process_port(process: Popen, port: int, timeout: TimeDeltaLike) -> None:
+def wait_for_process_port(
+    process: Popen,
+    port: int,
+    timeout: TimeDeltaLike,
+    *,
+    participant_admin_port: Optional[int] = None,
+    participant_admin_cert_file: Optional[PathLike] = None,
+) -> None:
     from .io import is_port_alive
 
     alive = False
@@ -63,8 +78,30 @@ def wait_for_process_port(process: Popen, port: int, timeout: TimeDeltaLike) -> 
         and not alive
     ):
         alive = is_port_alive(port)
-        if not alive:
-            time.sleep(0.1)
+        if alive:
+            # testing configurations might always include a participant_admin_port, even if it's not used
+            # (for example, a Daml 1.x test); so additionally check for an active participant_admin_port
+            # and only do a status check if that port is open
+            if participant_admin_port is not None and is_port_alive(participant_admin_port):
+                logging.debug("Waiting for the participant to report itself as active...")
+                with ExitStack() as stack:
+                    if participant_admin_cert_file is not None:
+                        credentials = ssl_channel_credentials(
+                            root_certificates=Path(participant_admin_cert_file).read_bytes()
+                        )
+                        channel = stack.enter_context(
+                            secure_channel(f"localhost:{participant_admin_port}", credentials)
+                        )
+                    else:
+                        channel = stack.enter_context(
+                            insecure_channel(f"localhost:{participant_admin_port}")
+                        )
+                    status_service = StatusServiceStub(channel)
+                    response = status_service.Status(Empty())
+                    alive = response.success.active
+
+                if not alive:
+                    time.sleep(0.5)
 
     if not alive:
         return_code = process.returncode


### PR DESCRIPTION
Numerous improvements to dazl to make them a little less fragile:
* Have the sandbox testing fixture hit the participant admin endpoint and actively check for `active` status before allowing tests to start. This should put an end to the `NO_DOMAIN_FOR_SUBMISSION` errors once and for all.
* Recent versions of Java seem to be more strict about TLS treatment, so make the participant start up with an explicit address of `localhost`, so that the SNI in our TLS test matches how we connect to it.