### PR TITLE
[bug] fixing import cycle in Golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,26 @@ jobs:
           command: make python-typecheck
       - store_test_results:
           path: target/test-results
+  check-go:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Nix preparation
+          command: .circleci/scripts/prep.sh
+      - restore_cache:
+          name: Nix restore cache
+          keys:
+            - nix-{{ checksum "/home/circleci/nix/cache-keys/nix-checksums" }}
+            - nix
+      - run:
+          name: Nix Setup
+          command: .circleci/scripts/setup.sh
+      - run:
+          name: Go build
+          command: go build ./...
   test-py:
     parameters:
       python_version:
@@ -160,6 +180,9 @@ workflows:
               python_version: ["3.10", "3.11", "3.12", "3.13"]
           requires:
             - nix-setup
+      - check-go:
+          requires:
+            - nix-setup
       - test-py:
           matrix:
             parameters:
@@ -169,5 +192,6 @@ workflows:
       - build:
           requires:
             - blackduck
+            - check-go
             - check-py
             - test-py

--- a/go/api/com/daml/ledger/api/v2/interactive/common/interactive_submission_common_data.pb.go
+++ b/go/api/com/daml/ledger/api/v2/interactive/common/interactive_submission_common_data.pb.go
@@ -6,7 +6,7 @@
 // 	protoc        v6.31.1
 // source: com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto
 
-package interactive
+package common
 
 import (
 	v2 "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2"
@@ -157,8 +157,8 @@ const file_com_daml_ledger_api_v2_interactive_interactive_submission_common_data
 	"\x04hash\x18\x04 \x01(\fR\x04hash\"}\n" +
 	"\x18GlobalKeyWithMaintainers\x12?\n" +
 	"\x03key\x18\x01 \x01(\v2-.com.daml.ledger.api.v2.interactive.GlobalKeyR\x03key\x12 \n" +
-	"\vmaintainers\x18\x02 \x03(\tR\vmaintainersB\xc7\x01\n" +
-	"\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZQgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive\xaa\x02\"Com.Daml.Ledger.Api.V2.Interactiveb\x06proto3"
+	"\vmaintainers\x18\x02 \x03(\tR\vmaintainersB\xce\x01\n" +
+	"\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZXgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common\xaa\x02\"Com.Daml.Ledger.Api.V2.Interactiveb\x06proto3"
 
 var (
 	file_com_daml_ledger_api_v2_interactive_interactive_submission_common_data_proto_rawDescOnce sync.Once

--- a/go/api/com/daml/ledger/api/v2/interactive/interactive_submission_service.pb.go
+++ b/go/api/com/daml/ledger/api/v2/interactive/interactive_submission_service.pb.go
@@ -10,6 +10,7 @@ package interactive
 
 import (
 	v2 "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2"
+	common "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common"
 	v1 "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/transaction/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -1763,7 +1764,7 @@ func (x *Metadata_SubmitterInfo) GetCommandId() string {
 type Metadata_GlobalKeyMappingEntry struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated: Marked as deprecated in com/daml/ledger/api/v2/interactive/interactive_submission_service.proto.
-	Key *GlobalKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Key *common.GlobalKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Deprecated: Marked as deprecated in com/daml/ledger/api/v2/interactive/interactive_submission_service.proto.
 	Value         *v2.Value `protobuf:"bytes,2,opt,name=value,proto3,oneof" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -1801,7 +1802,7 @@ func (*Metadata_GlobalKeyMappingEntry) Descriptor() ([]byte, []int) {
 }
 
 // Deprecated: Marked as deprecated in com/daml/ledger/api/v2/interactive/interactive_submission_service.proto.
-func (x *Metadata_GlobalKeyMappingEntry) GetKey() *GlobalKey {
+func (x *Metadata_GlobalKeyMappingEntry) GetKey() *common.GlobalKey {
 	if x != nil {
 		return x.Key
 	}
@@ -2250,7 +2251,7 @@ var file_com_daml_ledger_api_v2_interactive_interactive_submission_service_proto
 	(*v2.TransactionFormat)(nil),                           // 35: com.daml.ledger.api.v2.TransactionFormat
 	(*v2.Transaction)(nil),                                 // 36: com.daml.ledger.api.v2.Transaction
 	(*v2.PackageReference)(nil),                            // 37: com.daml.ledger.api.v2.PackageReference
-	(*GlobalKey)(nil),                                      // 38: com.daml.ledger.api.v2.interactive.GlobalKey
+	(*common.GlobalKey)(nil),                               // 38: com.daml.ledger.api.v2.interactive.GlobalKey
 	(*v2.Value)(nil),                                       // 39: com.daml.ledger.api.v2.Value
 	(*v1.Create)(nil),                                      // 40: com.daml.ledger.api.v2.interactive.transaction.v1.Create
 	(*v1.Node)(nil),                                        // 41: com.daml.ledger.api.v2.interactive.transaction.v1.Node
@@ -2330,7 +2331,6 @@ func file_com_daml_ledger_api_v2_interactive_interactive_submission_service_prot
 	if File_com_daml_ledger_api_v2_interactive_interactive_submission_service_proto != nil {
 		return
 	}
-	file_com_daml_ledger_api_v2_interactive_interactive_submission_common_data_proto_init()
 	file_com_daml_ledger_api_v2_interactive_interactive_submission_service_proto_msgTypes[2].OneofWrappers = []any{}
 	file_com_daml_ledger_api_v2_interactive_interactive_submission_service_proto_msgTypes[3].OneofWrappers = []any{}
 	file_com_daml_ledger_api_v2_interactive_interactive_submission_service_proto_msgTypes[6].OneofWrappers = []any{

--- a/go/api/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.pb.go
+++ b/go/api/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.pb.go
@@ -10,7 +10,7 @@ package v1
 
 import (
 	v2 "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2"
-	interactive "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive"
+	common "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -26,17 +26,17 @@ const (
 )
 
 type Fetch struct {
-	state         protoimpl.MessageState                `protogen:"open.v1"`
-	LfVersion     string                                `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
-	ContractId    string                                `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
-	PackageName   string                                `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	TemplateId    *v2.Identifier                        `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	Signatories   []string                              `protobuf:"bytes,5,rep,name=signatories,proto3" json:"signatories,omitempty"`
-	Stakeholders  []string                              `protobuf:"bytes,6,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
-	ActingParties []string                              `protobuf:"bytes,7,rep,name=acting_parties,json=actingParties,proto3" json:"acting_parties,omitempty"`
-	InterfaceId   *v2.Identifier                        `protobuf:"bytes,8,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
-	Key           *interactive.GlobalKeyWithMaintainers `protobuf:"bytes,9,opt,name=key,proto3,oneof" json:"key,omitempty"`
-	ByKey         bool                                  `protobuf:"varint,10,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
+	state         protoimpl.MessageState           `protogen:"open.v1"`
+	LfVersion     string                           `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
+	ContractId    string                           `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	PackageName   string                           `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
+	TemplateId    *v2.Identifier                   `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	Signatories   []string                         `protobuf:"bytes,5,rep,name=signatories,proto3" json:"signatories,omitempty"`
+	Stakeholders  []string                         `protobuf:"bytes,6,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
+	ActingParties []string                         `protobuf:"bytes,7,rep,name=acting_parties,json=actingParties,proto3" json:"acting_parties,omitempty"`
+	InterfaceId   *v2.Identifier                   `protobuf:"bytes,8,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
+	Key           *common.GlobalKeyWithMaintainers `protobuf:"bytes,9,opt,name=key,proto3,oneof" json:"key,omitempty"`
+	ByKey         bool                             `protobuf:"varint,10,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -127,7 +127,7 @@ func (x *Fetch) GetInterfaceId() *v2.Identifier {
 	return nil
 }
 
-func (x *Fetch) GetKey() *interactive.GlobalKeyWithMaintainers {
+func (x *Fetch) GetKey() *common.GlobalKeyWithMaintainers {
 	if x != nil {
 		return x.Key
 	}
@@ -142,23 +142,23 @@ func (x *Fetch) GetByKey() bool {
 }
 
 type Exercise struct {
-	state           protoimpl.MessageState                `protogen:"open.v1"`
-	LfVersion       string                                `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
-	ContractId      string                                `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
-	PackageName     string                                `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	TemplateId      *v2.Identifier                        `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	Signatories     []string                              `protobuf:"bytes,5,rep,name=signatories,proto3" json:"signatories,omitempty"`
-	Stakeholders    []string                              `protobuf:"bytes,6,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
-	ActingParties   []string                              `protobuf:"bytes,7,rep,name=acting_parties,json=actingParties,proto3" json:"acting_parties,omitempty"`
-	InterfaceId     *v2.Identifier                        `protobuf:"bytes,8,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
-	ChoiceId        string                                `protobuf:"bytes,9,opt,name=choice_id,json=choiceId,proto3" json:"choice_id,omitempty"`
-	ChosenValue     *v2.Value                             `protobuf:"bytes,10,opt,name=chosen_value,json=chosenValue,proto3" json:"chosen_value,omitempty"`
-	Consuming       bool                                  `protobuf:"varint,11,opt,name=consuming,proto3" json:"consuming,omitempty"`
-	Children        []string                              `protobuf:"bytes,12,rep,name=children,proto3" json:"children,omitempty"`
-	ExerciseResult  *v2.Value                             `protobuf:"bytes,13,opt,name=exercise_result,json=exerciseResult,proto3" json:"exercise_result,omitempty"`
-	ChoiceObservers []string                              `protobuf:"bytes,14,rep,name=choice_observers,json=choiceObservers,proto3" json:"choice_observers,omitempty"`
-	Key             *interactive.GlobalKeyWithMaintainers `protobuf:"bytes,15,opt,name=key,proto3,oneof" json:"key,omitempty"`
-	ByKey           bool                                  `protobuf:"varint,16,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
+	state           protoimpl.MessageState           `protogen:"open.v1"`
+	LfVersion       string                           `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
+	ContractId      string                           `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	PackageName     string                           `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
+	TemplateId      *v2.Identifier                   `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	Signatories     []string                         `protobuf:"bytes,5,rep,name=signatories,proto3" json:"signatories,omitempty"`
+	Stakeholders    []string                         `protobuf:"bytes,6,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
+	ActingParties   []string                         `protobuf:"bytes,7,rep,name=acting_parties,json=actingParties,proto3" json:"acting_parties,omitempty"`
+	InterfaceId     *v2.Identifier                   `protobuf:"bytes,8,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
+	ChoiceId        string                           `protobuf:"bytes,9,opt,name=choice_id,json=choiceId,proto3" json:"choice_id,omitempty"`
+	ChosenValue     *v2.Value                        `protobuf:"bytes,10,opt,name=chosen_value,json=chosenValue,proto3" json:"chosen_value,omitempty"`
+	Consuming       bool                             `protobuf:"varint,11,opt,name=consuming,proto3" json:"consuming,omitempty"`
+	Children        []string                         `protobuf:"bytes,12,rep,name=children,proto3" json:"children,omitempty"`
+	ExerciseResult  *v2.Value                        `protobuf:"bytes,13,opt,name=exercise_result,json=exerciseResult,proto3" json:"exercise_result,omitempty"`
+	ChoiceObservers []string                         `protobuf:"bytes,14,rep,name=choice_observers,json=choiceObservers,proto3" json:"choice_observers,omitempty"`
+	Key             *common.GlobalKeyWithMaintainers `protobuf:"bytes,15,opt,name=key,proto3,oneof" json:"key,omitempty"`
+	ByKey           bool                             `protobuf:"varint,16,opt,name=by_key,json=byKey,proto3" json:"by_key,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -291,7 +291,7 @@ func (x *Exercise) GetChoiceObservers() []string {
 	return nil
 }
 
-func (x *Exercise) GetKey() *interactive.GlobalKeyWithMaintainers {
+func (x *Exercise) GetKey() *common.GlobalKeyWithMaintainers {
 	if x != nil {
 		return x.Key
 	}
@@ -306,15 +306,15 @@ func (x *Exercise) GetByKey() bool {
 }
 
 type Create struct {
-	state         protoimpl.MessageState                `protogen:"open.v1"`
-	LfVersion     string                                `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
-	ContractId    string                                `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
-	PackageName   string                                `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	TemplateId    *v2.Identifier                        `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	Argument      *v2.Value                             `protobuf:"bytes,5,opt,name=argument,proto3" json:"argument,omitempty"`
-	Signatories   []string                              `protobuf:"bytes,6,rep,name=signatories,proto3" json:"signatories,omitempty"`
-	Stakeholders  []string                              `protobuf:"bytes,7,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
-	Key           *interactive.GlobalKeyWithMaintainers `protobuf:"bytes,8,opt,name=key,proto3,oneof" json:"key,omitempty"`
+	state         protoimpl.MessageState           `protogen:"open.v1"`
+	LfVersion     string                           `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
+	ContractId    string                           `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	PackageName   string                           `protobuf:"bytes,3,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
+	TemplateId    *v2.Identifier                   `protobuf:"bytes,4,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	Argument      *v2.Value                        `protobuf:"bytes,5,opt,name=argument,proto3" json:"argument,omitempty"`
+	Signatories   []string                         `protobuf:"bytes,6,rep,name=signatories,proto3" json:"signatories,omitempty"`
+	Stakeholders  []string                         `protobuf:"bytes,7,rep,name=stakeholders,proto3" json:"stakeholders,omitempty"`
+	Key           *common.GlobalKeyWithMaintainers `protobuf:"bytes,8,opt,name=key,proto3,oneof" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -398,7 +398,7 @@ func (x *Create) GetStakeholders() []string {
 	return nil
 }
 
-func (x *Create) GetKey() *interactive.GlobalKeyWithMaintainers {
+func (x *Create) GetKey() *common.GlobalKeyWithMaintainers {
 	if x != nil {
 		return x.Key
 	}
@@ -450,13 +450,13 @@ func (x *Rollback) GetChildren() []string {
 }
 
 type QueryByKey struct {
-	state         protoimpl.MessageState                `protogen:"open.v1"`
-	LfVersion     string                                `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
-	PackageName   string                                `protobuf:"bytes,2,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	TemplateId    *v2.Identifier                        `protobuf:"bytes,3,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	Exhaustive    bool                                  `protobuf:"varint,4,opt,name=exhaustive,proto3" json:"exhaustive,omitempty"`
-	Key           *interactive.GlobalKeyWithMaintainers `protobuf:"bytes,5,opt,name=key,proto3" json:"key,omitempty"`
-	Result        []string                              `protobuf:"bytes,6,rep,name=result,proto3" json:"result,omitempty"`
+	state         protoimpl.MessageState           `protogen:"open.v1"`
+	LfVersion     string                           `protobuf:"bytes,1,opt,name=lf_version,json=lfVersion,proto3" json:"lf_version,omitempty"`
+	PackageName   string                           `protobuf:"bytes,2,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
+	TemplateId    *v2.Identifier                   `protobuf:"bytes,3,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	Exhaustive    bool                             `protobuf:"varint,4,opt,name=exhaustive,proto3" json:"exhaustive,omitempty"`
+	Key           *common.GlobalKeyWithMaintainers `protobuf:"bytes,5,opt,name=key,proto3" json:"key,omitempty"`
+	Result        []string                         `protobuf:"bytes,6,rep,name=result,proto3" json:"result,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -519,7 +519,7 @@ func (x *QueryByKey) GetExhaustive() bool {
 	return false
 }
 
-func (x *QueryByKey) GetKey() *interactive.GlobalKeyWithMaintainers {
+func (x *QueryByKey) GetKey() *common.GlobalKeyWithMaintainers {
 	if x != nil {
 		return x.Key
 	}
@@ -757,15 +757,15 @@ func file_com_daml_ledger_api_v2_interactive_transaction_v1_interactive_submissi
 
 var file_com_daml_ledger_api_v2_interactive_transaction_v1_interactive_submission_data_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_com_daml_ledger_api_v2_interactive_transaction_v1_interactive_submission_data_proto_goTypes = []any{
-	(*Fetch)(nil),         // 0: com.daml.ledger.api.v2.interactive.transaction.v1.Fetch
-	(*Exercise)(nil),      // 1: com.daml.ledger.api.v2.interactive.transaction.v1.Exercise
-	(*Create)(nil),        // 2: com.daml.ledger.api.v2.interactive.transaction.v1.Create
-	(*Rollback)(nil),      // 3: com.daml.ledger.api.v2.interactive.transaction.v1.Rollback
-	(*QueryByKey)(nil),    // 4: com.daml.ledger.api.v2.interactive.transaction.v1.QueryByKey
-	(*Node)(nil),          // 5: com.daml.ledger.api.v2.interactive.transaction.v1.Node
-	(*v2.Identifier)(nil), // 6: com.daml.ledger.api.v2.Identifier
-	(*interactive.GlobalKeyWithMaintainers)(nil), // 7: com.daml.ledger.api.v2.interactive.GlobalKeyWithMaintainers
-	(*v2.Value)(nil), // 8: com.daml.ledger.api.v2.Value
+	(*Fetch)(nil),                           // 0: com.daml.ledger.api.v2.interactive.transaction.v1.Fetch
+	(*Exercise)(nil),                        // 1: com.daml.ledger.api.v2.interactive.transaction.v1.Exercise
+	(*Create)(nil),                          // 2: com.daml.ledger.api.v2.interactive.transaction.v1.Create
+	(*Rollback)(nil),                        // 3: com.daml.ledger.api.v2.interactive.transaction.v1.Rollback
+	(*QueryByKey)(nil),                      // 4: com.daml.ledger.api.v2.interactive.transaction.v1.QueryByKey
+	(*Node)(nil),                            // 5: com.daml.ledger.api.v2.interactive.transaction.v1.Node
+	(*v2.Identifier)(nil),                   // 6: com.daml.ledger.api.v2.Identifier
+	(*common.GlobalKeyWithMaintainers)(nil), // 7: com.daml.ledger.api.v2.interactive.GlobalKeyWithMaintainers
+	(*v2.Value)(nil),                        // 8: com.daml.ledger.api.v2.Value
 }
 var file_com_daml_ledger_api_v2_interactive_transaction_v1_interactive_submission_data_proto_depIdxs = []int32{
 	6,  // 0: com.daml.ledger.api.v2.interactive.transaction.v1.Fetch.template_id:type_name -> com.daml.ledger.api.v2.Identifier

--- a/go/api/import_test.go
+++ b/go/api/import_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/admin"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive"
+	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/transaction/v1"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/testing"
 	_ "github.com/digital-asset/dazl-client/v8/go/api/com/digitalasset/canton/admin/crypto/v30"

--- a/nix/protopack/patches.awk
+++ b/nix/protopack/patches.awk
@@ -1,8 +1,21 @@
 {
+  is_interactive_common = FILENAME ~ /com\/daml\/ledger\/api\/v2\/interactive\/interactive_submission_common_data\.proto$/
+
   if ($0 ~ /scalapb/) {
     # drop scalapb proto imports and options; scalapb proto files aren't included
     # in the Canton 2 bundle so this causes errors when trying to run codegen, but
     # we don't need them anyway
+
+  } else if (is_interactive_common && $0 ~ /^package .*;$/) {
+    # The common data is imported by both the interactive service and its transaction/v1
+    # dependency. Give it a leaf Go package to avoid an interactive <-> transaction/v1
+    # import cycle.
+    print
+    print ""
+    print "option go_package = \"github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common\";"
+
+  } else if (is_interactive_common && $0 ~ /^option go_package = /) {
+    # replace the upstream Go package with the leaf package above
 
   } else if ($0 ~ /^package .*;$/) {
     # write an `option go_package` line based on the contents of the protobuf package

--- a/python/_dazl/codegen/go.py
+++ b/python/_dazl/codegen/go.py
@@ -71,6 +71,10 @@ def corrected_name(name: str) -> str:
         return "com/digitalasset/daml/lf/value/value.pb.go"
     elif name == "com/digitalasset/daml/lf/transaction.pb.go":
         return "com/digitalasset/daml/lf/transaction/transaction.pb.go"
+    elif name == "com/daml/ledger/api/v2/interactive/interactive_submission_common_data.pb.go":
+        # patches.awk assigns this file a leaf Go package, but source_relative
+        # generation still emits it beside the interactive package.
+        return "com/daml/ledger/api/v2/interactive/common/interactive_submission_common_data.pb.go"
     else:
         return name
 

--- a/python/dazl/_gen/com/daml/ledger/api/v2/interactive/interactive_submission_common_data_pb2.py
+++ b/python/dazl/_gen/com/daml/ledger/api/v2/interactive/interactive_submission_common_data_pb2.py
@@ -29,14 +29,14 @@ _sym_db = _symbol_database.Default()
 from .. import value_pb2 as com_dot_daml_dot_ledger_dot_api_dot_v2_dot_value__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nKcom/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto\x12\"com.daml.ledger.api.v2.interactive\x1a\"com/daml/ledger/api/v2/value.proto\"\xb8\x01\n\tGlobalKey\x12\x43\n\x0btemplate_id\x18\x01 \x01(\x0b\x32\".com.daml.ledger.api.v2.IdentifierR\ntemplateId\x12!\n\x0cpackage_name\x18\x02 \x01(\tR\x0bpackageName\x12/\n\x03key\x18\x03 \x01(\x0b\x32\x1d.com.daml.ledger.api.v2.ValueR\x03key\x12\x12\n\x04hash\x18\x04 \x01(\x0cR\x04hash\"}\n\x18GlobalKeyWithMaintainers\x12?\n\x03key\x18\x01 \x01(\x0b\x32-.com.daml.ledger.api.v2.interactive.GlobalKeyR\x03key\x12 \n\x0bmaintainers\x18\x02 \x03(\tR\x0bmaintainersB\xc7\x01\n\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZQgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive\xaa\x02\"Com.Daml.Ledger.Api.V2.Interactiveb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\nKcom/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto\x12\"com.daml.ledger.api.v2.interactive\x1a\"com/daml/ledger/api/v2/value.proto\"\xb8\x01\n\tGlobalKey\x12\x43\n\x0btemplate_id\x18\x01 \x01(\x0b\x32\".com.daml.ledger.api.v2.IdentifierR\ntemplateId\x12!\n\x0cpackage_name\x18\x02 \x01(\tR\x0bpackageName\x12/\n\x03key\x18\x03 \x01(\x0b\x32\x1d.com.daml.ledger.api.v2.ValueR\x03key\x12\x12\n\x04hash\x18\x04 \x01(\x0cR\x04hash\"}\n\x18GlobalKeyWithMaintainers\x12?\n\x03key\x18\x01 \x01(\x0b\x32-.com.daml.ledger.api.v2.interactive.GlobalKeyR\x03key\x12 \n\x0bmaintainers\x18\x02 \x03(\tR\x0bmaintainersB\xce\x01\n\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZXgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common\xaa\x02\"Com.Daml.Ledger.Api.V2.Interactiveb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'com.daml.ledger.api.v2.interactive.interactive_submission_common_data_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'\n\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZQgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive\252\002\"Com.Daml.Ledger.Api.V2.Interactive'
+  _globals['DESCRIPTOR']._serialized_options = b'\n\"com.daml.ledger.api.v2.interactiveB)InteractiveSubmissionCommonDataOuterClassZXgithub.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/common\252\002\"Com.Daml.Ledger.Api.V2.Interactive'
   _globals['_GLOBALKEY']._serialized_start=152
   _globals['_GLOBALKEY']._serialized_end=336
   _globals['_GLOBALKEYWITHMAINTAINERS']._serialized_start=338


### PR DESCRIPTION
Latest proto update introduced cycle import issue in Go, can be reproduced only if import all photo files in project (which is go-daml doing).

* The GlobalKeyWithMaintainers message was moved into interactive_submission_common_data.proto.
* That proto file declares proto package com.daml.ledger.api.v2.interactive — the same package as interactive_submission_service.proto. The generator maps proto-package → Go-package 1:1, so both land in the same Go package …/interactive.
* That creates a two-way edge between two Go packages:
- …/interactive (the service) imports …/interactive/transaction/v1 — it needs v1.Create, v1.Node.
- …/interactive/transaction/v1 imports …/interactive — it needs GlobalKeyWithMaintainers, which now lives there.

My fix is moving GlobalKeyWithMaintainers to common package and updating CI/CD to build whole protos (to avoid cycles in future builds)

The error:
```
imports github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive from converters.go
        imports github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive/transaction/v1 from interactive_submission_service.pb.go
        imports github.com/digital-asset/dazl-client/v8/go/api/com/daml/ledger/api/v2/interactive from interactive_submission_data.pb.go: import cycle not allowed
```