### PR TITLE
meta: Re-run codegen, which only bumps the protoc version that is stamped into codegen files.

### DIFF
--- a/python/dazl/_gen/com/daml/ledger/api/v1/active_contracts_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/active_contracts_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import active_contracts_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_active__contracts__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/command_inspection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/command_inspection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_inspection_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_command__inspection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/config_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/config_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import config_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_config__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/identity_provider_config_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/identity_provider_config_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import identity_provider_config_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_identity__provider__config__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/metering_report_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/metering_report_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import metering_report_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_metering__report__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/package_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/package_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_package__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/participant_pruning_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/participant_pruning_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_pruning_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_participant__pruning__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/party_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/party_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import party_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_party__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/admin/user_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/admin/user_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import user_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_admin_dot_user__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/command_completion_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/command_completion_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_completion_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_command__completion__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/command_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/command_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import command_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_command__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/command_submission_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/command_submission_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import command_submission_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_command__submission__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/event_query_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/event_query_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import event_query_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_event__query__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/ledger_configuration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/ledger_configuration_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import ledger_configuration_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_ledger__configuration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/ledger_identity_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/ledger_identity_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import ledger_identity_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_ledger__identity__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/package_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/package_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_package__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/testing/time_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/testing/time_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import time_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_testing_dot_time__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/transaction_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/transaction_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import transaction_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_transaction__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v1/version_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v1/version_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import version_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v1_dot_version__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/command_inspection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/command_inspection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_inspection_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_command__inspection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/identity_provider_config_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/identity_provider_config_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import identity_provider_config_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_identity__provider__config__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/package_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/package_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_package__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/participant_pruning_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/participant_pruning_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_pruning_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_participant__pruning__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/party_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/party_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import party_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_party__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/admin/user_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/admin/user_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import user_management_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_admin_dot_user__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/command_completion_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/command_completion_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_completion_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_command__completion__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/command_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/command_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_command__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/command_submission_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/command_submission_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import command_submission_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_command__submission__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/event_query_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/event_query_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import event_query_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_event__query__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/interactive/interactive_submission_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/interactive/interactive_submission_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import interactive_submission_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_interactive_dot_interactive__submission__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/package_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/package_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_package__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/state_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/state_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import state_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_state__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/testing/time_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/testing/time_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import time_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_testing_dot_time__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/update_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/update_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import update_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_update__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/version_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/version_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import version_service_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_version__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/health/v30/status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/health/v30/status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import status_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_health_dot_v30_dot_status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/mediator/v30/mediator_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/mediator/v30/mediator_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import mediator_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_mediator_dot_v30_dot_mediator__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/enterprise_participant_replication_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/enterprise_participant_replication_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import enterprise_participant_replication_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_enterprise__participant__replication__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/package_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/package_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_package__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_inspection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_inspection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_inspection_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_participant__inspection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_repair_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_repair_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_repair_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_participant__repair__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/participant_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_participant__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/party_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/party_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import party_management_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_party__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/ping_pong_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/ping_pong_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import ping_pong_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_ping__pong__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/pruning_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/pruning_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import pruning_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_pruning__service__pb2
 from ...pruning.v30 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_pruning_dot_v30_dot_pruning__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/resource_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/resource_management_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import resource_management_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_resource__management__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/synchronizer_connectivity_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import synchronizer_connectivity_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_synchronizer__connectivity__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/traffic_control_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/participant/v30/traffic_control_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import traffic_control_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_participant_dot_v30_dot_traffic__control__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/admin/sequencer/v30/sequencer_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_sequencer_dot_v30_dot_sequencer__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/connection/v30/api_info_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/connection/v30/api_info_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import api_info_pb2 as com_dot_digitalasset_dot_canton_dot_connection_dot_v30_dot_api__info__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/crypto/admin/v0/vault_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/crypto/admin/v0/vault_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import vault_service_pb2 as com_dot_digitalasset_dot_canton_dot_crypto_dot_admin_dot_v0_dot_vault__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/crypto/admin/v30/vault_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/crypto/admin/v30/vault_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import vault_service_pb2 as com_dot_digitalasset_dot_canton_dot_crypto_dot_admin_dot_v30_dot_vault__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_initialization_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import domain_initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_domain__initialization__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_manager_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_manager_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import domain_manager_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_domain__manager__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import domain_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_d
 from ....protocol.v0 import sequencing_pb2 as com_dot_digitalasset_dot_canton_dot_protocol_dot_v0_dot_sequencing__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/domain_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import domain_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_domain__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_mediator_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_mediator_administration_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import enterprise_mediator_administration_service_pb2 as com_dot_digitala
 from ....pruning.admin.v0 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_pruning_dot_admin_dot_v0_dot_pruning__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_sequencer_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_sequencer_administration_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import enterprise_sequencer_administration_service_pb2 as com_dot_digital
 from ....pruning.admin.v0 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_pruning_dot_admin_dot_v0_dot_pruning__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_sequencer_connection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/enterprise_sequencer_connection_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import enterprise_sequencer_connection_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_enterprise__sequencer__connection__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/mediator_initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/mediator_initialization_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import mediator_initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_mediator__initialization__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/mediator_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/mediator_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import mediator_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_mediator__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_administration_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import sequencer_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_sequencer__administration__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_initialization_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import sequencer_initialization_service_pb2 as com_dot_digitalasset_dot_c
 from ..v1 import sequencer_initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v1_dot_sequencer__initialization__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_admin_dot_v0_dot_sequencer__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_version_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/admin/v0/sequencer_version_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from ....protocol.v0 import sequencing_pb2 as com_dot_digitalasset_dot_canton_dot_protocol_dot_v0_dot_sequencing__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/domain_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/domain_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import service_agreement_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_api_dot_v0_dot_service__agreement__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/domain_time_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/domain_time_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import domain_time_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_api_dot_v0_dot_domain__time__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_authentication_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_authentication_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_authentication_service_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_api_dot_v0_dot_sequencer__authentication__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_connect_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_connect_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import sequencer_connect_service_pb2 as com_dot_digitalasset_dot_canton_d
 from . import service_agreement_pb2 as com_dot_digitalasset_dot_canton_dot_domain_dot_api_dot_v0_dot_service__agreement__pb2
 from ....protocol.v0 import sequencing_pb2 as com_dot_digitalasset_dot_canton_dot_protocol_dot_v0_dot_sequencing__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/domain/api/v0/sequencer_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import sequencer_service_pb2 as com_dot_digitalasset_dot_canton_dot_domai
 from ....protocol.v0 import sequencing_pb2 as com_dot_digitalasset_dot_canton_dot_protocol_dot_v0_dot_sequencing__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/health/admin/v0/status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/health/admin/v0/status_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import status_service_pb2 as com_dot_digitalasset_dot_canton_dot_health_dot_admin_dot_v0_dot_status__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_administration_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from ....admin.pruning.v30 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_pruning_dot_v30_dot_pruning__pb2
 from . import mediator_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_mediator_dot_admin_dot_v30_dot_mediator__administration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_initialization_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import mediator_initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_mediator_dot_admin_dot_v30_dot_mediator__initialization__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_inspection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/mediator_inspection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import mediator_inspection_service_pb2 as com_dot_digitalasset_dot_canton_dot_mediator_dot_admin_dot_v30_dot_mediator__inspection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/sequencer_connection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/mediator/admin/v30/sequencer_connection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_connection_service_pb2 as com_dot_digitalasset_dot_canton_dot_mediator_dot_admin_dot_v30_dot_sequencer__connection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/domain_connectivity_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/domain_connectivity_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import domain_connectivity_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_domain__connectivity__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/enterprise_participant_replication_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/enterprise_participant_replication_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import enterprise_participant_replication_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_enterprise__participant__replication__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/inspection_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/inspection_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import inspection_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_inspection__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/package_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/package_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import package_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_package__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/participant_repair_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/participant_repair_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_repair_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_participant__repair__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/participant_status_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/participant_status_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import participant_status_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_participant__status__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/party_name_management_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/party_name_management_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import party_name_management_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_party__name__management__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/ping_pong_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/ping_pong_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import ping_pong_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_ping__pong__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/pruning_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/pruning_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import pruning_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_pruning__service__pb2
 from ....pruning.admin.v0 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_pruning_dot_admin_dot_v0_dot_pruning__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/resource_management_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/resource_management_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from . import resource_management_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_resource__management__service__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/transfer_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/participant/admin/v0/transfer_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import transfer_service_pb2 as com_dot_digitalasset_dot_canton_dot_participant_dot_admin_dot_v0_dot_transfer__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_administration_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_admin_dot_v30_dot_sequencer__administration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_bft_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_bft_administration_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_bft_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_admin_dot_v30_dot_sequencer__bft__administration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_bft_pruning_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_bft_pruning_administration_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from ....admin.pruning.v30 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_pruning_dot_v30_dot_pruning__pb2
 from . import sequencer_bft_pruning_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_admin_dot_v30_dot_sequencer__bft__pruning__administration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_initialization_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_admin_dot_v30_dot_sequencer__initialization__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_pruning_administration_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/admin/v30/sequencer_pruning_administration_service_pb2_grpc.py
@@ -10,7 +10,7 @@ import warnings
 from ....admin.pruning.v30 import pruning_pb2 as com_dot_digitalasset_dot_canton_dot_admin_dot_pruning_dot_v30_dot_pruning__pb2
 from . import sequencer_pruning_administration_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_admin_dot_v30_dot_sequencer__pruning__administration__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_authentication_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_authentication_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_authentication_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_api_dot_v30_dot_sequencer__authentication__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_channel_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_channel_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_channel_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_api_dot_v30_dot_sequencer__channel__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_connect_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_connect_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_connect_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_api_dot_v30_dot_sequencer__connect__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/sequencer/api/v30/sequencer_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import sequencer_service_pb2 as com_dot_digitalasset_dot_canton_dot_sequencer_dot_api_dot_v30_dot_sequencer__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/synchronizer/sequencing/sequencer/bftordering/standalone/v1/standalone_bft_ordering_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/synchronizer/sequencing/sequencer/bftordering/standalone/v1/standalone_bft_ordering_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import standalone_bft_ordering_service_pb2 as com_dot_digitalasset_dot_canton_dot_synchronizer_dot_sequencing_dot_sequencer_dot_bftordering_dot_standalone_dot_v1_dot_standalone__bft__ordering__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/synchronizer/sequencing/sequencer/bftordering/v30/bft_ordering_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/synchronizer/sequencing/sequencer/bftordering/v30/bft_ordering_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import bft_ordering_service_pb2 as com_dot_digitalasset_dot_canton_dot_synchronizer_dot_sequencing_dot_sequencer_dot_bftordering_dot_v30_dot_bft__ordering__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/time/admin/v30/synchronizer_time_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/time/admin/v30/synchronizer_time_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import synchronizer_time_service_pb2 as com_dot_digitalasset_dot_canton_dot_time_dot_admin_dot_v30_dot_synchronizer__time__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/initialization_service_pb2_grpc.py
@@ -11,7 +11,7 @@ from . import initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_aggregation_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_aggregation_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_aggregation_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v0_dot_topology__aggregation__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_manager_read_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_manager_read_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_manager_read_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v0_dot_topology__manager__read__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_manager_write_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v0/topology_manager_write_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_manager_write_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v0_dot_topology__manager__write__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/initialization_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/initialization_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import initialization_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v30_dot_initialization__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_aggregation_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_aggregation_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v30_dot_topology__aggregation__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_manager_read_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_manager_read_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v30_dot_topology__manager__read__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service_pb2_grpc.py
+++ b/python/dazl/_gen/com/digitalasset/canton/topology/admin/v30/topology_manager_write_service_pb2_grpc.py
@@ -9,7 +9,7 @@ import warnings
 
 from . import topology_manager_write_service_pb2 as com_dot_digitalasset_dot_canton_dot_topology_dot_admin_dot_v30_dot_topology__manager__write__service__pb2
 
-GRPC_GENERATED_VERSION = '1.76.0'
+GRPC_GENERATED_VERSION = '1.80.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/python/dazl/_gen/com/digitalasset/daml/lf/archive/__init__.py
+++ b/python/dazl/_gen/com/digitalasset/daml/lf/archive/__init__.py
@@ -3,9 +3,9 @@
 # fmt: off
 # isort: skip_file
 
-
 from .daml_lf_pb2 import Archive, ArchivePayload, HashFunction
 from . import daml_lf1_pb2, daml_lf2_pb2
+
 __all__ = [
     "Archive",
     "ArchivePayload",


### PR DESCRIPTION
The Python gRPC code generator annoyingly stamps the specific version number of `protoc` used in each codegened file, which means we really should be running codegen on every grpc upgrade.

This PR is exactly that: 107 lines of version changes that result from running `make generate` on `HEAD`.

Kept separate from #578 and #577 for clarity.