### PR TITLE
docs: Add a disclaimer that dazl does not work with 3.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copyright (c) 2017-2025 Digital Asset (Switzerland) GmbH and/or its affiliates. 
 SPDX-License-Identifier: Apache-2.0
 
 
-Rich Python bindings for accessing Ledger API-based applications.
+Rich Python bindings for accessing Canton 2.x Ledger API-based applications. It is not intended for use with Canton 3.x.
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,12 +9,12 @@ Version |release|
 Dependencies
 ------------
 
-You will need Python 3.6 or later and a Daml Ledger.
+You will need Python 3.10 or later and a Canton 2.x Ledger. `dazl` is not intended for use with Canton 3.x.
 
 Getting Started
 ---------------
 
-This section assumes that you already have a running ledger with the standard `daml new` model
+This section assumes that you already have a running Canton 2.x ledger with the standard `daml new` model
 loaded, and have imported `dazl`.
 
 Connect to the ledger and submit a single command:


### PR DESCRIPTION
Essentially, #531, but not as a fork of the repo.