### PR TITLE
go: Tweaks to the generated code to fix compilation errors.

### DIFF
--- a/go/api/com/digitalasset/daml/lf/transaction/transaction.pb.go
+++ b/go/api/com/digitalasset/daml/lf/transaction/transaction.pb.go
@@ -9,12 +9,13 @@
 package transaction
 
 import (
-	value "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/value"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	value "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/value"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -27,8 +28,8 @@ const (
 type Transaction struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
-	Roots         []string               `protobuf:"bytes,2,rep,name=roots,proto3" json:"roots,omitempty"`
-	Nodes         []*Node                `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
+	Roots         []string `protobuf:"bytes,2,rep,name=roots,proto3" json:"roots,omitempty"`
+	Nodes         []*Node  `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -360,8 +361,8 @@ type FatContractInstance struct {
 	NonMaintainerSignatories   []string               `protobuf:"bytes,5,rep,name=non_maintainer_signatories,json=nonMaintainerSignatories,proto3" json:"non_maintainer_signatories,omitempty"`
 	NonSignatoryStakeholders   []string               `protobuf:"bytes,6,rep,name=non_signatory_stakeholders,json=nonSignatoryStakeholders,proto3" json:"non_signatory_stakeholders,omitempty"`
 	CreatedAt                  int64                  `protobuf:"fixed64,7,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	AuthenticationData         []byte                 `protobuf:"bytes,8,opt,name=authentication_data,json=authenticationData,proto3" json:"authentication_data,omitempty"`
-	ContractKeyWithMaintainers *KeyWithMaintainers    `protobuf:"bytes,1001,opt,name=contract_key_with_maintainers,json=contractKeyWithMaintainers,proto3" json:"contract_key_with_maintainers,omitempty"`
+	AuthenticationData         []byte              `protobuf:"bytes,8,opt,name=authentication_data,json=authenticationData,proto3" json:"authentication_data,omitempty"`
+	ContractKeyWithMaintainers *KeyWithMaintainers `protobuf:"bytes,1001,opt,name=contract_key_with_maintainers,json=contractKeyWithMaintainers,proto3" json:"contract_key_with_maintainers,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -534,9 +535,9 @@ type Node_Fetch struct {
 	InterfaceId              *value.Identifier      `protobuf:"bytes,7,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
 	NonMaintainerSignatories []string               `protobuf:"bytes,4,rep,name=non_maintainer_signatories,json=nonMaintainerSignatories,proto3" json:"non_maintainer_signatories,omitempty"`
 	NonSignatoryStakeholders []string               `protobuf:"bytes,5,rep,name=non_signatory_stakeholders,json=nonSignatoryStakeholders,proto3" json:"non_signatory_stakeholders,omitempty"`
-	Actors                   []string               `protobuf:"bytes,6,rep,name=actors,proto3" json:"actors,omitempty"`
-	KeyWithMaintainers       *KeyWithMaintainers    `protobuf:"bytes,8,opt,name=key_with_maintainers,json=keyWithMaintainers,proto3" json:"key_with_maintainers,omitempty"`
-	ByKey                    bool                   `protobuf:"varint,9,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
+	Actors                   []string            `protobuf:"bytes,6,rep,name=actors,proto3" json:"actors,omitempty"`
+	KeyWithMaintainers       *KeyWithMaintainers `protobuf:"bytes,8,opt,name=key_with_maintainers,json=keyWithMaintainers,proto3" json:"key_with_maintainers,omitempty"`
+	ByKey                    bool                `protobuf:"varint,9,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -789,9 +790,9 @@ func (x *Node_Rollback) GetChildren() []string {
 type Node_QueryByKey struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	PackageName        string                 `protobuf:"bytes,1,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	TemplateId         *value.Identifier      `protobuf:"bytes,2,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	KeyWithMaintainers *KeyWithMaintainers    `protobuf:"bytes,3,opt,name=key_with_maintainers,json=keyWithMaintainers,proto3" json:"key_with_maintainers,omitempty"`
-	ContractId         [][]byte               `protobuf:"bytes,4,rep,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	TemplateId         *value.Identifier   `protobuf:"bytes,2,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	KeyWithMaintainers *KeyWithMaintainers `protobuf:"bytes,3,opt,name=key_with_maintainers,json=keyWithMaintainers,proto3" json:"key_with_maintainers,omitempty"`
+	ContractId         [][]byte            `protobuf:"bytes,4,rep,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
 	Exaustive          bool                   `protobuf:"varint,5,opt,name=exaustive,proto3" json:"exaustive,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/go/api/com/digitalasset/daml/lf/value/value.pb.go
+++ b/go/api/com/digitalasset/daml/lf/value/value.pb.go
@@ -9,12 +9,13 @@
 package value
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (
@@ -488,8 +489,8 @@ func (x *Value_Record) GetFields() []*Value_Record_Field {
 
 type Value_Variant struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Constructor   string                 `protobuf:"bytes,1,opt,name=constructor,proto3" json:"constructor,omitempty"`
-	Value         *Value                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Constructor   string `protobuf:"bytes,1,opt,name=constructor,proto3" json:"constructor,omitempty"`
+	Value         *Value `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -804,8 +805,8 @@ func (x *Value_Record_Field) GetValue() *Value {
 
 type Value_TextMap_Entry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Value         *Value                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Key           string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         *Value `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/go/api/import_test.go
+++ b/go/api/import_test.go
@@ -58,10 +58,11 @@ import (
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/canton/v30"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/canton/version"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/canton/version/v1"
-	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/archive"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/archive/daml_lf_1"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/archive/daml_lf_2"
+	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/transaction"
+	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/daml/lf/value"
 )
 
 func Test(_ *testing.T) {}


### PR DESCRIPTION
The protoc Go code generator currently generates code that does not compile based on our protos, so more munging is required to fix this again.

For now, fix things tactically so that `main` can be used again.